### PR TITLE
Barebones updates for port array support

### DIFF
--- a/src/main/scala/edg_ide/EdgirUtils.scala
+++ b/src/main/scala/edg_ide/EdgirUtils.scala
@@ -170,8 +170,8 @@ object EdgirUtils {
             case (Seq(), ResolveTarget.Port) => ???  // TODO return non-Port PortType
             case (Seq(), _) => None  // target isn't the right type, but nowhere to continue
             case (Seq(head, tail@_*), target) =>
-              if (port.ports.contains(head) && target == ResolveTarget.Port) {
-                fromPortLike(prefix :+ head, tail, port.ports(head), target)
+              if (port.contains.ports.getOrElse(elem.PortArray.Ports()).ports.contains(head) && target == ResolveTarget.Port) {
+                fromPortLike(prefix :+ head, tail, port.getPorts.ports(head), target)
               } else if (target == ResolveTarget.Port) {  // deepest possible target along path
                 ???  // TODO return non-Port PortType
               } else if (target == ResolveTarget.Any) {  // deepest possible target along path

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -165,8 +165,9 @@ object EdgirGraph {
      case elem.PortLike.Is.Array(portArray) =>
        portArray.contains match {
         case elem.PortArray.Contains.Ports(portArray) =>
-          portArray.ports.flatMap { case (eltName, eltPort) =>
-            expandPortsWithNames(path + eltName, s"$name[$eltName]", eltPort)
+          // create an entry for the array itself
+          Seq(s"$name[...]" -> portLikeToPort(path, portLike)) ++ portArray.ports.flatMap { case (eltName, eltPort) =>
+              expandPortsWithNames(path + eltName, s"$name[$eltName]", eltPort)
           }.toSeq
         case elem.PortArray.Contains.Empty =>
           Seq(name -> portLikeToPort(path, portLike))

--- a/src/main/scala/edg_ide/swing/CompilerErrorTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/CompilerErrorTreeTableModel.scala
@@ -64,12 +64,14 @@ object CompilerErrorNodeBase {
         (s"Missing library element ${target.toSimpleString}", path.toString, Seq())
 
       case CompilerError.BadRef(path, ref) =>
-        (s"Bad reference ${path.asIndirect ++ ref}", path.toString, Seq())
+        (s"Bad reference $ref", path.toString, Seq())
+      case CompilerError.UndefinedPortArray(path, portType) =>
+        (s"Undefined port array", path.toString, Seq())
       case CompilerError.LibraryError(path, target, err) =>
         (s"Library error, ${target.toSimpleString}", path.toString,
             err.split('\n').toSeq.map(new CompilerErrorDetailNode(_, "")))
-      case CompilerError.GeneratorError(path, target, fnName, err) =>
-        (s"Generator error, ${target.toSimpleString}:$fnName", path.toString,
+      case CompilerError.GeneratorError(path, target, err) =>
+        (s"Generator error, ${target.toSimpleString}", path.toString,
             err.split('\n').toSeq.map(new CompilerErrorDetailNode(_, "")))
       case CompilerError.RefinementSubclassError(path, refinedLibrary, designLibrary) =>
         (s"Refinement class ${refinedLibrary.toSimpleString} " +

--- a/src/main/scala/edg_ide/swing/CompilerErrorTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/CompilerErrorTreeTableModel.scala
@@ -2,7 +2,7 @@ package edg_ide.swing
 
 import com.intellij.ui.treeStructure.treetable.TreeTableModel
 import edg.EdgirUtils.SimpleLibraryPath
-import edg.compiler.{CompilerError, ElaborateRecord, ExprRef, ExprToString}
+import edg.compiler.{CompilerError, ElaborateRecord, ExprToString}
 import edg.wir.DesignPath
 import edg_ide.EdgirUtils
 
@@ -52,9 +52,6 @@ object CompilerErrorNodeBase {
         ("Unelaborated Link", path.toString, deps.toSeq.map(elaborateRecordToDetailNode))
       case CompilerError.Unelaborated(ElaborateRecord.ParamValue(path), deps) =>
         ("Unelaborated Param", path.toString, deps.toSeq.map(elaborateRecordToDetailNode))
-      case CompilerError.Unelaborated(ElaborateRecord.Generator(blockPath, blockClass, fnName, _, _, _), deps) =>
-        (s"Unelaborated Generator", s"${blockPath.toString} (${blockClass.toSimpleString}:$fnName)",
-            deps.toSeq.map(elaborateRecordToDetailNode))
       case CompilerError.Unelaborated(ElaborateRecord.Connect(toLinkPortPath, fromLinkPortPath), deps) =>
         (s"Unelaborated Connect", "", Seq(
           new CompilerErrorDetailNode("Connect Towards Link Port", toLinkPortPath.toString),
@@ -66,6 +63,8 @@ object CompilerErrorNodeBase {
       case CompilerError.LibraryElement(path, target) =>
         (s"Missing library element ${target.toSimpleString}", path.toString, Seq())
 
+      case CompilerError.BadRef(path, ref) =>
+        (s"Bad reference ${path.asIndirect ++ ref}", path.toString, Seq())
       case CompilerError.LibraryError(path, target, err) =>
         (s"Library error, ${target.toSimpleString}", path.toString,
             err.split('\n').toSeq.map(new CompilerErrorDetailNode(_, "")))
@@ -93,9 +92,8 @@ object CompilerErrorNodeBase {
           new CompilerErrorDetailNode(ExprToString(value),result.toStringValue)
         ))
       case CompilerError.MissingAssertion(root, constrName, value, missing) =>
-        (s"Missing assertion", s"$root:$constrName", missing.toSeq.map {
-          case ExprRef.Param(param) => new CompilerErrorDetailNode("Missing param", param.toString)
-          case ExprRef.Array(array) => new CompilerErrorDetailNode("Missing array", array.toString)
+        (s"Missing assertion", s"$root:$constrName", missing.toSeq.map { param =>
+          new CompilerErrorDetailNode("Missing param", param.toString)
         })
 
       case CompilerError.EmptyRange(param, root, constrName, value) =>

--- a/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
+++ b/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
@@ -9,7 +9,7 @@ import edgir.schema.schema
 import edg.wir._
 import edg.EdgirUtils.SimpleLibraryPath
 import edg.ExprBuilder
-import edg.compiler.{Compiler, ExprRef, ExprResult, ExprToString}
+import edg.compiler.{Compiler, ExprResult, ExprToString}
 import edg.util.SeqMapSortableFrom._
 import edg_ide.EdgirUtils
 
@@ -268,9 +268,8 @@ class ElementDetailNodes(root: schema.Design, compiler: Compiler) {
             case ExprResult.Result(result) =>
               (s"$name ⇐ ${result.toStringValue}", constraintStr, Seq())
             case ExprResult.Missing(missing) =>
-              (s"$name ⇐ unknown", constraintStr, missing.toSeq.map {
-                case ExprRef.Param(param) => new ConstraintDetailNode("Missing param", param)
-                case ExprRef.Array(array) => new ConstraintDetailNode("Missing array", array.asIndirect)
+              (s"$name ⇐ unknown", constraintStr, missing.toSeq.map { param =>
+                new ConstraintDetailNode("Missing param", param)
               })
           }
         case _ => (name, constraintStr, Seq())

--- a/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
+++ b/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
@@ -111,6 +111,9 @@ class ElementDetailNodes(root: schema.Design, compiler: Compiler) {
       Seq(
         linkNode,
         Some(new ParamNode(path.asIndirect + IndirectStep.IsConnected, ExprBuilder.ValInit.Boolean)),
+        Some(new ParamNode(path.asIndirect + IndirectStep.Length, ExprBuilder.ValInit.Integer)),
+        Some(new ParamNode(path.asIndirect + IndirectStep.Elements,
+          ExprBuilder.ValInit.Array(ExprBuilder.ValInit.Text))),
         port.contains.ports.getOrElse(elem.PortArray.Ports()).ports.sortKeysFrom(nameOrder).map {
           case (name, subport) => PortLikeNode(path + name, subport, fromLink)
         },
@@ -224,14 +227,18 @@ class ElementDetailNodes(root: schema.Design, compiler: Compiler) {
     }
 
     override def getColumns(index: Int): String = {
-      val typeName = param.`val` match {
+      def valInitName(valInit: init.ValInit): String = valInit.`val` match {
         case init.ValInit.Val.Floating(_) => "float"
         case init.ValInit.Val.Boolean(_) => "boolean"
         case init.ValInit.Val.Integer(_) => "integer"
         case init.ValInit.Val.Range(_) => "range"
         case init.ValInit.Val.Text(_) => "text"
-        case param => s"unknown ${param.getClass}"
+        case init.ValInit.Val.Array(arrayValInit) => s"array[${valInitName(arrayValInit)}]"
+        case init.ValInit.Val.Set(_) => "set"
+        case init.ValInit.Val.Struct(_) => "set"
+        case init.ValInit.Val.Empty => "empty"
       }
+      val typeName = valInitName(param)
       val value = compiler.getParamValue(path) match {
         case Some(value) => value.toStringValue
         case None => "Unsolved"

--- a/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
+++ b/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
@@ -111,7 +111,7 @@ class ElementDetailNodes(root: schema.Design, compiler: Compiler) {
       Seq(
         linkNode,
         Some(new ParamNode(path.asIndirect + IndirectStep.IsConnected, ExprBuilder.ValInit.Boolean)),
-        port.ports.sortKeysFrom(nameOrder).map {
+        port.contains.ports.getOrElse(elem.PortArray.Ports()).ports.sortKeysFrom(nameOrder).map {
           case (name, subport) => PortLikeNode(path + name, subport, fromLink)
         },
       ).flatten

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -691,6 +691,11 @@ class DesignToolTipTextMap(compiler: Compiler, project: Project) extends DesignM
     }
     textMap.put(path, s"<b>$classString</b> at $path$additionalDesc")
   }
+  override def mapLinkArray(path: DesignPath, link: elem.LinkArray,
+                            ports: SeqMap[String, Unit], links: SeqMap[String, Unit]): Unit = {
+    val classString = link.getSelfClass.toSimpleString
+    textMap.put(path, s"<b>$classString[]</b> at $path")
+  }
   override def mapLinkLibrary(path: DesignPath, link: ref.LibraryPath): Unit = {
     val classString = s"Unelaborated ${link.toSimpleString}"
     textMap.put(path, s"<b>$classString</b> at $path")

--- a/src/main/scala/edg_ide/ui/DesignFastPathUtil.scala
+++ b/src/main/scala/edg_ide/ui/DesignFastPathUtil.scala
@@ -120,7 +120,7 @@ class DesignFastPathUtil(library: wir.Library) {
           val i = arraySize.getOrElse(topPortName, 0)
           arraySize.put(topPortName, i+1)
           stubLink = stubLink.update(
-            _.ports(topPortName).array.ports(i.toString) := instantiatePortLike(connectType).exceptError
+            _.ports(topPortName).array.ports.ports(i.toString) := instantiatePortLike(connectType).exceptError
           )
           key -> ExprBuilder.Ref(topPortName, i.toString)
         case other => throw ExceptionNotifyException(s"unexpected ${other.getClass} in link connect mapping")

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -170,8 +170,12 @@ class EdgCompilerService(project: Project) extends
                 indicator.setText(s"EDG compiling: link at $linkPath")
               case ElaborateRecord.Connect(toLinkPortPath, fromLinkPortPath) =>
                 indicator.setText(s"EDG compiling: connect between $toLinkPortPath - $fromLinkPortPath")
-              case ElaborateRecord.Generator(blockPath, blockClass, fnName, _, _, _) =>
-                indicator.setText(s"EDG compiling: generator at $blockPath (${blockClass.toSimpleString}:$fnName)")
+              case ElaborateRecord.ElaboratePortArray(portPath) =>
+                indicator.setText(s"EDG compiling: expand port array $portPath")
+              case ElaborateRecord.LowerArrayAllocateConnections(parent, portPath, _, _) =>
+                indicator.setText(s"EDG compiling: expanding array connections ${parent ++ portPath}")
+              case ElaborateRecord.LowerAllocateConnections(parent, portPath, _, _) =>
+                indicator.setText(s"EDG compiling: resolving allocate connections ${parent ++ portPath}")
               case record: ElaborateRecord.ElaborateDependency =>
                 indicator.setText(s"EDG compiling: unexpected dependency $record")
             }

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -172,10 +172,18 @@ class EdgCompilerService(project: Project) extends
                 indicator.setText(s"EDG compiling: connect between $toLinkPortPath - $fromLinkPortPath")
               case ElaborateRecord.ElaboratePortArray(portPath) =>
                 indicator.setText(s"EDG compiling: expand port array $portPath")
+
               case ElaborateRecord.ResolveArrayAllocated(parent, portPath, _, _, _) =>
-                indicator.setText(s"EDG compiling: expanding array connections ${parent ++ portPath}")
+                indicator.setText(s"EDG compiling: resolving array allocations ${parent ++ portPath}")
+              case ElaborateRecord.RewriteArrayAllocate(parent, portPath, _, _, _) =>
+                indicator.setText(s"EDG compiling: rewriting array allocates ${parent ++ portPath}")
+              case ElaborateRecord.ExpandArrayConnections(parent, constrName) =>
+                indicator.setText(s"EDG compiling: expanding array connection $parent.$constrName")
               case ElaborateRecord.RewriteConnectAllocate(parent, portPath, _, _, _) =>
-                indicator.setText(s"EDG compiling: resolving allocate connections ${parent ++ portPath}")
+                indicator.setText(s"EDG compiling: rewriting connection allocates ${parent ++ portPath}")
+              case ElaborateRecord.ResolveArrayIsConnected(parent, portPath, _, _, _) =>
+                indicator.setText(s"EDG compiling: resolving array connectivity ${parent ++ portPath}")
+
               case record: ElaborateRecord.ElaborateDependency =>
                 indicator.setText(s"EDG compiling: unexpected dependency $record")
             }

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -168,6 +168,8 @@ class EdgCompilerService(project: Project) extends
                 indicator.setText(s"EDG compiling: block at $blockPath")
               case ElaborateRecord.Link(linkPath) =>
                 indicator.setText(s"EDG compiling: link at $linkPath")
+              case ElaborateRecord.LinkArray(linkPath) =>
+                indicator.setText(s"EDG compiling: link array at $linkPath")
               case ElaborateRecord.Connect(toLinkPortPath, fromLinkPortPath) =>
                 indicator.setText(s"EDG compiling: connect between $toLinkPortPath - $fromLinkPortPath")
               case ElaborateRecord.ElaboratePortArray(portPath) =>

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -172,9 +172,9 @@ class EdgCompilerService(project: Project) extends
                 indicator.setText(s"EDG compiling: connect between $toLinkPortPath - $fromLinkPortPath")
               case ElaborateRecord.ElaboratePortArray(portPath) =>
                 indicator.setText(s"EDG compiling: expand port array $portPath")
-              case ElaborateRecord.LowerArrayAllocateConnections(parent, portPath, _, _) =>
+              case ElaborateRecord.SetPortArrayAllocated(parent, portPath, _, _, _) =>
                 indicator.setText(s"EDG compiling: expanding array connections ${parent ++ portPath}")
-              case ElaborateRecord.LowerAllocateConnections(parent, portPath, _, _) =>
+              case ElaborateRecord.LowerAllocateConnections(parent, portPath, _, _, _) =>
                 indicator.setText(s"EDG compiling: resolving allocate connections ${parent ++ portPath}")
               case record: ElaborateRecord.ElaborateDependency =>
                 indicator.setText(s"EDG compiling: unexpected dependency $record")

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -172,9 +172,9 @@ class EdgCompilerService(project: Project) extends
                 indicator.setText(s"EDG compiling: connect between $toLinkPortPath - $fromLinkPortPath")
               case ElaborateRecord.ElaboratePortArray(portPath) =>
                 indicator.setText(s"EDG compiling: expand port array $portPath")
-              case ElaborateRecord.SetPortArrayAllocated(parent, portPath, _, _, _) =>
+              case ElaborateRecord.ResolveArrayAllocated(parent, portPath, _, _, _) =>
                 indicator.setText(s"EDG compiling: expanding array connections ${parent ++ portPath}")
-              case ElaborateRecord.LowerAllocateConnections(parent, portPath, _, _, _) =>
+              case ElaborateRecord.RewriteConnectAllocate(parent, portPath, _, _, _) =>
                 indicator.setText(s"EDG compiling: resolving allocate connections ${parent ++ portPath}")
               case record: ElaborateRecord.ElaborateDependency =>
                 indicator.setText(s"EDG compiling: unexpected dependency $record")

--- a/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
@@ -243,6 +243,10 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
         "block" -> EdgirGraph.EdgirNode(
           data = BlockWrapper(DesignPath() + "block", designIr.blocks("block")),
           members = SeqMap(
+            "ports[...]" -> EdgirGraph.EdgirPort(
+              data = PortWrapper(DesignPath() + "block" + "ports",
+                blockIr.ports("ports"))
+            ),
             "ports[0]" -> EdgirGraph.EdgirPort(
               data = PortWrapper(DesignPath() + "block" + "ports" + "0",
                 blockIr.ports("ports").getArray.getPorts.ports("0"))
@@ -259,6 +263,8 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
     )
 
     // These checks allow better error localization
+    edgirGraph.members("block").asInstanceOf[EdgirNode].members("ports[...]") should equal(
+      refGraph.members("block").asInstanceOf[EdgirNode].members("ports[...]"))
     edgirGraph.members("block").asInstanceOf[EdgirNode].members("ports[0]") should equal(
       refGraph.members("block").asInstanceOf[EdgirNode].members("ports[0]"))
     edgirGraph.members("block").asInstanceOf[EdgirNode].members("ports[test]") should equal(

--- a/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
@@ -204,4 +204,67 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
     // The final catch-all check
     edgirGraph should equal(refGraph)
   }
+
+  it should "work with block-side arrays" in {
+    val designIr = elem.HierarchyBlock(
+      blocks=Map(
+        "block" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
+          ports=Map(
+            "ports" -> elem.PortLike(is=elem.PortLike.Is.Array(elem.PortArray(
+              selfClass=Some(EdgirTestUtils.Ports.PowerSource),
+              contains=elem.PortArray.Contains.Ports(elem.PortArray.Ports(
+                ports=Map(
+                  "0" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+                    selfClass=Some(EdgirTestUtils.Ports.PowerSource)
+                  ))),
+                  "test" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+                    selfClass=Some(EdgirTestUtils.Ports.PowerSource)
+                  ))),
+                )
+              ))
+            ))),
+          ),
+        ))),
+      ),
+      links=Map(),
+      constraints=Map(),
+    )
+    val designBlocklikeIr = elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(designIr))
+    val edgirGraph = EdgirGraph.blockLikeToNode(
+      DesignPath(),
+      designBlocklikeIr
+    )
+
+    val blockIr = designIr.blocks("block").`type`.hierarchy.get
+
+    val refGraph = EdgirGraph.EdgirNode(
+      data = BlockWrapper(DesignPath(), designBlocklikeIr),
+      members = SeqMap(
+        "block" -> EdgirGraph.EdgirNode(
+          data = BlockWrapper(DesignPath() + "block", designIr.blocks("block")),
+          members = SeqMap(
+            "ports[0]" -> EdgirGraph.EdgirPort(
+              data = PortWrapper(DesignPath() + "block" + "ports" + "0",
+                blockIr.ports("ports").getArray.getPorts.ports("0"))
+            ),
+            "ports[test]" -> EdgirGraph.EdgirPort(
+              data = PortWrapper(DesignPath() + "block" + "ports" + "test",
+                blockIr.ports("ports").getArray.getPorts.ports("test"))
+            ),
+          ),
+          edges = Seq()
+        ),
+      ),
+      edges = Seq(),
+    )
+
+    // These checks allow better error localization
+    edgirGraph.members("block").asInstanceOf[EdgirNode].members("ports[0]") should equal(
+      refGraph.members("block").asInstanceOf[EdgirNode].members("ports[0]"))
+    edgirGraph.members("block").asInstanceOf[EdgirNode].members("ports[test]") should equal(
+      refGraph.members("block").asInstanceOf[EdgirNode].members("ports[test]"))
+
+    // The final catch-all check
+    edgirGraph should equal(refGraph)
+  }
 }


### PR DESCRIPTION
- Update IDE to reflect new proto changes, including link array node
- For array parameters in the detail view, allow expanding it to have a single line per element
- Roll HDL repository pointer
- TODO (in a separate PR): the visualizer is broken when dealing with array ports, more diagnosis needed but this PR is a checkpoint to get things building with the new HDL for now