### PR TITLE
Restore tree expanded-ness state on tree update

### DIFF
--- a/src/main/scala/edg_ide/swing/TreeTableUtils.scala
+++ b/src/main/scala/edg_ide/swing/TreeTableUtils.scala
@@ -17,7 +17,6 @@ object TreeTableUtils {
     treeTable.setModel(newModel)  // note that setModel resets TreeTable.getTree, so we need to get a fresh tree handle
     restoreExpandedNodes(treeTable.getTree, savedNodes)
     treeTable.setRootVisible(isRootVisible)
-
   }
 
   // Returns the tree path of all expanded nodes (as sequence of node objects).

--- a/src/main/scala/edg_ide/swing/TreeTableUtils.scala
+++ b/src/main/scala/edg_ide/swing/TreeTableUtils.scala
@@ -1,0 +1,68 @@
+package edg_ide.swing
+
+import com.intellij.ui.treeStructure.treetable.{TreeTable, TreeTableModel}
+
+import javax.swing.JTree
+import javax.swing.tree.TreePath
+import scala.collection.mutable
+
+
+// Utility methods to preserve user-visible state when the tree model is updated.
+// The clean solution would be to use TreeModelListener events, but these don't seem to behave
+// when the underlying node structure is modified, even if it's mostly isomorphic.
+object TreeTableUtils {
+  def updateModel(treeTable: TreeTable, newModel: TreeTableModel): Unit = {
+    val savedNodes = getExpandedNodes(treeTable.getTree)
+    val isRootVisible = treeTable.getTree.isRootVisible
+    treeTable.setModel(newModel)  // note that setModel resets TreeTable.getTree, so we need to get a fresh tree handle
+    restoreExpandedNodes(treeTable.getTree, savedNodes)
+    treeTable.setRootVisible(isRootVisible)
+
+  }
+
+  // Returns the tree path of all expanded nodes (as sequence of node objects).
+  protected def getExpandedNodes(tree: JTree): Seq[TreePath] = {
+    val expandedNodes = mutable.ListBuffer[TreePath]()
+    val model = tree.getModel
+
+    def traverse(path: TreePath): Unit = {
+      val thisNode = path.getLastPathComponent
+      if (tree.isExpanded(path)) {  // only recurse if expanded
+        expandedNodes.append(path)
+        (0 until model.getChildCount(thisNode)).map(model.getChild(thisNode, _)) foreach { childNode =>
+          val childPath = path.pathByAddingChild(childNode)
+          traverse(childPath)
+        }
+      }
+    }
+    traverse(new TreePath(model.getRoot))
+
+    expandedNodes.toSeq
+  }
+
+  // Restores expanded node state, by walking the tree and comparing node approximate-equality.
+  protected def restoreExpandedNodes(tree: JTree, expanded: Seq[TreePath]): Unit = {
+    // This is pretty computationally inefficient. Storing the expanded nodes in a tree structure can be
+    // much more efficient, but this is the lazy standard-classes based solution.
+    val model = tree.getModel
+
+    // Checks whether to expand the node at treePath, then recursively calls with filtered expandedPaths for each child
+    def traverse(treePath: TreePath, expandedPaths: Seq[TreePath]): Unit = {
+      val treeNode = treePath.getLastPathComponent
+      val expandedByThisNode = expandedPaths.groupBy(_.getPathComponent(treePath.getPathCount - 1))
+
+      expandedByThisNode foreach { case (expandedNode, expandedPaths) =>
+        // while it's theoretically possible to get multiple expandedNode matches this is probably unlikely
+        if (treeNode.toString == expandedNode.toString) {
+          tree.expandPath(treePath)
+          val treeNodeChildren = (0 until model.getChildCount(treeNode)).map(model.getChild(treeNode, _))
+          treeNodeChildren.foreach { childNode =>
+            val childExpandedPaths = expandedPaths.filter(_.getPathCount > treePath.getPathCount)
+            traverse(treePath.pathByAddingChild(childNode), childExpandedPaths)
+          }
+        }
+      }
+    }
+    traverse(new TreePath(model.getRoot), expanded)
+  }
+}

--- a/src/main/scala/edg_ide/ui/BaseTool.scala
+++ b/src/main/scala/edg_ide/ui/BaseTool.scala
@@ -22,14 +22,14 @@ trait ToolInterface {
   // TODO should these have smarter error handling?
   // Scrolls the graph so the selected elt is visible
   def scrollGraphToVisible(path: DesignPath): Unit
-  // Sets the selected design tree element in the graph.
-  def setDesignTreeSelection(path: Option[DesignPath]): Unit
   // Sets the selected elements in the graph
   def setGraphSelections(paths: Set[DesignPath]): Unit
   // Sets the highlighted items on the graph, or None to disable highlighting.
   def setGraphHighlights(paths: Option[Set[DesignPath]]): Unit
+
+  // Sets the selected design tree and detail view element
+  def setSelection(path: DesignPath): Unit
   def setFocus(path: DesignPath): Unit
-  def setDetailView(path: DesignPath): Unit
   def setStatus(status: String): Unit
 }
 
@@ -43,15 +43,10 @@ trait BaseTool {
   //
   // Initialization function that runs when the tool is made active. By default clears state.
   def init(): Unit = {
-    interface.setDesignTreeSelection(None)
     interface.setGraphSelections(Set())
     interface.setGraphHighlights(None)
   }
 
   // Mouse event that is generated on any mouse event in either the design tree or graph layout
   def onPathMouse(e: MouseEvent, path: DesignPath): Unit = { }
-
-  // Event that is generated when the tree selection changes.
-  // IMPORTANT: this may be triggered from setting the design tree selection, and may infinite-loop.
-  def onSelect(path: DesignPath): Unit = { }
 }

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -325,10 +325,8 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     this.design = design
     this.compiler = compiler
 
-    val block = design.contents.getOrElse(elem.HierarchyBlock())
-
     // Update the design tree first, in case graph layout fails
-    designTreeModel = new BlockTreeTableModel(block)
+    designTreeModel = new BlockTreeTableModel(design.contents.getOrElse(elem.HierarchyBlock()))
     TreeTableUtils.updateModel(designTree, designTreeModel)
     designTree.getTree.addTreeSelectionListener(designTreeListener)  // this seems to get overridden when the model is updated
 

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -322,7 +322,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
 
     // Update the design tree first, in case graph layout fails
     designTreeModel = new BlockTreeTableModel(block)
-    designTree.setModel(designTreeModel)
+    TreeTableUtils.updateModel(designTree, designTreeModel)
     designTree.getTree.addTreeSelectionListener(designTreeListener)  // this seems to get overridden when the model is updated
 
     updateDisplay()
@@ -558,7 +558,7 @@ class DetailPanel(initPath: DesignPath, initRoot: schema.Design, initRefinements
   // Actions
   //
   def setLoaded(path: DesignPath, root: schema.Design, refinements: edgrpc.Refinements, compiler: Compiler): Unit = {
-    tree.setModel(new ElementDetailTreeModel(path, root, refinements, compiler))
+    TreeTableUtils.updateModel(tree, new ElementDetailTreeModel(path, root, refinements, compiler))
   }
 
   // Configuration State
@@ -583,8 +583,7 @@ class ErrorPanel extends JPanel {
   // Actions
   //
   def setErrors(errs: Seq[CompilerError]): Unit = {
-    tree.setModel(new CompilerErrorTreeTableModel(errs))
-    tree.setRootVisible(false)
+    TreeTableUtils.updateModel(tree, new CompilerErrorTreeTableModel(errs))
   }
 
   // Configuration State

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -72,6 +72,8 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   // GUI-facing state
   //
   private var focusPath: DesignPath = DesignPath()  // visualize from root by default
+  private var ignoreSelect: Boolean = false  // ignore select operation to prevent infinite recursion
+  private var selectionPath: DesignPath = DesignPath()  // selection of detail view and graph selection
 
   // Tool
   //
@@ -82,17 +84,6 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   }
 
   private val toolInterface = new ToolInterface {
-    override def setDesignTreeSelection(path: Option[DesignPath]): Unit = {
-      designTree.clearSelection()
-      path match {
-        case Some(path) =>
-          val (targetDesignPrefix, targetDesignNode) = BlockTreeTableModel.follow(path, designTreeModel)
-          val treePath = targetDesignPrefix.tail.foldLeft(new TreePath(targetDesignPrefix.head)) { _.pathByAddingChild(_) }
-          designTree.addSelectedPath(treePath)
-        case None =>  // do nothing
-      }
-    }
-
     override def scrollGraphToVisible(path: DesignPath): Unit = {
       // TODO IMPLEMENT ME
     }
@@ -112,10 +103,8 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
       setContext(path)
     }
 
-    override def setDetailView(path: DesignPath): Unit = {
-      tabbedPane.setTitleAt(TAB_INDEX_DETAIL, s"Detail (${path.lastString})")
-      detailPanel.setLoaded(path, design, refinements, compiler)
-      kicadVizPanel.setBlock(path, design, compiler)
+    override def setSelection(path: DesignPath): Unit = {
+      BlockVisualizerPanel.this.selectPath(path)
     }
 
     override def setStatus(statusText: String): Unit = {
@@ -212,23 +201,18 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     override def valueChanged(e: TreeSelectionEvent): Unit = {
       import edg_ide.swing.HierarchyBlockNode
       e.getPath.getLastPathComponent match {
-        case selectedNode: HierarchyBlockNode =>
-          activeTool.onSelect(selectedNode.path)
+        case selectedNode: HierarchyBlockNode => selectPath(selectedNode.path)
         case _ =>  // any other type ignored, not that there should be any other types
-          // TODO should this error out?
       }
     }
   }
   designTree.getTree.addTreeSelectionListener(designTreeListener)
   designTree.addMouseListener(new MouseAdapter {  // right click context menu
     override def mousePressed(e: MouseEvent): Unit = {
-      designTree.getTree.getPathForLocation(e.getX, e.getY) match {
-        case null =>  // ignored
-        case treePath: TreePath => treePath.getLastPathComponent match {
-          case clickedNode: HierarchyBlockNode => activeTool.onPathMouse(e, clickedNode.path)
-          case _ =>  // any other type ignored
-        }
-      }
+      Option(designTree.getTree.getPathForLocation(e.getX, e.getY)).foreach { _.getLastPathComponent match {
+        case clickedNode: HierarchyBlockNode => activeTool.onPathMouse(e, clickedNode.path)
+        case _ =>  // any other type ignored
+      } }
     }
   })
   designTree.setShowColumns(true)
@@ -275,7 +259,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   def getDesign: schema.Design = design
 
   def getSelectedPath: Option[DesignPath] = {
-    defaultTool.getSelected
+    Some(selectionPath)
   }
 
   def setContext(path: DesignPath): Unit = {
@@ -286,9 +270,32 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   }
 
   def selectPath(path: DesignPath): Unit = {
-    if (activeTool == defaultTool) {
-      defaultTool.onSelect(path)
+    if (ignoreSelect) {
+      return
     }
+    ignoreSelect = true
+    selectionPath = path
+
+    val (containingPath, containingBlock) = EdgirUtils.resolveDeepestBlock(path, design)
+
+    designTree.clearSelection()
+    val (targetDesignPrefix, targetDesignNode) = BlockTreeTableModel.follow(path, designTreeModel)
+    val treePath = targetDesignPrefix.tail.foldLeft(new TreePath(targetDesignPrefix.head)) {
+      _.pathByAddingChild(_)
+    }
+    designTree.addSelectedPath(treePath)
+
+    graph.setSelected(pathsToGraphNodes(Set(path)))
+
+    BlockVisualizerPanel.this.setDetailView(containingPath)
+
+    ignoreSelect = false
+  }
+
+  def setDetailView(path: DesignPath): Unit = {
+    tabbedPane.setTitleAt(TAB_INDEX_DETAIL, s"Detail (${path.lastString})")
+    detailPanel.setLoaded(path, design, refinements, compiler)
+    kicadVizPanel.setBlock(path, design, compiler)
   }
 
   /** Sets the design and updates displays accordingly.
@@ -325,6 +332,9 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     TreeTableUtils.updateModel(designTree, designTreeModel)
     designTree.getTree.addTreeSelectionListener(designTreeListener)  // this seems to get overridden when the model is updated
 
+    // Also update the active detail panel
+    selectPath(selectionPath)
+
     updateDisplay()
   }
 
@@ -332,8 +342,6 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     * Does not update visualizations that are unaffected by operations that don't change the design.
     */
   def updateDisplay(): Unit = {
-    import ElemBuilder.LibraryPath
-
     val currentDesign = design
 
     ReadAction.nonBlocking((() => { // analyses happen in the background to avoid slow ops in UI thread

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -270,7 +270,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   }
 
   def selectPath(path: DesignPath): Unit = {
-    if (ignoreSelect) {
+    if (ignoreSelect) {  // setting the tree selection triggers a select event, this prevents an infinite loop
       return
     }
     ignoreSelect = true

--- a/src/main/scala/edg_ide/ui/ConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/ConnectTool.scala
@@ -479,7 +479,7 @@ class ConnectTool(val interface: ToolInterface, focusPath: DesignPath, portPath:
   }
 
   override def init(): Unit = {
-    interface.setDesignTreeSelection(None)
+    interface.setGraphSelections(Set())
     updateSelected()
   }
 

--- a/src/main/scala/edg_ide/ui/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/DefaultTool.scala
@@ -130,14 +130,8 @@ class DesignPortPopupMenu(path: DesignPath, interface: ToolInterface)
 
 
 class DefaultTool(val interface: ToolInterface) extends BaseTool {
-  private var ignoreSelect: Boolean = false  // TODO synchronization?
-  private var selected: Option[DesignPath] = None  // TODO synchronization?
-
-  def getSelected: Option[DesignPath] = selected
-
   override def init(): Unit = {
     super.init()
-    selected = None
   }
 
   // Mouse event that is generated on any mouse event in either the design tree or graph layout
@@ -145,7 +139,7 @@ class DefaultTool(val interface: ToolInterface) extends BaseTool {
     val resolved = EdgirUtils.resolveExact(path, interface.getDesign)
 
     if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 1) {
-      onSelect(path)
+      interface.setSelection(path)
     } else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) {
       // double click
       resolved match {
@@ -169,19 +163,5 @@ class DefaultTool(val interface: ToolInterface) extends BaseTool {
         case _ =>  // TODO support other element types
       }
     }
-  }
-
-  // Event that is generated when the tree selection changes.
-  override def onSelect(path: DesignPath): Unit = {
-    if (ignoreSelect) {
-      return
-    }
-    ignoreSelect = true
-    val (containingPath, containingBlock) = EdgirUtils.resolveDeepestBlock(path, interface.getDesign)
-    interface.setDesignTreeSelection(Some(containingPath))
-    interface.setGraphSelections(Set(path))
-    interface.setDetailView(containingPath)
-    selected = Some(path)
-    ignoreSelect = false
   }
 }

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -69,7 +69,7 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
           NotificationType.ERROR
         ).notify(project)
       }
-      tree.setModel(model)
+      TreeTableUtils.updateModel(tree, model)
     }
 
     def pathToFootprintName(file: File): Option[String] = {

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -586,11 +586,10 @@ class LibraryPanel(project: Project) extends JPanel {
   def setLibrary(library: wir.Library): Unit = {
     this.library = library
     this.libraryTreeModel = new FilteredTreeTableModel(new EdgirLibraryTreeTableModel(this.library))
-    libraryTree.setModel(this.libraryTreeModel)
+    TreeTableUtils.updateModel(libraryTree, this.libraryTreeModel)
     updateFilter()
     libraryTree.getTree.addTreeSelectionListener(libraryTreeListener)
     libraryTree.setTreeCellRenderer(libraryTreeRenderer)
-    libraryTree.setRootVisible(false)  // this seems to get overridden when the model is updated
   }
 
   // Configuration State


### PR DESCRIPTION
Includes a util to save and restore the expanded paths of a tree.

The nice solution is probably to do a tree-diff and generate update TreeModelEvent, but those don't seem to work at all. So here's the next best thing.

Also automatically updates the detail view to be consistent with an updated recompiled design.

Internal changes:
- consolidates setting the design tree and setting the detail view into one operation (the two are meant to be linked), and moves the implementation into the BlockVisualizerPanel