### PR TITLE
Pdf generator2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 *.mod
 *.kicad_mod
+*.pdf
 
 worksheet.*
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val root = (project in file("."))
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "3.2.0" % "test",
         "org.eclipse.elk" % "org.eclipse.elk.alg.layered" % "0.7.0",
-        "com.github.librepdf" % "openpdf" % "1.3.29",
+        "com.github.librepdf" % "openpdf" % "1.3.30",
 
         "de.siegmar" % "fastcsv" % "2.1.0",
       ),

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -181,8 +181,7 @@ object HierarchyGraphElk {
   }
 
 
-  // Experimental
-  def HGraphToElkGraph(content: HierarchyBlock, focusPath: DesignPath = DesignPath(), depth: Int = 1): ElkNode = {
+  def HBlockToElkNode(content: HierarchyBlock, focusPath: DesignPath = DesignPath(), depth: Int = 1): ElkNode = {
     // For now, this only updates the graph visualization, which can change with focus.
     // In the future, maybe this will also update or filter the design tree.
     val edgirGraph = EdgirGraph.blockToNode(focusPath, content)

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -267,9 +267,11 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
         BlockVisualizerService(project).setLibrary(EdgCompilerService(project).pyLib)
 
         if (options.pdfFile.nonEmpty) {
+          val startTime = System.currentTimeMillis()
           console.print("Printing PDF\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
           PDFGeneratorUtil.generate(compiled.getContents, options.pdfFile)
-          console.print(s"Wrote PDF to ${options.pdfFile}\n",
+          val printPdfTime = System.currentTimeMillis() - startTime
+          console.print(s"Wrote PDF to ${options.pdfFile} ($printPdfTime ms)\n",
             ConsoleViewContentType.SYSTEM_OUTPUT)
         }
 

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -267,12 +267,16 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
         BlockVisualizerService(project).setLibrary(EdgCompilerService(project).pyLib)
 
         if (options.pdfFile.nonEmpty) {
-          val startTime = System.currentTimeMillis()
+          indicator.setText("EDG compiling: generating PDF")
           console.print("Printing PDF\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
-          PDFGeneratorUtil.generate(compiled.getContents, options.pdfFile)
-          val printPdfTime = System.currentTimeMillis() - startTime
-          console.print(s"Wrote PDF to ${options.pdfFile} ($printPdfTime ms)\n",
+          val (pdfGeneration, pdfTime) = timeExec {
+            PDFGeneratorUtil.generate(compiled.getContents, options.pdfFile)
+          }
+          console.print(s"Printed PDF at ${options.pdfFile} ($pdfTime ms)\n",
             ConsoleViewContentType.SYSTEM_OUTPUT)
+        } else {
+          console.print(s"Not generating PDF, no PDF file specified in run options\n",
+            ConsoleViewContentType.ERROR_OUTPUT)
         }
 
         if (options.netlistFile.nonEmpty) {

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -268,7 +268,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
 
         if (options.pdfFile.nonEmpty) {
           console.print("Printing PDF\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
-          PDFGeneratorUtil.generate(HierarchyGraphElk.HGraphToElkGraph(compiled.getContents), options.pdfFile)
+          PDFGeneratorUtil.generate(compiled.getContents, options.pdfFile)
           console.print(s"Wrote PDF to ${options.pdfFile}\n",
             ConsoleViewContentType.SYSTEM_OUTPUT)
         }

--- a/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
+++ b/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
@@ -2,10 +2,10 @@ package edg_ide.runner
 
 import com.lowagie.text.{Document, Element, HeaderFooter, Rectangle}
 import com.lowagie.text.pdf.PdfWriter
+import edg.wir.ProtoUtil.BlockProtoToSeqMap
 import edg_ide.swing.ElkNodePainter
 import edgir.elem.elem.{BlockLike, HierarchyBlock}
 import org.eclipse.elk.graph.ElkNode
-import edg.util.SeqMapSortableFrom._
 import edg.wir.{DesignPath, ProtoUtil}
 import edg_ide.edgir_graph.HierarchyGraphElk
 
@@ -55,10 +55,9 @@ object PDFGeneratorUtil{
         val node = HierarchyGraphElk.HBlockToElkNode(block, path)
         printNode(node)
 
-        val nameOrder = ProtoUtil.getNameOrder(block.meta)
-        block.blocks.map {
+        block.blocks.asPairs.map {
           case (name, subblock) => (name, subblock.`type`)
-        }.sortKeysFrom(nameOrder)
+        }
           .collect {
             case (name, BlockLike.Type.Hierarchy(subblock)) if subblock.blocks.nonEmpty => (path + name, subblock)
           }.toMap.foreach {

--- a/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
+++ b/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
@@ -6,7 +6,7 @@ import edg.wir.ProtoUtil.BlockProtoToSeqMap
 import edg_ide.swing.ElkNodePainter
 import edgir.elem.elem.{BlockLike, HierarchyBlock}
 import org.eclipse.elk.graph.ElkNode
-import edg.wir.{DesignPath, ProtoUtil}
+import edg.wir.{DesignPath}
 import edg_ide.edgir_graph.HierarchyGraphElk
 
 import java.awt.Color

--- a/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
+++ b/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
@@ -17,62 +17,22 @@ import scala.jdk.CollectionConverters.ListHasAsScala
 
 object PDFGeneratorUtil{
 
-//  private def getPrintableChildren(block: HierarchyBlock): Map[String, HierarchyBlock] = {
-//    val nameOrder = ProtoUtil.getNameOrder(block.meta)
-//    val children: Map[String, HierarchyBlock] = block.blocks.map {
-//      case (name, subblock) => (name, subblock.`type`)
-//    }  .sortKeysFrom(nameOrder)
-//      .collect {
-//        case (name, BlockLike.Type.Hierarchy(subblock)) => (name, subblock)
-//      }.toMap
-//
-//    println(children)
-//    children
-//  }
+  private def getPrintableChildren(block: HierarchyBlock): Map[String, HierarchyBlock] = {
+    val nameOrder = ProtoUtil.getNameOrder(block.meta)
+    val children: Map[String, HierarchyBlock] = block.blocks.map {
+      case (name, subblock) => (name, subblock.`type`)
+    }  .sortKeysFrom(nameOrder)
+      .collect {
+        case (name, BlockLike.Type.Hierarchy(subblock)) => (name, subblock)
+      }.toMap
 
-//  def generate(content: HierarchyBlock, fileName: String): Unit = {
-//
-//    val rootNode = HierarchyGraphElk.HBlockToElkNode(content, depth=2)
-//
-//    // TODO: Set a fixed document size and scale graphics accordingly?
-//    val width = rootNode.getWidth.toFloat + 2 * ElkNodePainter.margin.toFloat
-//    val height = rootNode.getHeight.toFloat + 2 * ElkNodePainter.margin.toFloat
-//    val document = new Document(new Rectangle(width, height))
-//
-//    // TODO: make a try..catch for FileOutputStream
-//    val writer = PdfWriter.getInstance(document, new FileOutputStream(fileName))
-//    document.open()
-//    val cb = writer.getDirectContent
-//    val graphics = cb.createGraphics(width, height)
-//    val painter = new ElkNodePainter(rootNode)
-//    painter.paintComponent(graphics, Color.white)
-//    graphics.dispose()
-//
-//    def printChild(node: ElkNode, path: String): Unit ={
-//      println("Printing...")
-//      document.newPage
-//      val subGraphics = cb.createGraphics(width, height)
-//      val painter = new ElkNodePainter(node)
-//      painter.paintComponent(subGraphics, Color.white)
-//      subGraphics.dispose()
-//      println("Printed" + path)
-//    }
-//
-//    getPrintableChildren(content).foreach(hBlock => {
-//      if (hBlock != null) {
-//        val node = HierarchyGraphElk.HBlockToElkNode(hBlock._2)
-//        printChild(node, hBlock._1)
-//      }
-//      else{
-//        println("Null node encountered")
-//      }
-//    })
-//    println("FINISHED PRINTING")
-//    document.close()
-//  }
+    children
+  }
 
   def generate(content: HierarchyBlock, fileName: String): Unit = {
-    val rootNode = HierarchyGraphElk.HBlockToElkNode(content, depth=2)
+
+    val rootNode = HierarchyGraphElk.HBlockToElkNode(content)
+
     // TODO: Set a fixed document size and scale graphics accordingly?
     val width = rootNode.getWidth.toFloat + 2 * ElkNodePainter.margin.toFloat
     val height = rootNode.getHeight.toFloat + 2 * ElkNodePainter.margin.toFloat
@@ -86,6 +46,40 @@ object PDFGeneratorUtil{
     val painter = new ElkNodePainter(rootNode)
     painter.paintComponent(graphics, Color.white)
     graphics.dispose()
+
+    def printChild(node: ElkNode, path: String): Unit ={
+      println("Printing...")
+      document.newPage
+      val subGraphics = cb.createGraphics(width, height)
+      val painter = new ElkNodePainter(node)
+      painter.paintComponent(subGraphics, Color.white)
+      subGraphics.dispose()
+      println("Printed " + path)
+    }
+
+    getPrintableChildren(content).foreach(hBlock => {
+      val node = HierarchyGraphElk.HBlockToElkNode(hBlock._2, DesignPath()+hBlock._1)
+      printChild(node, hBlock._1)
+    })
+    println("FINISHED PRINTING")
     document.close()
   }
+
+//  def generate(content: HierarchyBlock, fileName: String): Unit = {
+//    val rootNode = HierarchyGraphElk.HBlockToElkNode(content, depth=2)
+//    // TODO: Set a fixed document size and scale graphics accordingly?
+//    val width = rootNode.getWidth.toFloat + 2 * ElkNodePainter.margin.toFloat
+//    val height = rootNode.getHeight.toFloat + 2 * ElkNodePainter.margin.toFloat
+//    val document = new Document(new Rectangle(width, height))
+//
+//    // TODO: make a try..catch for FileOutputStream
+//    val writer = PdfWriter.getInstance(document, new FileOutputStream(fileName))
+//    document.open()
+//    val cb = writer.getDirectContent
+//    val graphics = cb.createGraphics(width, height)
+//    val painter = new ElkNodePainter(rootNode)
+//    painter.paintComponent(graphics, Color.white)
+//    graphics.dispose()
+//    document.close()
+//  }
 }

--- a/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
+++ b/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
@@ -1,17 +1,78 @@
 package edg_ide.runner
 
 import com.lowagie.text.{Document, Rectangle}
-import com.lowagie.text.pdf.PdfWriter
-import edg_ide.swing.ElkNodePainter
+import com.lowagie.text.pdf.{PdfContentByte, PdfWriter}
+import edg_ide.swing.{ElkNodePainter, HierarchyBlockNode}
+import edgir.elem.elem.{BlockLike, HierarchyBlock}
 import org.eclipse.elk.graph.ElkNode
+import edgir.elem.elem
+import edg.util.SeqMapSortableFrom._
+import edg.wir.{DesignPath, ProtoUtil}
+import edg_ide.edgir_graph.HierarchyGraphElk
 
 import java.awt.Color
 import java.io.FileOutputStream
+import scala.jdk.CollectionConverters.ListHasAsScala
 
 
 object PDFGeneratorUtil{
 
-  def generate(rootNode: ElkNode, fileName: String): Unit = {
+//  private def getPrintableChildren(block: HierarchyBlock): Map[String, HierarchyBlock] = {
+//    val nameOrder = ProtoUtil.getNameOrder(block.meta)
+//    val children: Map[String, HierarchyBlock] = block.blocks.map {
+//      case (name, subblock) => (name, subblock.`type`)
+//    }  .sortKeysFrom(nameOrder)
+//      .collect {
+//        case (name, BlockLike.Type.Hierarchy(subblock)) => (name, subblock)
+//      }.toMap
+//
+//    println(children)
+//    children
+//  }
+
+//  def generate(content: HierarchyBlock, fileName: String): Unit = {
+//
+//    val rootNode = HierarchyGraphElk.HBlockToElkNode(content, depth=2)
+//
+//    // TODO: Set a fixed document size and scale graphics accordingly?
+//    val width = rootNode.getWidth.toFloat + 2 * ElkNodePainter.margin.toFloat
+//    val height = rootNode.getHeight.toFloat + 2 * ElkNodePainter.margin.toFloat
+//    val document = new Document(new Rectangle(width, height))
+//
+//    // TODO: make a try..catch for FileOutputStream
+//    val writer = PdfWriter.getInstance(document, new FileOutputStream(fileName))
+//    document.open()
+//    val cb = writer.getDirectContent
+//    val graphics = cb.createGraphics(width, height)
+//    val painter = new ElkNodePainter(rootNode)
+//    painter.paintComponent(graphics, Color.white)
+//    graphics.dispose()
+//
+//    def printChild(node: ElkNode, path: String): Unit ={
+//      println("Printing...")
+//      document.newPage
+//      val subGraphics = cb.createGraphics(width, height)
+//      val painter = new ElkNodePainter(node)
+//      painter.paintComponent(subGraphics, Color.white)
+//      subGraphics.dispose()
+//      println("Printed" + path)
+//    }
+//
+//    getPrintableChildren(content).foreach(hBlock => {
+//      if (hBlock != null) {
+//        val node = HierarchyGraphElk.HBlockToElkNode(hBlock._2)
+//        printChild(node, hBlock._1)
+//      }
+//      else{
+//        println("Null node encountered")
+//      }
+//    })
+//    println("FINISHED PRINTING")
+//    document.close()
+//  }
+
+  def generate(content: HierarchyBlock, fileName: String): Unit = {
+    val rootNode = HierarchyGraphElk.HBlockToElkNode(content, depth=2)
     // TODO: Set a fixed document size and scale graphics accordingly?
     val width = rootNode.getWidth.toFloat + 2 * ElkNodePainter.margin.toFloat
     val height = rootNode.getHeight.toFloat + 2 * ElkNodePainter.margin.toFloat
@@ -22,10 +83,8 @@ object PDFGeneratorUtil{
     document.open()
     val cb = writer.getDirectContent
     val graphics = cb.createGraphics(width, height)
-
     val painter = new ElkNodePainter(rootNode)
     painter.paintComponent(graphics, Color.white)
-
     graphics.dispose()
     document.close()
   }

--- a/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
+++ b/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
@@ -57,10 +57,9 @@ object PDFGeneratorUtil{
 
         block.blocks.asPairs.map {
           case (name, subblock) => (name, subblock.`type`)
-        }
-          .collect {
-            case (name, BlockLike.Type.Hierarchy(subblock)) if subblock.blocks.nonEmpty => (path + name, subblock)
-          }.toMap.foreach {
+        }.collect {
+          case (name, BlockLike.Type.Hierarchy(subblock)) if subblock.blocks.nonEmpty => (path + name, subblock)
+        }.foreach {
           case (path, subblock) => printNextHierarchyLevel(subblock, path)
         }
       }

--- a/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
+++ b/src/main/scala/edg_ide/runner/PDFGeneratorUtil.scala
@@ -1,19 +1,16 @@
 package edg_ide.runner
 
-import com.lowagie.text.{Document, Rectangle}
-import com.lowagie.text.pdf.{PdfContentByte, PdfWriter}
-import edg_ide.swing.{ElkNodePainter, HierarchyBlockNode}
+import com.lowagie.text.{Document, Element, HeaderFooter, Rectangle}
+import com.lowagie.text.pdf.PdfWriter
+import edg_ide.swing.ElkNodePainter
 import edgir.elem.elem.{BlockLike, HierarchyBlock}
 import org.eclipse.elk.graph.ElkNode
-import edgir.elem.elem
 import edg.util.SeqMapSortableFrom._
 import edg.wir.{DesignPath, ProtoUtil}
 import edg_ide.edgir_graph.HierarchyGraphElk
 
 import java.awt.Color
 import java.io.FileOutputStream
-import com.lowagie.text.HeaderFooter
-import com.lowagie.text.Phrase
 
 
 object PDFGeneratorUtil{
@@ -32,6 +29,11 @@ object PDFGeneratorUtil{
 
     // TODO: make a try..catch for FileOutputStream
     val writer = PdfWriter.getInstance(document, new FileOutputStream(fileName))
+    val header = new HeaderFooter(true)
+    header.setBorder(Rectangle.NO_BORDER)
+    header.setAlignment(Element.ALIGN_RIGHT)
+    header.setPadding(0)
+    document.setFooter(header)
     document.open()
     val cb = writer.getDirectContent
     val graphics = cb.createGraphics(initWidth, initHeight)
@@ -50,8 +52,8 @@ object PDFGeneratorUtil{
 
       def printChild(node: ElkNode, path: String): Unit ={
         val (width, height) = generatePageSize(node)
-        document.newPage
         document.setPageSize(new Rectangle(width, height))
+        document.newPage
         val subGraphics = cb.createGraphics(width, height)
         val painter = new ElkNodePainter(node)
         painter.paintComponent(subGraphics, Color.white)
@@ -66,7 +68,6 @@ object PDFGeneratorUtil{
     }
 
     printNextHierarchyLevel(content)
-    println("FINISHED PRINTING")
     document.close()
   }
 }

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -338,7 +338,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
 
     ReadAction.nonBlocking((() => { // analyses happen in the background to avoid slow ops in UI thread
       val (blockPath, block) = EdgirUtils.resolveDeepestBlock(focusPath, currentDesign)
-      val layoutGraphRoot = HierarchyGraphElk.HGraphToElkGraph(block, blockPath, depthSpinner.getNumber)
+      val layoutGraphRoot = HierarchyGraphElk.HBlockToElkNode(block, blockPath, depthSpinner.getNumber)
       val tooltipTextMap = new DesignToolTipTextMap(compiler, project)
       tooltipTextMap.map(design)
 

--- a/src/test/scala/edg_ide/edgir_graph/tests/PDFGeneratorTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/PDFGeneratorTest.scala
@@ -1,0 +1,83 @@
+package edg_ide.edgir_graph.tests
+
+import edg.ExprBuilder.ValueExpr
+import edg_ide.runner.PDFGeneratorUtil
+import edgir.elem.elem
+import edgir.expr.expr
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{BufferedInputStream, FileInputStream}
+import scala.language.postfixOps
+
+
+class PDFGeneratorTest extends AnyFlatSpec with Matchers {
+  behavior of "PDFGeneratorUtil"
+
+  it should "generate a working PDF file" in {
+
+    val blockIr = elem.HierarchyBlock(
+      blocks=Map(
+        "source" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
+          ports=Map(
+            "port" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+              selfClass=Some(EdgirTestUtils.Ports.PowerSource)
+            ))),
+          ),
+          blocks=Map(
+            "inner" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
+              ports=Map(
+                "port" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+                  selfClass=Some(EdgirTestUtils.Ports.PowerSource)
+                ))),
+              ),
+            ))),
+          ),
+          constraints=Map(
+            "export" -> expr.ValueExpr(expr=expr.ValueExpr.Expr.Exported(expr.ExportedExpr(
+              internalBlockPort = Some(ValueExpr.Ref("inner", "port")),
+              exteriorPort = Some(ValueExpr.Ref("port"))
+            ))),
+          ),
+        ))),
+        "sink" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
+          ports=Map(
+            "port" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+              selfClass=Some(EdgirTestUtils.Ports.PowerSink)
+            ))),
+          ),
+        ))),
+      ),
+      links=Map(
+        "link" -> elem.LinkLike(`type`=elem.LinkLike.Type.Link(elem.Link(
+          selfClass=Some(EdgirTestUtils.Links.Power),
+          ports=Map(
+            "source" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+              selfClass=Some(EdgirTestUtils.Ports.PowerSource)
+            ))),
+            "sink" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+              selfClass=Some(EdgirTestUtils.Ports.PowerSource)
+            ))),
+          ),
+        ))),
+      ),
+      constraints=Map(
+        "connect_source" -> expr.ValueExpr(expr=expr.ValueExpr.Expr.Connected(expr.ConnectedExpr(
+          blockPort = Some(ValueExpr.Ref("source", "port")),
+          linkPort = Some(ValueExpr.Ref("link", "source"))
+        ))),
+        "connect_sink" -> expr.ValueExpr(expr=expr.ValueExpr.Expr.Connected(expr.ConnectedExpr(
+          blockPort = Some(ValueExpr.Ref("sink", "port")),
+          linkPort = Some(ValueExpr.Ref("link", "sink"))
+        ))),
+      ),
+    )
+
+    PDFGeneratorUtil.generate( blockIr, "unit_test.pdf")
+
+    val bufferedInputStream = new BufferedInputStream(new FileInputStream("unit_test.pdf"))
+    val byteArray = LazyList.continually(bufferedInputStream.read).takeWhile(-1 !=).map(_.toByte).toArray
+
+    byteArray should not be empty
+  }
+}

--- a/src/test/scala/edg_ide/util/tests/PDFGeneratorTest.scala
+++ b/src/test/scala/edg_ide/util/tests/PDFGeneratorTest.scala
@@ -1,6 +1,7 @@
-package edg_ide.edgir_graph.tests
+package edg_ide.util.tests
 
 import edg.ExprBuilder.ValueExpr
+import edg_ide.edgir_graph.tests.EdgirTestUtils
 import edg_ide.runner.PDFGeneratorUtil
 import edgir.elem.elem
 import edgir.expr.expr
@@ -73,7 +74,7 @@ class PDFGeneratorTest extends AnyFlatSpec with Matchers {
       ),
     )
 
-    PDFGeneratorUtil.generate( blockIr, "unit_test.pdf")
+    PDFGeneratorUtil.generate(blockIr, "unit_test.pdf")
 
     val bufferedInputStream = new BufferedInputStream(new FileInputStream("unit_test.pdf"))
     val byteArray = LazyList.continually(bufferedInputStream.read).takeWhile(-1 !=).map(_.toByte).toArray

--- a/src/test/scala/edg_ide/util/tests/PDFGeneratorTest.scala
+++ b/src/test/scala/edg_ide/util/tests/PDFGeneratorTest.scala
@@ -1,6 +1,7 @@
 package edg_ide.util.tests
 
 import edg.ExprBuilder.ValueExpr
+import edg.wir.ProtoUtil.{BlockSeqMapToProto, ConstraintSeqMapToProto, LinkSeqMapToProto, PortSeqMapToProto}
 import edg_ide.edgir_graph.tests.EdgirTestUtils
 import edg_ide.runner.PDFGeneratorUtil
 import edgir.elem.elem
@@ -9,6 +10,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{BufferedInputStream, FileInputStream}
+import scala.collection.SeqMap
 import scala.language.postfixOps
 
 
@@ -18,51 +20,45 @@ class PDFGeneratorTest extends AnyFlatSpec with Matchers {
   it should "generate a working PDF file" in {
 
     val blockIr = elem.HierarchyBlock(
-      blocks=Map(
+      blocks = SeqMap(
         "source" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
-          ports=Map(
+          ports = SeqMap(
             "port" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
               selfClass=Some(EdgirTestUtils.Ports.PowerSource)
             ))),
-          ),
-          blocks=Map(
-            "inner" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
-              ports=Map(
-                "port" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
-                  selfClass=Some(EdgirTestUtils.Ports.PowerSource)
+          ).toPb,
+          blocks = SeqMap(
+            "inner_block" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
+              ports = SeqMap(
+                "inner_port" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
+                  selfClass=Some(EdgirTestUtils.Ports.PowerSource),
                 ))),
-              ),
+              ).toPb,
             ))),
-          ),
-          constraints=Map(
-            "export" -> expr.ValueExpr(expr=expr.ValueExpr.Expr.Exported(expr.ExportedExpr(
-              internalBlockPort = Some(ValueExpr.Ref("inner", "port")),
-              exteriorPort = Some(ValueExpr.Ref("port"))
-            ))),
-          ),
+          ).toPb,
         ))),
         "sink" -> elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
-          ports=Map(
+          ports = SeqMap(
             "port" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
               selfClass=Some(EdgirTestUtils.Ports.PowerSink)
             ))),
-          ),
+          ).toPb,
         ))),
-      ),
-      links=Map(
+      ).toPb,
+      links = SeqMap(
         "link" -> elem.LinkLike(`type`=elem.LinkLike.Type.Link(elem.Link(
           selfClass=Some(EdgirTestUtils.Links.Power),
-          ports=Map(
+          ports = SeqMap(
             "source" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
               selfClass=Some(EdgirTestUtils.Ports.PowerSource)
             ))),
             "sink" -> elem.PortLike(is=elem.PortLike.Is.Port(elem.Port(
               selfClass=Some(EdgirTestUtils.Ports.PowerSource)
             ))),
-          ),
+          ).toPb,
         ))),
-      ),
-      constraints=Map(
+      ).toPb,
+      constraints = SeqMap(
         "connect_source" -> expr.ValueExpr(expr=expr.ValueExpr.Expr.Connected(expr.ConnectedExpr(
           blockPort = Some(ValueExpr.Ref("source", "port")),
           linkPort = Some(ValueExpr.Ref("link", "source"))
@@ -71,7 +67,7 @@ class PDFGeneratorTest extends AnyFlatSpec with Matchers {
           blockPort = Some(ValueExpr.Ref("sink", "port")),
           linkPort = Some(ValueExpr.Ref("link", "sink"))
         ))),
-      ),
+      ).toPb,
     )
 
     PDFGeneratorUtil.generate(blockIr, "unit_test.pdf")


### PR DESCRIPTION
PR Notes:
- Updated openpdf version from 1.3.29 to 1.3.30
- PDFGeneratorUtil now prints multiple numbered pages
    - Each page shows 1 level deeper into each block (i.e. all the sub-blocks of a given block)
    - Added error handling for the exceptions thrown by FileOutputStream
- Created new unit test for PDFGeneratorUtil (checks for creation of an uncorrupted file)