### PR TITLE
Nonfatal compilation stages

### DIFF
--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -198,7 +198,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
     fnResult
   }
 
-  /** Similar to (actually wraps) runRequiredStage, except error are non-fatal and logs to console.
+  /** Similar to (actually wraps) runRequiredStage, except errors are non-fatal and logs to console.
     * If the function fails, a specified default is returned.
     */
   private def runFailableStage[ReturnType](name: String, default: ReturnType, indicator: ProgressIndicator)

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -275,12 +275,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
 
         val (compiled, compiler, refinements) = runRequiredStage("compile", indicator) {
           val designType = ElemBuilder.LibraryPath(options.designName)
-
-          def compileProgressFn(record: ElaborateRecord): Unit = {
-            indicator.setText(s"EDG compiling: ${elaborateRecordToProgressString(record)}")
-          }
-
-          val output = EdgCompilerService(project).compile(designType, Some(compileProgressFn))
+          val output = EdgCompilerService(project).compile(designType, None)
           (output, "")
         }
 

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -315,7 +315,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
         }
 
         if (options.netlistFile.nonEmpty) {
-          runFailableStage("generate PDF", indicator) {
+          runFailableStage("generate netlist", indicator) {
             val netlist =pythonInterface.get.runBackend(
               ElemBuilder.LibraryPath("electronics_model.NetlistBackend"),
               compiled, compiler.getAllSolved,

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -262,6 +262,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
           val designModule = options.designName.split('.').init.mkString(".")
 
           def rebuildProgressFn(library: ref.LibraryPath, index: Int, total: Int): Unit = {
+            // TODO this is called even if the library is not recompiled
             console.print(s"Compile ${library.toSimpleString}\n",
               ConsoleViewContentType.LOG_INFO_OUTPUT)
             indicator.setIndeterminate(false)
@@ -309,9 +310,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
 
         if (options.pdfFile.nonEmpty) {
           runFailableStage("generate PDF", indicator) {
-            val (pdfGeneration, pdfTime) = timeExec {
-              PDFGeneratorUtil.generate(compiled.getContents, options.pdfFile)
-            }
+            PDFGeneratorUtil.generate(compiled.getContents, options.pdfFile)
             f"wrote ${options.pdfFile}"
           }
         } else {
@@ -321,7 +320,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
 
         if (options.netlistFile.nonEmpty) {
           runFailableStage("generate netlist", indicator) {
-            val netlist =pythonInterface.get.runBackend(
+            val netlist = pythonInterface.get.runBackend(
               ElemBuilder.LibraryPath("electronics_model.NetlistBackend"),
               compiled, compiler.getAllSolved,
               Map("RefdesMode" -> options.toggle.toString)


### PR DESCRIPTION
With refinements-as-a-Python-pass that runs before block diagram visualization, some designs that would compile with errors now fail. This restructures the design compile Run as sequences of stages that can fail without preventing further stages from running.

This also unifies the logging infrastructure and cuts down on some console spam and moves instrumentation from internals to the top-level compiler.