### PR TITLE
Optional (no-longer-default) persist block cache

### DIFF
--- a/src/main/java/edg_ide/ui/EdgSettingsState.java
+++ b/src/main/java/edg_ide/ui/EdgSettingsState.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 )
 public class EdgSettingsState implements PersistentStateComponent<EdgSettingsState> {
     public String kicadDirectory = "";
+    public boolean persistBlockCache = false;
 
 
     public static EdgSettingsState getInstance() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,8 +32,8 @@
   </extensions>
 
   <actions>
-    <action id="edg_ide.actions.EmptyCacheAction" class="edg_ide.actions.EmptyCacheAction"
-            text="Empty IDE Cache" description="Empty the IDE cache">
+    <action id="edg_ide.actions.EmptyBlockCacheAction" class="edg_ide.actions.EmptyBlockCacheAction"
+            text="Empty Block Cache" description="Empty the cache of compiled Blocks">
       <add-to-group group-id="ToolsMenu" anchor="first"/>
     </action>
 

--- a/src/main/scala/edg_ide/actions/EmptyBlockCacheAction.scala
+++ b/src/main/scala/edg_ide/actions/EmptyBlockCacheAction.scala
@@ -6,14 +6,14 @@ import edg_ide.EdgirUtils
 import edg_ide.ui.EdgCompilerService
 
 
-class EmptyCacheAction() extends AnAction() {
+class EmptyBlockCacheAction() extends AnAction() {
   val notificationGroup: NotificationGroup = NotificationGroup.balloonGroup("edg_ide.actions.EmptyCacheAction")
 
   override def actionPerformed(event: AnActionEvent): Unit = {
     EdgCompilerService(event.getProject).pyLib.clearThisCache()
 
     notificationGroup.createNotification(
-      s"IDE Cache Emptied",
+      s"Block Cache Emptied",
       NotificationType.INFORMATION
     ).notify(event.getProject)
   }

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -142,15 +142,20 @@ class EdgCompilerService(project: Project) extends
   }
 
   override def getState: EdgCompilerServiceState = {
-    // TODO discard stale cache?
     val state = new EdgCompilerServiceState
-    state.serializedBlocks = pyLib.toLibraryPb.toProtoString
+    val settings = EdgSettingsState.getInstance()
+    if (settings.persistBlockCache) {
+      state.serializedBlocks = pyLib.toLibraryPb.toProtoString
+    }
     state
   }
 
   override def loadState(state: EdgCompilerServiceState): Unit = {
-    val library = schema.Library.fromAscii(state.serializedBlocks)
-    pyLib.loadFromLibraryPb(library)
+    val settings = EdgSettingsState.getInstance()
+    if (settings.persistBlockCache) {
+      val library = schema.Library.fromAscii(state.serializedBlocks)
+      pyLib.loadFromLibraryPb(library)
+    }
   }
 
   override def dispose(): Unit = { }

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -1,12 +1,12 @@
 package edg_ide.ui
 
-import com.intellij.openapi.fileChooser.{FileChooserDescriptor, FileChooserDescriptorFactory}
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
-import com.intellij.ui.components.{JBLabel, JBTextField}
+import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.FormBuilder
 
-import javax.swing.JPanel
+import javax.swing.{JCheckBox, JPanel}
 
 
 class EdgSettingsComponent {
@@ -15,10 +15,20 @@ class EdgSettingsComponent {
     "Choose KiCad Footprint Directory", "", null,
     FileChooserDescriptorFactory.createSingleFolderDescriptor()
   )
+  val kicadDirectoryHelp = new JBLabel("IDE restart may be required to take effect.")
+  kicadDirectoryHelp.setEnabled(false)
+  val persistBlockCache = new JCheckBox()
+  val persistBlockCacheHelp = new JBLabel("Not recommended. "
+    + "Persists compiled blocks across IDE restarts for a faster first compile. "
+    + "May not detect HDL changes when the IDE is not running.")
+  persistBlockCacheHelp.setEnabled(false)
+  persistBlockCacheHelp.setAllowAutoWrapping(true)
 
   val mainPanel = FormBuilder.createFormBuilder()
       .addLabeledComponent(new JBLabel("KiCad Footprint Directory"), kicadDirectoryText, false)
-      .addComponent(new JBLabel("IDE restart may be required to take effect"))
+      .addComponent(kicadDirectoryHelp)
+      .addLabeledComponent(new JBLabel("Persist Block Cache"), persistBlockCache, false)
+      .addComponent(persistBlockCacheHelp)
       .addComponentFillVertically(new JPanel(), 0)
       .getPanel
 }
@@ -35,15 +45,18 @@ class EdgSettingsConfigurable extends Configurable {
   override def isModified: Boolean = {
     val settings = EdgSettingsState.getInstance()
     settings.kicadDirectory != component.kicadDirectoryText.getText
+    settings.persistBlockCache != component.persistBlockCache.isSelected
   }
 
   override def apply(): Unit = {
     val settings = EdgSettingsState.getInstance()
     settings.kicadDirectory = component.kicadDirectoryText.getText
+    settings.persistBlockCache = component.persistBlockCache.isSelected
   }
 
   override def reset(): Unit = {
     val settings = EdgSettingsState.getInstance()
     component.kicadDirectoryText.setText(settings.kicadDirectory)
+    component.persistBlockCache.setSelected(settings.persistBlockCache)
   }
 }

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -22,7 +22,6 @@ class EdgSettingsComponent {
     + "Persists compiled blocks across IDE restarts for a faster first compile. "
     + "May not detect HDL changes when the IDE is not running.")
   persistBlockCacheHelp.setEnabled(false)
-  persistBlockCacheHelp.setAllowAutoWrapping(true)
 
   val mainPanel = FormBuilder.createFormBuilder()
       .addLabeledComponent(new JBLabel("KiCad Footprint Directory"), kicadDirectoryText, false)


### PR DESCRIPTION
Make the block cache persist-across-IDE-restarts optional, configured by a not-recommended checkbox in the project settings. The behavior is really kind of flakey as of right now but useful in come cases for rapid iteration.

Also renames to "Empty Block Cache" for better descriptiveness and rolls the HDL submodule to include the cache behavior documentation.