### PR TITLE
DSE: Plotting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ lazy val root = (project in file("."))
       version := "0.1-SNAPSHOT",
 
       libraryDependencies ++= Seq(
-        "org.scala-lang" % "scala-reflect" % "2.13.8",
         "org.scalatest" %% "scalatest" % "3.2.0" % "test",
         "org.eclipse.elk" % "org.eclipse.elk.alg.layered" % "0.7.0",
         "com.github.librepdf" % "openpdf" % "1.3.30",

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val root = (project in file("."))
       version := "0.1-SNAPSHOT",
 
       libraryDependencies ++= Seq(
+        "org.scala-lang" % "scala-reflect" % "2.13.8",
         "org.scalatest" %% "scalatest" % "3.2.0" % "test",
         "org.eclipse.elk" % "org.eclipse.elk.alg.layered" % "0.7.0",
         "com.github.librepdf" % "openpdf" % "1.3.30",

--- a/src/main/java/edg_ide/ui/EdgSettingsState.java
+++ b/src/main/java/edg_ide/ui/EdgSettingsState.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
         storages = @Storage("EdgSettingsPlugin.xml")
 )
 public class EdgSettingsState implements PersistentStateComponent<EdgSettingsState> {
-    public String kicadDirectory = "";
+    public String[] kicadDirectories = {};
     public boolean persistBlockCache = false;
 
 

--- a/src/main/scala/edg_ide/PsiUtils.scala
+++ b/src/main/scala/edg_ide/PsiUtils.scala
@@ -3,13 +3,10 @@ package edg_ide
 import com.intellij.openapi.project.Project
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.{PsiDocumentManager, PsiElement}
-import com.jetbrains.python.psi.types.TypeEvalContext
-import com.jetbrains.python.psi.{LanguageLevel, PyAssignmentStatement, PyClass, PyElementGenerator, PyFunction, PyRecursiveElementVisitor, PyReferenceExpression, PyTargetExpression}
+import com.jetbrains.python.psi.{PyFunction, PyReferenceExpression, PyTargetExpression}
 import edg.util.Errorable
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptSeq}
-import edg_ide.util.{ExceptionNotifyException, exceptable}
-
-import scala.collection.mutable
+import edg_ide.util.exceptable
 
 object PsiUtils {
   def fileLineOf(element: PsiElement, project: Project): Errorable[String] = {
@@ -48,7 +45,7 @@ object PsiUtils {
         ref.getName
       case (None, Some(target)) if target.getQualifier != null &&  target.getQualifier.textMatches(selfName) =>
         target.getName
-      case _ => throw ExceptionNotifyException("not in a reference expression")
+      case _ => exceptable.fail("not in a reference expression")
     }
   }
 }

--- a/src/main/scala/edg_ide/dse/.gitignore
+++ b/src/main/scala/edg_ide/dse/.gitignore
@@ -1,2 +1,0 @@
-# this just contains a config flag
-DseFeature.scala

--- a/src/main/scala/edg_ide/dse/.gitignore
+++ b/src/main/scala/edg_ide/dse/.gitignore
@@ -1,0 +1,2 @@
+# this just contains a config flag
+DseFeature.scala

--- a/src/main/scala/edg_ide/dse/DseConfigElement.scala
+++ b/src/main/scala/edg_ide/dse/DseConfigElement.scala
@@ -1,13 +1,13 @@
 package edg_ide.dse
 
 import edg.EdgirUtils.SimpleLibraryPath
-import edg.compiler.{Compiler, BooleanValue, ExprValue, FloatValue, IntValue, PartialCompile, RangeValue, TextValue, ArrayValue}
+import edg.compiler.{ArrayValue, BooleanValue, Compiler, ExprValue, FloatValue, IntValue, PartialCompile, RangeValue, TextValue}
 import edg.util.Errorable
-import edgir.ref.ref
 import edg.wir.{DesignPath, Refinements}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptBoolean, ExceptErrorable, ExceptOption, ExceptSeq}
 import edg_ide.util.IterableExtensions.IterableExtension
-import edg_ide.util.{ExceptionNotifyException, exceptable, requireExcept}
+import edg_ide.util.{exceptable, requireExcept}
+import edgir.ref.ref
 
 import scala.collection.{SeqMap, mutable}
 
@@ -195,7 +195,7 @@ case class DseParameterSearch(path: DesignPath, values: Seq[ExprValue])
           RangeValue(min, max)
         }
       case v =>
-        throw ExceptionNotifyException(f"unknown type of value $v")
+        exceptable.fail(f"unknown type of value $v")
     }
     requireExcept(newValues.nonEmpty, "no values specified")
     DseParameterSearch(path, newValues)

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -30,23 +30,50 @@ abstract class DseTypedObjective[T](implicit val tag: TypeTag[T]) extends DseObj
 
 
 // Extracts the value of a single parameter
-case class DseObjectiveParameter(path: IndirectDesignPath)
-    extends DseTypedObjective[Option[Any]] with Serializable {
-  override def objectiveToString = f"Parameter($path)"
+//case class DseObjectiveParameter(path: IndirectDesignPath)
+//    extends DseTypedObjective[Option[Any]] with Serializable {
+//  override def objectiveToString = f"Parameter($path)"
+//
+//  override def calculate(design: Design, compiler: Compiler): Option[Any] = {
+//    compiler.getParamValue(path) match {
+//      case Some(FloatValue(value)) => Some(value)
+//      case Some(IntValue(value)) => Some(value)
+//      case Some(RangeValue(lower, upper)) => Some((lower, upper))
+//      case Some(BooleanValue(value)) => Some(value)
+//      case Some(TextValue(value)) => Some(value)
+//      case Some(RangeEmpty) => Some((None, None))
+//      case Some(ArrayValue(values)) => Some(values)  // TODO recursively unpack
+//      case None => None
+//    }
+//  }
+//}
 
-  override def calculate(design: Design, compiler: Compiler): Option[Any] = {
-    compiler.getParamValue(path) match {
-      case Some(FloatValue(value)) => Some(value)
-      case Some(IntValue(value)) => Some(value)
-      case Some(RangeValue(lower, upper)) => Some((lower, upper))
-      case Some(BooleanValue(value)) => Some(value)
-      case Some(TextValue(value)) => Some(value)
-      case Some(RangeEmpty) => Some((None, None))
-      case Some(ArrayValue(values)) => Some(values)  // TODO recursively unpack
-      case None => None
-    }
-  }
+abstract class DseObjectiveParameter[T] extends DseTypedObjective[Option[T]] with Serializable {
+
 }
+
+case class DseFloatParameter(path: IndirectDesignPath) extends DseObjectiveParameter[Float] {
+  override def objectiveToString = f"FloatParameter($path)"
+}
+
+case class DseIntParameter(path: IndirectDesignPath) extends DseObjectiveParameter[Int] {
+  override def objectiveToString = f"IntParameter($path)"
+}
+
+case class DseRangeParameter(path: IndirectDesignPath) extends DseObjectiveParameter[(Float, Float)] {
+  // TODO support empty range case
+  override def objectiveToString = f"RangeParameter($path)"
+}
+
+case class DseBooleanParameter(path: IndirectDesignPath) extends DseObjectiveParameter[Boolean] {
+  override def objectiveToString = f"BooleanParameter($path)"
+}
+
+case class DseStringParameter(path: IndirectDesignPath) extends DseObjectiveParameter[String] {
+  override def objectiveToString = f"StringParameter($path)"
+}
+
+// Arrays not supported, unclear what to do with them
 
 
 // Stores footprint area so the data is not serialized and cached across multiple compilation runs

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -25,7 +25,7 @@ sealed trait DseObjective { self: Serializable =>
 
 
 // Abstract base class that defines the calculation type
-sealed abstract class DseTypedObjective[T](implicit val tag: TypeTag[T]) extends DseObjective { self: Serializable =>
+sealed abstract class DseTypedObjective[T] extends DseObjective { self: Serializable =>
   def calculate(design: schema.Design, compiler: Compiler): T
 }
 
@@ -40,7 +40,7 @@ case class DseFloatParameter(path: IndirectDesignPath) extends DseObjectiveParam
   override def calculate(design: Design, compiler: Compiler): Option[Float] = {
     compiler.getParamValue(path) match {
       case Some(FloatValue(value)) => Some(value)
-      case None => None
+      case _ => None
     }
   }
 }
@@ -52,7 +52,7 @@ case class DseIntParameter(path: IndirectDesignPath) extends DseObjectiveParamet
   override def calculate(design: Design, compiler: Compiler): Option[BigInt] = {
     compiler.getParamValue(path) match {
       case Some(IntValue(value)) => Some(value)
-      case None => None
+      case _ => None
     }
   }
 }
@@ -65,7 +65,7 @@ case class DseRangeParameter(path: IndirectDesignPath) extends DseObjectiveParam
   override def calculate(design: Design, compiler: Compiler): Option[(Float, Float)] = {
     compiler.getParamValue(path) match {
       case Some(RangeValue(minValue, maxValue)) => Some((minValue, maxValue))
-      case None => None
+      case _ => None
     }
   }
 }
@@ -77,7 +77,7 @@ case class DseBooleanParameter(path: IndirectDesignPath) extends DseObjectivePar
   override def calculate(design: Design, compiler: Compiler): Option[Boolean] = {
     compiler.getParamValue(path) match {
       case Some(BooleanValue(value)) => Some(value)
-      case None => None
+      case _ => None
     }
   }
 }
@@ -89,7 +89,7 @@ case class DseStringParameter(path: IndirectDesignPath) extends DseObjectivePara
   override def calculate(design: Design, compiler: Compiler): Option[String] = {
     compiler.getParamValue(path) match {
       case Some(TextValue(value)) => Some(value)
-      case None => None
+      case _ => None
     }
   }
 }

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -10,7 +10,6 @@ import edgir.schema.schema
 import edgir.schema.schema.Design
 
 import scala.collection.{SeqMap, mutable}
-import scala.reflect.runtime.universe._
 
 
 // Abstract base class for all design space objectives - some function of the design

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -1,6 +1,6 @@
 package edg_ide.dse
 import scala.reflect.runtime.universe._
-import edg.compiler.{ArrayValue, BooleanValue, Compiler, ExprValue, FloatValue, IntValue, RangeEmpty, RangeValue, TextValue}
+import edg.compiler.{ArrayValue, BooleanValue, Compiler, FloatValue, IntValue, RangeEmpty, RangeValue, TextValue}
 import edg.wir.ProtoUtil.ParamProtoToSeqMap
 import edg.wir.{DesignPath, IndirectDesignPath}
 import edg_ide.ui.{EdgSettingsState, KicadParser}

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -17,16 +17,13 @@ import scala.collection.{SeqMap, mutable}
 //
 // Must be serializable so configs can be saved and persist across IDE restarts
 sealed trait DseObjective { self: Serializable =>
-  // TODO: also needs libraries and external sources?
   def objectiveToString: String  // short human-friendly string describing this configuration
 
   def calculate(design: schema.Design, compiler: Compiler): Any
 }
 
 
-sealed trait DseTypedObjective[+T] extends DseObjective { self: Serializable =>
-//  implicit val classTagB: TypeTag[T] = typeTag[T]
-
+abstract class DseTypedObjective[T](implicit val tag: TypeTag[T]) extends DseObjective { self: Serializable =>
   def calculate(design: schema.Design, compiler: Compiler): T
 }
 

--- a/src/main/scala/edg_ide/psi_edits/InsertFootprintAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertFootprintAction.scala
@@ -91,7 +91,7 @@ object InsertFootprintAction {
       case (Errorable.Success(modifyAction), _) => modifyAction
       case (Errorable.Error(_), Errorable.Success(insertAction)) => insertAction
       case (Errorable.Error(modifyErr), Errorable.Error(insertErr)) =>
-        throw ExceptionNotifyException(s"$modifyErr and $insertErr")
+        exceptable.fail(s"$modifyErr and $insertErr")
     }
   }
 }

--- a/src/main/scala/edg_ide/psi_edits/InsertPinningAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertPinningAction.scala
@@ -2,19 +2,19 @@ package edg_ide.psi_edits
 
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
 import com.intellij.openapi.project.Project
-import com.intellij.psi.{PsiElement, PsiParserFacade}
 import com.intellij.psi.util.PsiTreeUtil
-import com.jetbrains.python.psi.{LanguageLevel, PyCallExpression, PyClass, PyDictLiteralExpression, PyElementGenerator, PyExpression, PyFunction, PyKeyValueExpression, PyStatementList, PyStringLiteralExpression}
+import com.intellij.psi.{PsiElement, PsiParserFacade}
 import com.jetbrains.python.psi.types.TypeEvalContext
-import edgir.elem.elem
-import edgir.ref.ref
-import edg.{ElemBuilder, ExprBuilder}
+import com.jetbrains.python.psi._
 import edg.compiler.ExprToString
 import edg.util.Errorable
 import edg.wir.ProtoUtil.PortProtoToSeqMap
+import edg.{ElemBuilder, ExprBuilder}
 import edg_ide.ui.PopupUtils
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption, ExceptSeq}
-import edg_ide.util.{DesignAnalysisUtils, ExceptionNotifyException, exceptable, requireExcept}
+import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
+import edgir.elem.elem
+import edgir.ref.ref
 
 import java.awt.event.MouseEvent
 
@@ -87,7 +87,7 @@ object InsertPinningAction {
     }.toSeq match {
       case Seq(kv) => Some(kv)
       case Seq() => None
-      case _ => throw ExceptionNotifyException(s"more than one pinning entry for $pin")
+      case _ => exceptable.fail(s"more than one pinning entry for $pin")
     }
 
     val priorPinned = pinning.values.toSet

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -50,7 +50,7 @@ class SingleThreadRunner() {
   */
 object DseCsvWriter {
   def apply(writer: java.io.Writer, elts: Seq[DseConfigElement],
-            objectives: SeqMap[String, DseObjective[Any]]): Option[DseCsvWriter] = {
+            objectives: SeqMap[String, DseObjective]): Option[DseCsvWriter] = {
     Option(CsvWriter.builder().build(writer)).map { csv =>
       new DseCsvWriter(writer, csv, elts, objectives)
     }
@@ -59,7 +59,7 @@ object DseCsvWriter {
 
 
 class DseCsvWriter(writer: java.io.Writer, csv: CsvWriter, searchConfigs: Seq[DseConfigElement],
-                   objectives: SeqMap[String, DseObjective[Any]]) {
+                   objectives: SeqMap[String, DseObjective]) {
   private val objectiveNames = objectives.keys.toSeq
   private val searchNames = searchConfigs.map(_.configToString)
 

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -114,7 +114,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
     // the UI update is in a thread so it doesn't block the main search loop
     val uiUpdater = new SingleThreadRunner()
     uiUpdater.runIfIdle {
-      BlockVisualizerService(project).setDseResults(Seq(), true)  // show searching in UI
+      BlockVisualizerService(project).setDseResults(Seq(), options.objectives.keys.toSeq, true)  // show searching in UI
     }
 
     // Open a CSV file (if desired) and write result rows as they are computed.
@@ -224,7 +224,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
               uiUpdater.runIfIdle { // only have one UI update in progress at any time
                 System.gc() // clean up after this compile run
-                BlockVisualizerService(project).setDseResults(results.toSeq, true) // show searching in UI
+                BlockVisualizerService(project).setDseResults(results.toSeq, options.objectives.keys.toSeq, true) // show searching in UI
               }
             } else {
               console.print(s"Intermediate point ($compileTime ms)\n",
@@ -239,7 +239,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
         runFailableStage("update visualization", indicator) {
           uiUpdater.join()  // wait for pending UI updates to finish before updating to final value
-          BlockVisualizerService(project).setDseResults(results.toSeq, false)  // plumb results to UI
+          BlockVisualizerService(project).setDseResults(results.toSeq, options.objectives.keys.toSeq, false)  // plumb results to UI
           ""
         }
       }

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -114,7 +114,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
     // the UI update is in a thread so it doesn't block the main search loop
     val uiUpdater = new SingleThreadRunner()
     uiUpdater.runIfIdle {
-      BlockVisualizerService(project).setDseResults(Seq(), options.objectives.keys.toSeq, true)  // show searching in UI
+      BlockVisualizerService(project).setDseResults(Seq(), options.objectives, true)  // show searching in UI
     }
 
     // Open a CSV file (if desired) and write result rows as they are computed.
@@ -224,7 +224,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
               uiUpdater.runIfIdle { // only have one UI update in progress at any time
                 System.gc() // clean up after this compile run
-                BlockVisualizerService(project).setDseResults(results.toSeq, options.objectives.keys.toSeq, true) // show searching in UI
+                BlockVisualizerService(project).setDseResults(results.toSeq, options.objectives, true) // show searching in UI
               }
             } else {
               console.print(s"Intermediate point ($compileTime ms)\n",
@@ -239,7 +239,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
         runFailableStage("update visualization", indicator) {
           uiUpdater.join()  // wait for pending UI updates to finish before updating to final value
-          BlockVisualizerService(project).setDseResults(results.toSeq, options.objectives.keys.toSeq, false)  // plumb results to UI
+          BlockVisualizerService(project).setDseResults(results.toSeq, options.objectives, false)  // plumb results to UI
           ""
         }
       }

--- a/src/main/scala/edg_ide/runner/DseRunConfigurationType.scala
+++ b/src/main/scala/edg_ide/runner/DseRunConfigurationType.scala
@@ -57,7 +57,7 @@ class DseRunConfigurationOptions extends RunConfigurationOptions {
   var resultCsvFile: String = ""
 
   var searchConfigs: Seq[DseConfigElement] = Seq()
-  var objectives: SeqMap[String, DseObjective[Any]] = SeqMap()
+  var objectives: SeqMap[String, DseObjective] = SeqMap()
 }
 
 
@@ -99,9 +99,9 @@ class DseRunConfiguration(project: Project, factory: ConfigurationFactory, name:
         .foreach(options.searchConfigs = _)  // only set if valid, otherwise leave as default
     Option(JDOMExternalizerUtil.readField(element, kFieldObjectives))
         .flatMap(ObjectSerializer.deserialize)
-        .flatMap(ObjectSerializer.optionInstanceOfSeq[(String, DseObjective[Any])](
+        .flatMap(ObjectSerializer.optionInstanceOfSeq[(String, DseObjective)](
           _,
-          { elt: (String, DseObjective[Any]) => elt._1.isInstanceOf[String] && elt._2.isInstanceOf[DseObjective[Any]] }))
+          { elt: (String, DseObjective) => elt._1.isInstanceOf[String] && elt._2.isInstanceOf[DseObjective] }))
         .map(SeqMap.from)
         .foreach(options.objectives = _)
   }

--- a/src/main/scala/edg_ide/swing/ColorUtil.scala
+++ b/src/main/scala/edg_ide/swing/ColorUtil.scala
@@ -1,0 +1,13 @@
+package edg_ide.swing
+
+import java.awt.Color
+
+object ColorUtil {
+  def blendColor(baseColor: Color, topColor: Color, factor: Double): Color = {
+    new Color(
+      (baseColor.getRed * (1 - factor) + topColor.getRed * factor).toInt,
+      (baseColor.getGreen * (1 - factor) + topColor.getGreen * factor).toInt,
+      (baseColor.getBlue * (1 - factor) + topColor.getBlue * factor).toInt,
+    )
+  }
+}

--- a/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
@@ -6,16 +6,19 @@ import javax.swing.JTree
 import javax.swing.event.TreeModelListener
 import javax.swing.tree.TreePath
 import java.io.File
-import java.nio.file.{Files, NotDirectoryException, Paths}
 
 
 sealed trait FootprintBrowserBaseNode {
   def children: Seq[FootprintBrowserBaseNode]
 }
 
+
 class FootprintBrowserRootNode(directories: Seq[File]) extends FootprintBrowserBaseNode {
-  override lazy val children: Seq[FootprintBrowserNode] = directories.map { directory =>
-    new FootprintBrowserNode(directory)
+  override lazy val children: Seq[FootprintBrowserNode] = directories.flatMap { directory =>
+    directory.list().flatMap {  // flatten the libraries regardless of their containing directory
+      case elt if elt.endsWith(".pretty") => Some(new FootprintBrowserNode(new File(directory, elt)))
+      case _ => None
+    }
   }
 }
 

--- a/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
@@ -1,6 +1,7 @@
 package edg_ide.swing
 
 import com.intellij.ui.treeStructure.treetable.TreeTableModel
+
 import javax.swing.JTree
 import javax.swing.event.TreeModelListener
 import javax.swing.tree.TreePath
@@ -8,17 +9,25 @@ import java.io.File
 import java.nio.file.{Files, NotDirectoryException, Paths}
 
 
-class FootprintBrowserNode(directories: Seq[File]) {
+sealed trait FootprintBrowserBaseNode {
+  def children: Seq[FootprintBrowserBaseNode]
+}
 
-  val file: File = fArg
+class FootprintBrowserRootNode(directories: Seq[File]) extends FootprintBrowserBaseNode {
+  override lazy val children: Seq[FootprintBrowserNode] = directories.map { directory =>
+    new FootprintBrowserNode(directory)
+  }
+}
 
+
+class FootprintBrowserNode(val file: File) extends FootprintBrowserBaseNode {
   def isValidFile(filename: String): Boolean = {
     if (filename == "." || filename == "..") return false  // ignore self and up pointers
     val currFile = new File(filename)
     currFile.exists() && (filename.endsWith(".mod") || filename.endsWith(".kicad_mod") || currFile.isDirectory)
   }
 
-  lazy val children: Seq[FootprintBrowserNode] = {
+  override lazy val children: Seq[FootprintBrowserNode] = {
     Option(file.list()) match {
       case Some(filenames) => filenames.toSeq
         .map(filename => file.getCanonicalPath + "/" + filename)
@@ -39,15 +48,15 @@ class FootprintBrowserNode(directories: Seq[File]) {
 
 }
 
-class FootprintBrowserTreeTableModel(directories: Seq[File]) extends SeqTreeTableModel[FootprintBrowserNode] {
-  val rootNode: FootprintBrowserNode = new FootprintBrowserNode(directories)
-  val COLUMNS = Seq("Path")
+class FootprintBrowserTreeTableModel(directories: Seq[File]) extends SeqTreeTableModel[FootprintBrowserBaseNode] {
+  private val rootNode: FootprintBrowserRootNode = new FootprintBrowserRootNode(directories)
+  private val COLUMNS = Seq("Path")
 
-  override def getNodeChildren(node: FootprintBrowserNode): Seq[FootprintBrowserNode] = node.children
+  override def getNodeChildren(node: FootprintBrowserBaseNode): Seq[FootprintBrowserBaseNode] = node.children
 
-  override def getRootNode: FootprintBrowserNode = rootNode
+  override def getRootNode: FootprintBrowserBaseNode = rootNode
 
-  override def getNodeValueAt(node: FootprintBrowserNode, column: Int): AnyRef = node.file
+  override def getNodeValueAt(node: FootprintBrowserBaseNode, column: Int): FootprintBrowserBaseNode = node
 
   override def getColumnCount: Int = COLUMNS.length
 

--- a/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
@@ -8,7 +8,7 @@ import java.io.File
 import java.nio.file.{Files, NotDirectoryException, Paths}
 
 
-class FootprintBrowserNode(fArg: File) {
+class FootprintBrowserNode(directories: Seq[File]) {
 
   val file: File = fArg
 
@@ -39,8 +39,8 @@ class FootprintBrowserNode(fArg: File) {
 
 }
 
-class FootprintBrowserTreeTableModel(file: File) extends SeqTreeTableModel[FootprintBrowserNode] {
-  val rootNode: FootprintBrowserNode = new FootprintBrowserNode(file)
+class FootprintBrowserTreeTableModel(directories: Seq[File]) extends SeqTreeTableModel[FootprintBrowserNode] {
+  val rootNode: FootprintBrowserNode = new FootprintBrowserNode(directories)
   val COLUMNS = Seq("Path")
 
   override def getNodeChildren(node: FootprintBrowserNode): Seq[FootprintBrowserNode] = node.children

--- a/src/main/scala/edg_ide/swing/TreeTableUtils.scala
+++ b/src/main/scala/edg_ide/swing/TreeTableUtils.scala
@@ -64,4 +64,15 @@ object TreeTableUtils {
     }
     traverse(new TreePath(model.getRoot), expanded)
   }
+
+  // Returns the TreePath for a location where the entire row is valid, instead of the getPathForLocation behavior
+  // which must hit on the text.
+  def getPathForRowLocation(treeTable: TreeTable, x: Int, y: Int): Option[TreePath] = {
+    val nearestRow = treeTable.getTree.getClosestRowForLocation(x, y)
+    if (nearestRow < 0) {
+      return None
+    }
+    val nearestRowBounds = treeTable.getTree.getRowBounds(nearestRow)
+    Option(treeTable.getTree.getPathForLocation(nearestRowBounds.x, y))
+  }
 }

--- a/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
@@ -1,5 +1,6 @@
 package edg_ide.swing.blocks
 
+import edg_ide.swing.ColorUtil
 import edg_ide.swing.blocks.ElkNodeUtil.edgeSectionPairs
 import org.eclipse.elk.core.options._
 import org.eclipse.elk.graph._
@@ -13,16 +14,7 @@ object ElkNodePainter{
 }
 
 
-class ElkNodePainter(rootNode: ElkNode, showTop: Boolean = false, zoomLevel: Float = 1.0f){
-
-  def blendColor(baseColor: Color, topColor: Color, factor: Double): Color = {
-    new Color(
-      (baseColor.getRed * (1 - factor) + topColor.getRed * factor).toInt,
-      (baseColor.getGreen * (1 - factor) + topColor.getGreen * factor).toInt,
-      (baseColor.getBlue * (1 - factor) + topColor.getBlue * factor).toInt,
-    )
-  }
-
+class ElkNodePainter(rootNode: ElkNode, showTop: Boolean = false, zoomLevel: Float = 1.0f) {
   // Modify the base graphics for filling some element, eg by highlighted status
   protected def fillGraphics(base: Graphics2D, background: Color, element: ElkGraphElement): Graphics2D = {
     if (element == rootNode && !showTop) { // completely transparent for root if not showing top
@@ -164,7 +156,7 @@ class ElkNodePainter(rootNode: ElkNode, showTop: Boolean = false, zoomLevel: Flo
 
 
   protected def getNodeBackground(containingG: Graphics2D, containingBackground: Color, node: ElkNode): Color = {
-    val nodeBackground = blendColor(containingBackground, containingG.getColor, 0.15)
+    val nodeBackground = ColorUtil.blendColor(containingBackground, containingG.getColor, 0.15)
     nodeBackground
   }
 

--- a/src/main/scala/edg_ide/swing/blocks/ModifiedElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/ModifiedElkNodePainter.scala
@@ -2,7 +2,7 @@ package edg_ide.swing.blocks
 
 import edg.wir.DesignPath
 import edg_ide.edgir_graph.ElkEdgirGraphUtils
-import edg_ide.swing.DrawAnchored
+import edg_ide.swing.{ColorUtil, DrawAnchored}
 import org.eclipse.elk.graph._
 
 import java.awt._
@@ -43,7 +43,7 @@ class ModifiedElkNodePainter(rootNode: ElkNode,
     } else if (!selected.contains(element) &&
       highlighted.isDefined && !highlighted.get.contains(element)) { // dimmed out if not highlighted
       val newGraphics = base.create().asInstanceOf[Graphics2D]
-      newGraphics.setColor(blendColor(background, newGraphics.getColor, 0.25))
+      newGraphics.setColor(ColorUtil.blendColor(background, newGraphics.getColor, 0.25))
       newGraphics
     } else {
       base
@@ -54,14 +54,14 @@ class ModifiedElkNodePainter(rootNode: ElkNode,
   override def fillGraphics(base: Graphics2D, background: Color, element: ElkGraphElement): Graphics2D = {
     if (errorElts.contains(element)) {
       val newBase = base.create().asInstanceOf[Graphics2D]
-      newBase.setColor(blendColor(background, Color.RED, 0.25))
+      newBase.setColor(ColorUtil.blendColor(background, Color.RED, 0.25))
       newBase // explicitly ignores showTop invisibility if it's an error
     } else if (staleElts.contains(element)) {
       val newBase = base.create().asInstanceOf[Graphics2D]
       if (highlighted.isDefined && !highlighted.get.contains(element)) { // dimmed out if not highlighted
-        newBase.setPaint(makeHatchTexture(background, blendColor(background, base.getColor, 0.0375)))
+        newBase.setPaint(makeHatchTexture(background, ColorUtil.blendColor(background, base.getColor, 0.0375)))
       } else {
-        newBase.setPaint(makeHatchTexture(background, blendColor(background, base.getColor, 0.15)))
+        newBase.setPaint(makeHatchTexture(background, ColorUtil.blendColor(background, base.getColor, 0.15)))
       }
       newBase
     } else {
@@ -89,7 +89,7 @@ class ModifiedElkNodePainter(rootNode: ElkNode,
       newGraphics
     } else if (highlighted.isDefined && !highlighted.get.contains(element)) { // dimmed out if not highlighted
       val newGraphics = base.create().asInstanceOf[Graphics2D]
-      newGraphics.setColor(blendColor(background, newGraphics.getColor, 0.25))
+      newGraphics.setColor(ColorUtil.blendColor(background, newGraphics.getColor, 0.25))
       newGraphics
     } else {
       base
@@ -144,9 +144,9 @@ class ModifiedElkNodePainter(rootNode: ElkNode,
 
   override def getNodeBackground(containingG: Graphics2D, containingBackground: Color, node: ElkNode): Color = {
     val nodeBackground = if (highlighted.isDefined && !highlighted.get.contains(node)) { // dimmed out
-      blendColor(containingBackground, containingG.getColor, 0.375)
+      ColorUtil.blendColor(containingBackground, containingG.getColor, 0.375)
     } else {
-      blendColor(containingBackground, containingG.getColor, 0.15)
+      ColorUtil.blendColor(containingBackground, containingG.getColor, 0.15)
     }
 
     nodeBackground

--- a/src/main/scala/edg_ide/swing/dse/DseConfigTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/dse/DseConfigTreeTableModel.scala
@@ -32,7 +32,7 @@ object DseConfigTreeNode {
     override val children: Seq[SeqNodeBase] = Seq()
   }
 
-  class Root(configs: Seq[DseConfigElement], objectives: SeqMap[String, DseObjective[Any]]) extends DseConfigTreeNode {
+  class Root(configs: Seq[DseConfigElement], objectives: SeqMap[String, DseObjective]) extends DseConfigTreeNode {
     override val path = ""
     override val value = ""
     override lazy val children = Seq(
@@ -50,7 +50,7 @@ object DseConfigTreeNode {
     }
   }
 
-  class Objectives(objectives: SeqMap[String, DseObjective[Any]]) extends DseConfigTreeNode {
+  class Objectives(objectives: SeqMap[String, DseObjective]) extends DseConfigTreeNode {
     override val path = "Objective Functions"
     override val value = ""
     override lazy val children = objectives.map { case (name, config) =>
@@ -77,10 +77,10 @@ object DseConfigTreeNode {
   }
 
   sealed trait DseObjectiveNode extends DseConfigTreeNode {
-    def config: DseObjective[Any]
+    def config: DseObjective
   }
 
-  class DseObjectiveSingleNode(name: String, val config: DseObjective[Any]) extends DseObjectiveNode {
+  class DseObjectiveSingleNode(name: String, val config: DseObjective) extends DseObjectiveNode {
     override val path = name
     override val value = config.objectiveToString
     override lazy val children = Seq()
@@ -88,7 +88,7 @@ object DseConfigTreeNode {
 }
 
 
-class DseConfigTreeTableModel(searchConfigs: Seq[DseConfigElement], objectives: SeqMap[String, DseObjective[Any]])
+class DseConfigTreeTableModel(searchConfigs: Seq[DseConfigElement], objectives: SeqMap[String, DseObjective])
     extends SeqTreeTableModel[SeqNodeBase] {
   val rootNode: SeqNodeBase = new DseConfigTreeNode.Root(searchConfigs, objectives)
   val COLUMNS = Seq("Path", "Value")

--- a/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
@@ -1,7 +1,7 @@
 package edg_ide.swing.dse
 
 import com.intellij.ui.treeStructure.treetable.TreeTableModel
-import edg_ide.dse.{DseConfigElement, DseResult}
+import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseResult}
 import edg_ide.swing.SeqTreeTableModel
 
 import javax.swing.JTree
@@ -17,24 +17,19 @@ trait DseResultNodeBase {
   override def toString = config
 }
 
-class DseResultTreeNode(columnToObjectiveName: Map[Int, String], results: Seq[DseResult], inProgress: Boolean) extends DseResultNodeBase {
-  // Aggregates similar results together, somewhat preserving order of the input
-  private def combineSimilarResults(results: Seq[DseResult]): Seq[Seq[DseResult]] = {
-    // Stores results, combining by unique combination of design, error, and objective results
-    // Specifically avoids the actual refinements, which may produce a false positive match
-    // (different configurations that produce the same design in the end)
-    results.groupBy(result => (result.compiled, result.errors, result.objectives))
-        .values.toSeq
-  }
-
+class DseResultTreeNode(results: CombinedDseResultSet, objectiveNames: Seq[String], inProgress: Boolean) extends DseResultNodeBase {
   private val informationalHeader = if (inProgress) {
     Seq(new InformationalNode("... search in progress ..."))
   } else {
     Seq()
   }
+  private val objectiveNameByColumn = objectiveNames.zipWithIndex.map { case (objective, index) =>
+    index + 1 -> objective
+  }.toMap
+
 
   // Defines the root node
-  override lazy val children = informationalHeader ++ combineSimilarResults(results).map { resultsSet =>
+  override lazy val children = informationalHeader ++ results.groupedResults.map { resultsSet =>
     new ResultSetNode(resultsSet)
   }
   override val config = "" // empty, since the root node is hidden
@@ -51,10 +46,10 @@ class DseResultTreeNode(columnToObjectiveName: Map[Int, String], results: Seq[Ds
     }
     override val config = f"${setMembers.length} points" + errString
     override lazy val children = setMembers.map(result => new ResultNode(result))
-    override def getColumns(index: Int): String = columnToObjectiveName.get(index) match {
+    override def getColumns(index: Int): String = objectiveNameByColumn.get(index) match {
       case Some(objectiveName) => exampleResult.objectives.get(objectiveName) match {
         case Some(value) => DseConfigElement.valueToString(value)
-        case _ => "???"
+        case _ => "(unknown)"
       }
       case _ => "???"
     }
@@ -74,13 +69,11 @@ class DseResultTreeNode(columnToObjectiveName: Map[Int, String], results: Seq[Ds
 }
 
 
-class DseResultTreeTableModel(results: Seq[DseResult], inProgress: Boolean)
+class DseResultTreeTableModel(results: CombinedDseResultSet, objectiveNames: Seq[String], inProgress: Boolean)
     extends SeqTreeTableModel[DseResultNodeBase] {
-  val objectiveNames = results.headOption.map(_.objectives.keys).getOrElse(Seq()).toSeq
   val COLUMNS = Seq("Config") ++ objectiveNames
 
-  val columnToObjectiveNames = objectiveNames.zipWithIndex.map(elt => elt._2 + 1 -> elt._1).toMap
-  val rootNode: DseResultNodeBase = new DseResultTreeNode(columnToObjectiveNames, results, inProgress)
+  val rootNode: DseResultNodeBase = new DseResultTreeNode(results, objectiveNames, inProgress)
 
   // TreeView abstract methods
   //

--- a/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
@@ -37,7 +37,7 @@ class DseResultTreeNode(results: CombinedDseResultSet, objectiveNames: Seq[Strin
 
 
   // Displays a set of equivalent results, useful for deduplicating similar results
-  class ResultSetNode(setMembers: Seq[DseResult]) extends DseResultNodeBase {
+  class ResultSetNode(val setMembers: Seq[DseResult]) extends DseResultNodeBase {
     private val exampleResult = setMembers.head
     private val errString = if (exampleResult.errors.nonEmpty) {
       f", ${exampleResult.errors.length} errors"
@@ -73,7 +73,7 @@ class DseResultTreeTableModel(results: CombinedDseResultSet, objectiveNames: Seq
     extends SeqTreeTableModel[DseResultNodeBase] {
   val COLUMNS = Seq("Config") ++ objectiveNames
 
-  val rootNode: DseResultNodeBase = new DseResultTreeNode(results, objectiveNames, inProgress)
+  val rootNode: DseResultTreeNode = new DseResultTreeNode(results, objectiveNames, inProgress)
 
   // TreeView abstract methods
   //

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -1,0 +1,52 @@
+package edg_ide.swing.dse
+
+import java.awt.{Dimension, Graphics, Rectangle}
+import javax.swing.{JComponent, Scrollable}
+
+
+/** Scatterplot widget with two numerical axes, with labels inside the plot.
+  * Data is structured as (x, y, data) coordinates, with some arbitrary data attached to each point.
+  *
+  * TODO: support other ordinal axes?
+  */
+class JScatterPlot[DataType] extends JComponent with Scrollable{
+  private var data: Seq[(Float, Float, DataType)] = Seq()
+
+  def setData(xys: Seq[(Float, Float, DataType)]): Unit = {
+    data = xys
+    validate()
+    repaint()
+  }
+
+  private def paintAxes(paintGraphics: Graphics): Unit = {
+    // bottom horizontal axis
+    paintGraphics.drawLine(0, getHeight, getWidth, getHeight)
+
+    // left vertical axis
+    paintGraphics.drawLine(0, 0, 0, getHeight)
+  }
+
+  private def paintData(paintGraphics: Graphics): Unit = {
+    // paintGraphics.drawOval()
+  }
+
+  override def paintComponent(paintGraphics: Graphics): Unit = {
+    paintAxes(paintGraphics)
+    paintData(paintGraphics)
+  }
+
+
+  override def getPreferredScrollableViewportSize: Dimension = getPreferredSize
+
+  // Scrollable APIs
+  //
+  override def getPreferredSize: Dimension = new Dimension(100, 100)  // TODO arbitrary
+
+  override def getScrollableBlockIncrement(rectangle: Rectangle, i: Int, i1: Int): Int = 1
+
+  override def getScrollableUnitIncrement(rectangle: Rectangle, i: Int, i1: Int): Int = 1
+
+  override def getScrollableTracksViewportWidth: Boolean = false
+
+  override def getScrollableTracksViewportHeight: Boolean = false
+}

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -3,7 +3,7 @@ package edg_ide.swing.dse
 import edg_ide.swing.{ColorUtil, DrawAnchored}
 
 import java.awt.event.{MouseEvent, MouseMotionAdapter, MouseWheelEvent, MouseWheelListener}
-import java.awt.{Dimension, Graphics, Rectangle}
+import java.awt.{Color, Dimension, Graphics, Rectangle}
 import javax.swing.{JComponent, Scrollable}
 import scala.collection.mutable
 
@@ -14,6 +14,14 @@ import scala.collection.mutable
   * TODO: support other ordinal axes?
   */
 class JScatterPlot[ValueType] extends JComponent with Scrollable {
+  /** Scatterplot data point. Value (arbitrary data associated with this point), X, Y are required,
+    * others are optional with defaults.
+    * This allows future extensibility with additional parameters, eg size or marks.
+    */
+  class Data(val value: ValueType, val x: Float, val y: Float,
+             val color: Option[Color] = None) {
+  }
+
   // GUI constants
   private val kDefaultRangeMarginFactor = 1.1f  // factor to extend the default range by
 
@@ -26,7 +34,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   private val kTickSizePx = 4
 
   // data state
-  private var data: Seq[(Float, Float, ValueType)] = Seq()
+  private var data: Seq[Data] = Seq()
   private var mouseOverData: Set[Int] = Set()  // index into data
 
   // UI state
@@ -45,7 +53,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   private def dataToScreenX(dataVal: Float): Int = ((dataVal - xRange._1) * dataScale(xRange, getWidth)).toInt
   private def dataToScreenY(dataVal: Float): Int = ((yRange._2 - dataVal) * dataScale(yRange, getHeight)).toInt
 
-  def setData(xys: Seq[(Float, Float, ValueType)]): Unit = {
+  def setData(xys: Seq[Data]): Unit = {
     data = xys
     mouseOverData = Set()  // clear
 
@@ -54,9 +62,9 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
       val expansion = span * (factor - 1) / 2  // range units to expand on each side
       (range._1 - expansion, range._2 + expansion)
     }
-    val xs = data.map(_._1)
+    val xs = data.map(_.x)
     xRange = expandedRange(((xs :+ 0f).min, (xs :+ 0f).max), kDefaultRangeMarginFactor)
-    val ys = data.map(_._2)
+    val ys = data.map(_.y)
     yRange = expandedRange(((ys :+ 0f).min, (ys :+ 0f).max), kDefaultRangeMarginFactor)
 
     validate()
@@ -101,9 +109,9 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   }
 
   private def paintData(paintGraphics: Graphics): Unit = {
-    data.zipWithIndex.foreach { case ((dataX, dataY, value), index) =>
-      val screenX = dataToScreenX(dataX)
-      val screenY = dataToScreenY(dataY)
+    data.zipWithIndex.foreach { case (data, index) =>
+      val screenX = dataToScreenX(data.x)
+      val screenY = dataToScreenY(data.y)
       paintGraphics.fillOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
       if (mouseOverData.contains(index)) {  // makes it thicker
         paintGraphics.drawOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
@@ -121,8 +129,8 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
 
   // Returns the points with some specified distance (in screen coordinates, px) of the point.
   def getPointsForLocation(x: Int, y: Int, distance: Int): Seq[Int] = {
-    data.zipWithIndex.flatMap { case ((rawX, rawY, value), index) =>
-      if (math.abs(dataToScreenX(rawX) - x) <= distance && math.abs(dataToScreenY(rawY) - y) <= distance) {
+    data.zipWithIndex.flatMap { case (data, index) =>
+      if (math.abs(dataToScreenX(data.x) - x) <= distance && math.abs(dataToScreenY(data.y) - y) <= distance) {
         Some(index)
       } else {
         None

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -1,8 +1,11 @@
 package edg_ide.swing.dse
 
+import edg_ide.swing.DrawAnchored
+
 import java.awt.event.{MouseEvent, MouseMotionAdapter}
 import java.awt.{Dimension, Graphics, Rectangle}
 import javax.swing.{JComponent, Scrollable}
+import scala.collection.mutable
 
 
 /** Scatterplot widget with two numerical axes, with labels inside the plot.
@@ -13,13 +16,16 @@ import javax.swing.{JComponent, Scrollable}
 class JScatterPlot[ValueType] extends JComponent with Scrollable{
   private var data: Seq[(Float, Float, ValueType)] = Seq()
 
+  private val kPlotMarginPx = 4 // px margin on every side of the plot
+
   private val kPointSizePx = 4 // diameter in px
   private val kSnapDistancePx = 4 // distance (box) to snap for a click
 
-  private val kPlotMarginPx = 4 // px margin on every side of the plot
+  private val kMinTickSpacingPx = 32  // min spacing between axis ticks, used to determine tick resolution
+  private val kTickSizePx = 4
 
   private var xOrigin = 0  // zero data is here in screen coordinates
-  private var xScale = 1.0f  // multiply data coord by this to get screen pos
+  private var xScale = 1.0f  // in px/data; multiply data coord by this to get screen pos
   private var yOrigin = 0
   private var yScale = -1.0f  // screen coordinates are +Y = down
 
@@ -34,12 +40,41 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable{
     repaint()
   }
 
+  // Returns all the axis ticks given some scale, screen origin, screen size, and min screen spacing
+  private def getAxisTicks(scale: Float, screenOrigin: Int, screenSize: Int, minScreenSpacing: Int): Seq[Float] = {
+    val minDataSpacing = math.abs(minScreenSpacing / scale)  // min tick spacing in data units
+    val tickSpacing = math.pow(10, math.log10(minDataSpacing).ceil)  // actual spacing in data units
+    val tickBound1 = -screenOrigin / scale  // because scale could be negative this could be the high end
+    val tickBound2 = (screenSize - screenOrigin) / scale
+
+    var tickPos = (math.floor(math.min(tickBound1, tickBound2) / tickSpacing) * tickSpacing).toFloat
+    val tickEnd = math.max(tickBound1, tickBound2)
+    val ticksBuilder = mutable.ArrayBuffer[Float]()
+    while (tickPos <= tickEnd) {
+      ticksBuilder.append(tickPos)
+      tickPos = (tickPos + tickSpacing).toFloat
+    }
+    ticksBuilder.toSeq
+  }
+
   private def paintAxes(paintGraphics: Graphics): Unit = {
     // bottom horizontal axis
     paintGraphics.drawLine(0, getHeight-1, getWidth-1, getHeight-1)
+    getAxisTicks(xScale, xOrigin, getWidth, kMinTickSpacingPx).foreach { tickPos =>
+      val screenX = (tickPos * xScale).toInt + xOrigin
+      paintGraphics.drawLine(screenX, getHeight - 1, screenX, getHeight - 1 - kTickSizePx)
+      DrawAnchored.drawLabel(paintGraphics, f"$tickPos%.02g",
+        (screenX, getHeight - 1 - kTickSizePx), DrawAnchored.Bottom)
+    }
 
     // left vertical axis
     paintGraphics.drawLine(0, 0, 0, getHeight-1)
+    getAxisTicks(yScale, yOrigin, getHeight, kMinTickSpacingPx).foreach { tickPos =>
+      val screenY = (tickPos * yScale).toInt + yOrigin
+      paintGraphics.drawLine(0, screenY, kTickSizePx, screenY)
+      DrawAnchored.drawLabel(paintGraphics, f"$tickPos%.02g",
+        (kTickSizePx, screenY), DrawAnchored.Left)
+    }
   }
 
   private def paintData(paintGraphics: Graphics): Unit = {

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -75,13 +75,12 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
 
   // Sets the selected data, which is rendered with a highlight.
   // Unlike the other functions, this just takes values for simplicity and does not require X/Y/etc data.
+  // Values not in rendered data are ignored.
   def setSelected(values: Seq[ValueType]): Unit = {
-    selectedIndices = values map { value =>
+    selectedIndices = values flatMap { value =>
       data.indexWhere(_.value == value) match {
-        case index if (index >= 0) =>
-        println(s"SetSelected($index)")
-          index
-        case _ => throw new IllegalArgumentException(f"no value $value")
+        case index if (index >= 0) => Some(index)
+        case _ => None  // ignored
       }
     }
 

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -20,10 +20,10 @@ class JScatterPlot[DataType] extends JComponent with Scrollable{
 
   private def paintAxes(paintGraphics: Graphics): Unit = {
     // bottom horizontal axis
-    paintGraphics.drawLine(0, getHeight, getWidth, getHeight)
+    paintGraphics.drawLine(0, getHeight-1, getWidth-1, getHeight-1)
 
     // left vertical axis
-    paintGraphics.drawLine(0, 0, 0, getHeight)
+    paintGraphics.drawLine(0, 0, 0, getHeight-1)
   }
 
   private def paintData(paintGraphics: Graphics): Unit = {

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -36,6 +36,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   // data state
   private var data: IndexedSeq[Data] = IndexedSeq()
   private var mouseOverIndices: Seq[Int] = Seq()  // sorted by increasing index
+  private var selectedIndices: Seq[Int] = Seq()  // unsorted
 
   // UI state
   private var xRange = (0f, 0f)
@@ -56,6 +57,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   def setData(xys: IndexedSeq[Data]): Unit = {
     data = xys
     mouseOverIndices = Seq()  // clear
+    selectedIndices = Seq()  // clear
 
     def expandedRange(range: (Float, Float), factor: Float): (Float, Float) = {
       val span = range._2 - range._1
@@ -66,6 +68,22 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
     xRange = expandedRange(((xs :+ 0f).min, (xs :+ 0f).max), kDefaultRangeMarginFactor)
     val ys = data.map(_.y)
     yRange = expandedRange(((ys :+ 0f).min, (ys :+ 0f).max), kDefaultRangeMarginFactor)
+
+    validate()
+    repaint()
+  }
+
+  // Sets the selected data, which is rendered with a highlight.
+  // Unlike the other functions, this just takes values for simplicity and does not require X/Y/etc data.
+  def setSelected(values: Seq[ValueType]): Unit = {
+    selectedIndices = values map { value =>
+      data.indexWhere(_.value == value) match {
+        case index if (index >= 0) =>
+        println(s"SetSelected($index)")
+          index
+        case _ => throw new IllegalArgumentException(f"no value $value")
+      }
+    }
 
     validate()
     repaint()
@@ -117,7 +135,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
       val screenX = dataToScreenX(data.x)
       val screenY = dataToScreenY(data.y)
       dataGraphics.fillOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
-      if (mouseOverIndices.contains(index)) {  // makes it thicker
+      if (mouseOverIndices.contains(index) || selectedIndices.contains(index)) {  // makes it thicker
         dataGraphics.drawOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
       }
     }

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -21,7 +21,8 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable{
   private val kPointSizePx = 4 // diameter in px
   private val kSnapDistancePx = 4 // distance (box) to snap for a click
 
-  private val kMinTickSpacingPx = 32  // min spacing between axis ticks, used to determine tick resolution
+  private val kTickSpacingIntervals = Seq(1, 2, 5)
+  private val kMinTickSpacingPx = 64  // min spacing between axis ticks, used to determine tick resolution
   private val kTickSizePx = 4
 
   private var xOrigin = 0  // zero data is here in screen coordinates
@@ -43,7 +44,10 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable{
   // Returns all the axis ticks given some scale, screen origin, screen size, and min screen spacing
   private def getAxisTicks(scale: Float, screenOrigin: Int, screenSize: Int, minScreenSpacing: Int): Seq[Float] = {
     val minDataSpacing = math.abs(minScreenSpacing / scale)  // min tick spacing in data units
-    val tickSpacing = math.pow(10, math.log10(minDataSpacing).ceil)  // actual spacing in data units
+    val tickSpacings = kTickSpacingIntervals.map { factor =>  // try all the spacings and take the minimum
+      math.pow(10, math.log10(minDataSpacing / factor).ceil) * factor
+    }
+    val tickSpacing = tickSpacings.min
     val tickBound1 = -screenOrigin / scale  // because scale could be negative this could be the high end
     val tickBound2 = (screenSize - screenOrigin) / scale
 

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -13,9 +13,8 @@ import scala.collection.mutable
   *
   * TODO: support other ordinal axes?
   */
-class JScatterPlot[ValueType] extends JComponent with Scrollable{
-  private var data: Seq[(Float, Float, ValueType)] = Seq()
-
+class JScatterPlot[ValueType] extends JComponent with Scrollable {
+  // GUI constants
   private val kDefaultRangeMarginFactor = 1.1f  // factor to extend the default range by
 
   private val kPointSizePx = 4 // diameter in px
@@ -26,11 +25,13 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable{
   private val kMinTickSpacingPx = 64  // min spacing between axis ticks, used to determine tick resolution
   private val kTickSizePx = 4
 
+  // data state
+  private var data: Seq[(Float, Float, ValueType)] = Seq()
+  private var mouseOverData: Set[Int] = Set()  // index into data
+
+  // UI state
   private var xRange = (0f, 0f)
   private var yRange = (0f, 0f)
-
-  // index into data
-  private var mouseOverData: Set[Int] = Set()
 
   // multiply data by this to get screen coordinates
   private def dataScale(dataRange: (Float, Float), screenSize: Int): Float = {

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -55,9 +55,9 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
       (range._1 - expansion, range._2 + expansion)
     }
     val xs = data.map(_._1)
-    xRange = expandedRange((math.min(0, xs.min), math.max(0, xs.max)), kDefaultRangeMarginFactor)
+    xRange = expandedRange(((xs :+ 0f).min, (xs :+ 0f).max), kDefaultRangeMarginFactor)
     val ys = data.map(_._2)
-    yRange = expandedRange((math.min(0, ys.min), math.max(0, ys.max)), kDefaultRangeMarginFactor)
+    yRange = expandedRange(((ys :+ 0f).min, (ys :+ 0f).max), kDefaultRangeMarginFactor)
 
     validate()
     repaint()

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -12,8 +12,23 @@ import javax.swing.{JComponent, Scrollable}
 class JScatterPlot[DataType] extends JComponent with Scrollable{
   private var data: Seq[(Float, Float, DataType)] = Seq()
 
+  private var xCenter = 0f  // center in data coordinates
+  private var xScale = 1.0f  // multiply data coord by this to get screen pos
+  private var yCenter = 0f
+  private var yScale = 1.0f
+
   def setData(xys: Seq[(Float, Float, DataType)]): Unit = {
     data = xys
+
+    val xs = xys.map(_._1)
+    val xMin = math.max(0, xs.min)
+    val xMax = math.min(0, xs.max)
+    xScale = (xMax - xMin)/getWidth
+    val ys = xys.map(_._2)
+    val yMin = math.max(0, ys.min)
+    val yMax = math.min(0, ys.max)
+    yScale = (yMax - yMin)/getHeight
+
     validate()
     repaint()
   }

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -110,11 +110,15 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
 
   private def paintData(paintGraphics: Graphics): Unit = {
     data.zipWithIndex.foreach { case (data, index) =>
+      val dataGraphics = paintGraphics.create()
+      data.color.foreach { color =>  // if color is specified, set the color
+        dataGraphics.setColor(color)
+      }
       val screenX = dataToScreenX(data.x)
       val screenY = dataToScreenY(data.y)
-      paintGraphics.fillOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
+      dataGraphics.fillOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
       if (mouseOverData.contains(index)) {  // makes it thicker
-        paintGraphics.drawOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
+        dataGraphics.drawOval(screenX - kPointSizePx / 2, screenY - kPointSizePx / 2, kPointSizePx, kPointSizePx)
       }
     }
   }

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -148,8 +148,8 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable{
       val zoomFactor = Math.pow(1.1, -1 * e.getPreciseWheelRotation)
       xScale = (xScale * zoomFactor).toFloat
       yScale = (yScale * zoomFactor).toFloat
-      xOrigin = (e.getPoint.x * (zoomFactor - 1) + zoomFactor * xOrigin).toInt
-      yOrigin = (e.getPoint.y * (zoomFactor - 1) + zoomFactor * yOrigin).toInt
+      xOrigin = ((xOrigin - e.getPoint.x) * (zoomFactor - 1) + xOrigin).toInt
+      yOrigin = ((yOrigin - e.getPoint.y) * (zoomFactor - 1) + yOrigin).toInt
       validate()
       repaint()
     }

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -2,7 +2,7 @@ package edg_ide.swing.dse
 
 import edg_ide.swing.{ColorUtil, DrawAnchored}
 
-import java.awt.event.{MouseEvent, MouseMotionAdapter, MouseWheelEvent, MouseWheelListener}
+import java.awt.event.{MouseAdapter, MouseEvent, MouseMotionAdapter, MouseWheelEvent, MouseWheelListener}
 import java.awt.{Color, Dimension, Graphics, Rectangle}
 import javax.swing.{JComponent, Scrollable}
 import scala.collection.mutable
@@ -145,6 +145,13 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
       }
     }
   }
+
+  addMouseListener(new MouseAdapter {
+    override def mouseClicked(e: MouseEvent): Unit = {
+      val clickedPoints = getPointsForLocation(e.getX, e.getY, kSnapDistancePx)
+      onClick(clickedPoints.sortBy(_._2).map(pair => data(pair._1)))
+    }
+  })
 
   addMouseMotionListener(new MouseMotionAdapter {
     override def mouseMoved(e: MouseEvent): Unit = {

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -19,7 +19,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
     * This allows future extensibility with additional parameters, eg size or marks.
     */
   class Data(val value: ValueType, val x: Float, val y: Float,
-             val color: Option[Color] = None) {
+             val color: Option[Color] = None, val tooltipText: Option[String] = None) {
   }
 
   // GUI constants
@@ -181,6 +181,13 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
       repaint()
     }
   })
+
+  override def getToolTipText(e: MouseEvent): String = {
+    getPointsForLocation(e.getX, e.getY, kSnapDistancePx).headOption match {
+      case Some((index, distance)) => data(index).tooltipText.orNull
+      case None => null
+    }
+  }
 
   // User hooks - can be overridden
   //

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -211,10 +211,11 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   designTree.getTree.addTreeSelectionListener(designTreeListener)
   designTree.addMouseListener(new MouseAdapter {  // right click context menu
     override def mousePressed(e: MouseEvent): Unit = {
-      Option(designTree.getTree.getPathForLocation(e.getX, e.getY)).foreach { _.getLastPathComponent match {
+      val selectedTreePath = TreeTableUtils.getPathForRowLocation(designTree, e.getX, e.getY).getOrElse(return)
+      selectedTreePath.getLastPathComponent match {
         case clickedNode: HierarchyBlockNode => activeTool.onPathMouse(e, clickedNode.path)
         case _ =>  // any other type ignored
-      } }
+      }
     }
   })
   designTree.setShowColumns(true)

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -246,7 +246,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
 
   // GUI: Design Space Exploration (bottom tab)
   //
-  private val dsePanel = new DseConfigPanel(project)
+  private val dsePanel = new DsePanel(project)
   dseSplitter.setSecondComponent(dsePanel)
 
   setLayout(new BorderLayout())
@@ -254,7 +254,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
 
   // Actions
   //
-  def getDsePanel: DseConfigPanel = dsePanel
+  def getDsePanel: DsePanel = dsePanel
 
   def getContextBlock: Option[(DesignPath, elem.HierarchyBlock)] = {
     EdgirUtils.resolveExactBlock(focusPath, design).map((focusPath, _))

--- a/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
@@ -31,7 +31,7 @@ class BlockVisualizerService(project: Project) extends
 
   def visualizerPanelOption: Option[BlockVisualizerPanel] = visualizerPanel
 
-  def dsePanelOption: Option[DseConfigPanel] = visualizerPanelOption.map(_.getDsePanel)
+  def dsePanelOption: Option[DsePanel] = visualizerPanelOption.map(_.getDsePanel)
 
   def createBlockVisualizerPanel(toolWindow: ToolWindow): BlockVisualizerPanel = {
     require(visualizerPanel.isEmpty)

--- a/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
@@ -102,8 +102,8 @@ class BlockVisualizerService(project: Project) extends
     }
   }
 
-  def setDseResults(results: Seq[DseResult], inProgress: Boolean): Unit = {
-    dsePanelOption.foreach(_.setResults(results, inProgress))
+  def setDseResults(results: Seq[DseResult], objectiveNames: Seq[String], inProgress: Boolean): Unit = {
+    dsePanelOption.foreach(_.setResults(results, objectiveNames, inProgress))
   }
 
   // State management

--- a/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
@@ -104,7 +104,7 @@ class BlockVisualizerService(project: Project) extends
     }
   }
 
-  def setDseResults(results: Seq[DseResult], objectives: SeqMap[String, DseObjective[Any]],
+  def setDseResults(results: Seq[DseResult], objectives: SeqMap[String, DseObjective],
                     inProgress: Boolean): Unit = {
     dsePanelOption.foreach(_.setResults(results, objectives, inProgress))
   }

--- a/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
@@ -11,9 +11,11 @@ import edgir.schema.schema
 import edgir.elem.elem
 import edgir.ref.ref
 import edg.wir.DesignPath
-import edg_ide.dse.DseResult
+import edg_ide.dse.{DseObjective, DseResult}
 import edg_ide.runner.{DseConfigurationFactory, DseRunConfiguration, DseRunConfigurationType}
 import edgrpc.hdl.{hdl => edgrpc}
+
+import scala.collection.SeqMap
 
 
 // Note: the implementation is here, but the actual service in plugin.xml is a Java class,
@@ -102,8 +104,9 @@ class BlockVisualizerService(project: Project) extends
     }
   }
 
-  def setDseResults(results: Seq[DseResult], objectiveNames: Seq[String], inProgress: Boolean): Unit = {
-    dsePanelOption.foreach(_.setResults(results, objectiveNames, inProgress))
+  def setDseResults(results: Seq[DseResult], objectives: SeqMap[String, DseObjective[Any]],
+                    inProgress: Boolean): Unit = {
+    dsePanelOption.foreach(_.setResults(results, objectives, inProgress))
   }
 
   // State management

--- a/src/main/scala/edg_ide/ui/DesignFastPathUtil.scala
+++ b/src/main/scala/edg_ide/ui/DesignFastPathUtil.scala
@@ -32,7 +32,7 @@ class DesignFastPathUtil(library: wir.Library) {
     portLike.is match {
       case elem.PortLike.Is.LibElem(portType) => instantiatePortLike(portType).exceptError
       case elem.PortLike.Is.Array(array) => portLike  // for now, don't elaborate arrays
-      case other => throw ExceptionNotifyException(s"unexpected ${other.getClass} in expand port")
+      case other => exceptable.fail(s"unexpected ${other.getClass} in expand port")
     }
 
   }
@@ -124,7 +124,7 @@ class DesignFastPathUtil(library: wir.Library) {
                 (i.toString, instantiatePortLike(connectType).exceptError).toPb
           )
           key -> ExprBuilder.Ref(topPortName, i.toString)
-        case other => throw ExceptionNotifyException(s"unexpected ${other.getClass} in link connect mapping")
+        case other => exceptable.fail(s"unexpected ${other.getClass} in link connect mapping")
       }
     }
 

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -63,11 +63,7 @@ class DetailPanel(initPath: DesignPath, initCompiler: Compiler, project: Project
 
   private val treeMouseListener = new MouseAdapter {
     override def mousePressed(e: MouseEvent): Unit = {
-      val selectedTreePath = tree.getTree.getPathForLocation(e.getX, e.getY)
-      if (selectedTreePath == null) {
-        return
-      }
-
+      val selectedTreePath = TreeTableUtils.getPathForRowLocation(tree, e.getX, e.getY).getOrElse(return)
       selectedTreePath.getLastPathComponent match {
         case selected: swing.ElementDetailNodes#ParamNode => // insert actions / menu for blocks
           if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) {  // right click context menu

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -3,7 +3,7 @@ package edg_ide.ui
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.treeStructure.treetable.TreeTable
-import edg.compiler.{BooleanValue, Compiler, FloatValue, IntValue, RangeValue, TextValue}
+import edg.compiler.{BooleanValue, Compiler, FloatValue, IntValue, RangeType, RangeValue, TextValue}
 import edg.wir.{DesignPath, IndirectDesignPath}
 import edg_ide.dse.{DseBooleanParameter, DseFeature, DseFloatParameter, DseIntParameter, DseObjectiveParameter, DseParameterSearch, DseRangeParameter, DseStringParameter}
 import edg_ide.swing
@@ -36,7 +36,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
     val objective = compiler.getParamType(path) match {
       case Some(q) if q == classOf[FloatValue]  => DseFloatParameter(path)
       case Some(q) if q == classOf[IntValue]  => DseIntParameter(path)
-      case Some(q) if q == classOf[RangeValue]  => DseRangeParameter(path)
+      case Some(q) if q == classOf[RangeType]  => DseRangeParameter(path)  // RangeType includes EmptyRange as well
       case Some(q) if q == classOf[BooleanValue]  => DseBooleanParameter(path)
       case Some(q) if q == classOf[TextValue]  => DseStringParameter(path)
       case Some(q) => exceptable.fail(f"unknown parameter type ${q.getSimpleName} at $path")

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -39,7 +39,8 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       case Some(q) if q == classOf[RangeValue]  => DseRangeParameter(path)
       case Some(q) if q == classOf[BooleanValue]  => DseBooleanParameter(path)
       case Some(q) if q == classOf[TextValue]  => DseStringParameter(path)
-      case _ => exceptable.fail(f"unknown parameter type at $path")
+      case Some(q) => exceptable.fail(f"unknown parameter type ${q.getSimpleName} at $path")
+      case _ => exceptable.fail(f"no parameter type at $path")
     }
 
     () => PopupUtils.createStringEntryPopup("Name", project) { text => exceptable {

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -17,6 +17,7 @@ import edg_ide.util.{exceptable, requireExcept}
 import java.awt.event.{ItemEvent, ItemListener, MouseAdapter, MouseEvent}
 import java.awt.{GridBagConstraints, GridBagLayout}
 import java.util.concurrent.TimeUnit
+import javax.swing.tree.TreePath
 import javax.swing.{JPanel, JPopupMenu, SwingUtilities}
 import scala.collection.SeqMap
 
@@ -261,8 +262,16 @@ class DsePanel(project: Project) extends JPanel {
   // GUI: Top plot
   private val plot = new DsePlotPanel() {
     override def onClick(data: Seq[Seq[DseResult]]): Unit = {
-      // TODO set results tree selection
+      resultsTree.clearSelection()
+      val treeRoot = resultsTree.getTableModel.asInstanceOf[DseResultTreeTableModel].rootNode
+      val treeRootPath = new TreePath(treeRoot)
+      treeRoot.children foreach {
+        case node: treeRoot.ResultSetNode if data.contains(node.setMembers) =>
+          resultsTree.addSelectedPath(treeRootPath.pathByAddingChild(node))
+        case node =>  // ignored
+      }
     }
+
     override def onHoverChange(data: Seq[Seq[DseResult]]): Unit = {
       // TODO something w/ results tree selection?
     }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -71,7 +71,15 @@ class DsePlotPanel() extends JPanel {
 
   setLayout(new GridBagLayout)
 
-  private val plot = new JScatterPlot[Seq[DseResult]]()
+  private val plot = new JScatterPlot[Seq[DseResult]]() {
+    override def onClick(data: Seq[Data]): Unit = {
+      println(f"click: $data")
+    }
+
+    override def onHoverChange(data: Seq[Data]): Unit = {
+      println(f"hover: $data")
+    }
+  }
   add(plot, Gbc(0, 0, GridBagConstraints.BOTH, 2))
 
   sealed trait AxisItem {
@@ -123,7 +131,7 @@ class DsePlotPanel() extends JPanel {
   add(ySelector, Gbc(1, 1, GridBagConstraints.HORIZONTAL))
 
   private def updatePlot(): Unit = {
-    val points = combinedResults.groupedResults.flatMap { resultSet =>
+    val points = combinedResults.groupedResults.toIndexedSeq.flatMap { resultSet =>
       val exampleResult = resultSet.head
       (xSelector.getItem.resultToValue(exampleResult), ySelector.getItem.resultToValue(exampleResult)) match {
         case (Some(xVal), Some(yVal)) =>
@@ -161,8 +169,8 @@ class DsePlotPanel() extends JPanel {
     }
     }
 
-    xSelector.removeItemListener(selectorListener)
-    ySelector.removeItemListener(selectorListener)
+    xSelector.removeItemListener(axisSelectorListener)
+    ySelector.removeItemListener(axisSelectorListener)
 
     xSelector.removeAllItems()
     ySelector.removeAllItems()
@@ -174,8 +182,8 @@ class DsePlotPanel() extends JPanel {
       ySelector.addItem(item)
     }
 
-    xSelector.addItemListener(selectorListener)
-    ySelector.addItemListener(selectorListener)
+    xSelector.addItemListener(axisSelectorListener)
+    ySelector.addItemListener(axisSelectorListener)
     displayAxisSelectorObjectives = objectives
 
     // restore prior selection by name matching
@@ -183,7 +191,7 @@ class DsePlotPanel() extends JPanel {
     items.find { item => item.toString == selectedY.toString }.foreach { item => ySelector.setItem(item) }
   }
 
-  private val selectorListener = new ItemListener() {
+  private val axisSelectorListener = new ItemListener() {
     override def itemStateChanged(e: ItemEvent): Unit = {
       if (e.getStateChange == ItemEvent.SELECTED) {
         updatePlot()

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -1,6 +1,7 @@
 package edg_ide.ui
 
 import com.intellij.openapi.project.Project
+import com.intellij.ui.JBSplitter
 import com.intellij.ui.components.{JBScrollPane, JBTabbedPane}
 import com.intellij.ui.dsl.builder.impl.CollapsibleTitledSeparator
 import com.intellij.ui.treeStructure.treetable.TreeTable
@@ -8,7 +9,7 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import edg_ide.dse.{DseConfigElement, DseObjective, DseParameterSearch, DseResult}
 import edg_ide.runner.DseRunConfiguration
 import edg_ide.swing._
-import edg_ide.swing.dse.{DseConfigTreeNode, DseConfigTreeTableModel, DseResultTreeNode, DseResultTreeTableModel}
+import edg_ide.swing.dse.{DseConfigTreeNode, DseConfigTreeTableModel, DseResultTreeNode, DseResultTreeTableModel, JScatterPlot}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption}
 import edg_ide.util.{exceptable, requireExcept}
 
@@ -62,7 +63,7 @@ class DseObjectivePopupMenu(objective: DseObjective[Any], project: Project) exte
 }
 
 
-class DseConfigPanel(project: Project) extends JPanel {
+class DsePanel(project: Project) extends JPanel {
   // currently displayed config
   private var displayedConfig: Option[DseRunConfiguration] = None
 
@@ -104,10 +105,19 @@ class DseConfigPanel(project: Project) extends JPanel {
   private val separator = new CollapsibleTitledSeparator("Design Space Exploration")
   add(separator, Gbc(0, 0, GridBagConstraints.HORIZONTAL))
 
-  private val tabbedPane = new JBTabbedPane()
-  add(tabbedPane, Gbc(0, 1, GridBagConstraints.BOTH))
+  private val mainSplitter = new JBSplitter(true, 0.5f, 0.1f, 0.9f)
+  add(mainSplitter, Gbc(0, 1, GridBagConstraints.BOTH))
 
-  // GUI: Config Tab
+  // GUI: Top plot
+  private val plot = new JScatterPlot[String]()
+  mainSplitter.setFirstComponent(plot)
+
+  // GUI: Bottom tabs
+
+  private val tabbedPane = new JBTabbedPane()
+  mainSplitter.setSecondComponent(tabbedPane)
+
+  // GUI: Bottom Tabs: Config
   //
   private val configTree = new TreeTable(new DseConfigTreeTableModel(Seq(), SeqMap()))
   configTree.setShowColumns(true)
@@ -134,7 +144,7 @@ class DseConfigPanel(project: Project) extends JPanel {
   })
   tabbedPane.addTab("Config", new JBScrollPane(configTree))
 
-  // GUI: Results Tab
+  // GUI: Bottom Tabs: Results
   //
   private val resultsTree = new TreeTable(new DseResultTreeTableModel(Seq(), false))
   resultsTree.setShowColumns(true)

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -19,6 +19,7 @@ import java.awt.{GridBagConstraints, GridBagLayout}
 import java.util.concurrent.TimeUnit
 import javax.swing.{JComboBox, JPanel, JPopupMenu, SwingUtilities}
 import scala.collection.SeqMap
+import scala.reflect.runtime.universe.typeOf
 
 
 class DseSearchConfigPopupMenu(searchConfig: DseConfigElement, project: Project) extends JPopupMenu {
@@ -104,10 +105,14 @@ class DsePlotPanel() extends JPanel {
     val selectedY = ySelector.getItem
     // TODO restore prior selection
 
-    val items = objectives flatMap { case (name, objective) => objective match {
-      case objective: DseTypedObjective[Float] => Seq(new DseObjectiveItem(objective, name))
-      case objective: DseTypedObjective[Double] => Seq(new DseObjectiveItem(objective, name))
-      case objective: DseTypedObjective[Int] => Seq(new DseObjectiveItem(objective, name))
+    val items = objectives flatMap { case (name, objective) =>
+      objective match {
+      case objective: DseTypedObjective[Float] if objective.tag.tpe =:= typeOf[Float] =>
+        Seq(new DseObjectiveItem(objective, name))
+      case objective: DseTypedObjective[Double] if objective.tag.tpe =:= typeOf[Double] =>
+        Seq(new DseObjectiveItem(objective, name))
+      case objective: DseTypedObjective[Int] if objective.tag.tpe =:= typeOf[Int] =>
+        Seq(new DseObjectiveItem(objective, name))
       case _ => Seq(new DummyAxisItem(f"unknown $name"))
     } }
 

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -207,6 +207,10 @@ class DsePlotPanel() extends JPanel {
     updatePlot()
   }
 
+  def setSelection(resultSets: Seq[Seq[DseResult]]): Unit = {
+    plot.setSelected(resultSets)
+  }
+
   // User hooks - can be overridden
   //
   // called when this widget clicked, for all points within some hover radius of the cursor
@@ -323,6 +327,10 @@ class DsePanel(project: Project) extends JPanel {
       }
 
       selectedTreePath.getLastPathComponent match {
+        case node: DseResultTreeNode#ResultSetNode =>
+          if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 1) { // single click, highlight in chart
+            plot.setSelection(Seq(node.setMembers))
+          }
         case node: DseResultTreeNode#ResultNode =>
           if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) { // double click
             val result = node.result

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -15,7 +15,7 @@ import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, Exc
 import edg_ide.util.{exceptable, requireExcept}
 
 import java.awt.event.{ItemEvent, ItemListener, MouseAdapter, MouseEvent}
-import java.awt.{GridBagConstraints, GridBagLayout}
+import java.awt.{Color, GridBagConstraints, GridBagLayout}
 import java.util.concurrent.TimeUnit
 import javax.swing.{JPanel, JPopupMenu, SwingUtilities}
 import scala.collection.SeqMap
@@ -125,7 +125,13 @@ class DsePlotPanel() extends JPanel {
     val points = combinedResults.groupedResults.flatMap { resultSet =>
       val exampleResult = resultSet.head
       (xSelector.getItem.resultToValue(exampleResult), ySelector.getItem.resultToValue(exampleResult)) match {
-        case (Some(xVal), Some(yVal)) => Some(new plot.Data(resultSet, xVal, yVal))
+        case (Some(xVal), Some(yVal)) =>
+          val color = if (exampleResult.errors.nonEmpty) {
+            Some(com.intellij.ui.JBColor.RED)
+          } else {
+            None
+          }
+          Some(new plot.Data(resultSet, xVal, yVal, color))
         case _ => None
       }
     }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -87,8 +87,9 @@ class DsePlotPanel() extends JPanel {
   ySelector.addItem(new DummyAxisItem("Y Axis"))
   add(ySelector, Gbc(1, 1, GridBagConstraints.HORIZONTAL))
 
-  def setResults(combinedResults: CombinedDseResultSet, objectiveNames: Seq[String]): Unit = {
-
+  def setResults(combinedResults: CombinedDseResultSet, objectives: SeqMap[String, DseObjective[Any]]): Unit = {
+    val selectedX = xSelector.getItem
+    val selectedY = ySelector.getItem
   }
 }
 
@@ -202,10 +203,11 @@ class DsePanel(project: Project) extends JPanel {
     }
   }
 
-  def setResults(results: Seq[DseResult], objectiveNames: Seq[String], inProgress: Boolean): Unit = {
+  def setResults(results: Seq[DseResult], objectives: SeqMap[String, DseObjective[Any]], inProgress: Boolean): Unit = {
     val combinedResults = new CombinedDseResultSet(results)
-    TreeTableUtils.updateModel(resultsTree, new DseResultTreeTableModel(combinedResults, objectiveNames, inProgress))
-    plot.setResults(combinedResults, objectiveNames)
+    TreeTableUtils.updateModel(resultsTree,
+      new DseResultTreeTableModel(combinedResults, objectives.keys.toSeq, inProgress))
+    plot.setResults(combinedResults, objectives)
   }
 
   // Configuration State

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -73,11 +73,11 @@ class DsePlotPanel() extends JPanel {
 
   private val plot = new JScatterPlot[Seq[DseResult]]() {
     override def onClick(data: Seq[Data]): Unit = {
-      println(f"click: $data")
+      DsePlotPanel.this.onClick(data.map(_.value))
     }
 
     override def onHoverChange(data: Seq[Data]): Unit = {
-      println(f"hover: $data")
+      DsePlotPanel.this.onHoverChange(data.map(_.value))
     }
   }
   add(plot, Gbc(0, 0, GridBagConstraints.BOTH, 2))
@@ -205,6 +205,17 @@ class DsePlotPanel() extends JPanel {
     this.combinedResults = combinedResults
     updatePlot()
   }
+
+  // User hooks - can be overridden
+  //
+  // called when this widget clicked, for all points within some hover radius of the cursor
+  // sorted by distance from cursor (earlier = closer), and may be empty
+  def onClick(data: Seq[Seq[DseResult]]): Unit = {}
+
+  // called when the hovered-over data changes, for all points within some hover radius of the cursor
+  // may be empty (when hovering over nothing)
+  def onHoverChange(data: Seq[Seq[DseResult]]): Unit = {}
+
 }
 
 
@@ -248,7 +259,14 @@ class DsePanel(project: Project) extends JPanel {
   add(mainSplitter, Gbc(0, 1, GridBagConstraints.BOTH))
 
   // GUI: Top plot
-  private val plot = new DsePlotPanel()
+  private val plot = new DsePlotPanel() {
+    override def onClick(data: Seq[Seq[DseResult]]): Unit = {
+      // TODO set results tree selection
+    }
+    override def onHoverChange(data: Seq[Seq[DseResult]]): Unit = {
+      // TODO something w/ results tree selection?
+    }
+  }
   mainSplitter.setFirstComponent(plot)
 
   // GUI: Bottom tabs

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -105,7 +105,6 @@ class DsePlotPanel() extends JPanel {
   add(ySelector, Gbc(1, 1, GridBagConstraints.HORIZONTAL))
 
   private def updatePlot(): Unit = {
-    println("changed redraw")
     val points = combinedResults.groupedResults.flatMap { resultSet =>
       val exampleResult = resultSet.head
       (xSelector.getItem.resultToValue(exampleResult), ySelector.getItem.resultToValue(exampleResult)) match {

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -70,18 +70,26 @@ class DsePlotPanel() extends JPanel {
   private val plot = new JScatterPlot[String]()
   add(plot, Gbc(0, 0, GridBagConstraints.BOTH, 2))
 
-  class AxisItem(val name: String) {
+  trait AxisItem {
+    def resultToValue(result: DseResult): Option[Float]
+  }
+
+  class DummyAxisItem(val name: String) extends AxisItem {
+    override def resultToValue(result: DseResult): Option[Float] = None
+
     override def toString = name
   }
 
   private val xSelector = new ComboBox[AxisItem]()
-  xSelector.addItem(new AxisItem("X Axis"))
+  xSelector.addItem(new DummyAxisItem("X Axis"))
   add(xSelector, Gbc(0, 1, GridBagConstraints.HORIZONTAL))
   private val ySelector = new ComboBox[AxisItem]()
-  ySelector.addItem(new AxisItem("Y Axis"))
+  ySelector.addItem(new DummyAxisItem("Y Axis"))
   add(ySelector, Gbc(1, 1, GridBagConstraints.HORIZONTAL))
 
-  plot.setData(Seq((0, 0, ""), (0, 0.5f, ""), (0, 1, ""), (-1, 0, ""), (1, 0, "")))
+  def setResults(combinedResults: CombinedDseResultSet, objectiveNames: Seq[String]): Unit = {
+
+  }
 }
 
 
@@ -113,17 +121,6 @@ class DsePanel(project: Project) extends JPanel {
         TreeTableUtils.updateModel(resultsTree,
           new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false))  // clear existing data
     }
-  }
-
-  def onConfigChange(config: DseRunConfiguration): Unit = {
-    if (displayedConfig.contains(config)) {
-      onConfigUpdate()
-    }
-  }
-
-  def setResults(results: Seq[DseResult], objectiveNames: Seq[String], inProgress: Boolean): Unit = {
-    val combinedResults = new CombinedDseResultSet(results)
-    TreeTableUtils.updateModel(resultsTree, new DseResultTreeTableModel(combinedResults, objectiveNames, inProgress))
   }
 
   setLayout(new GridBagLayout())
@@ -197,6 +194,19 @@ class DsePanel(project: Project) extends JPanel {
   tabbedPane.addTab("Results", new JBScrollPane(resultsTree))
 
   onConfigUpdate()  // set initial state
+
+  // Data state update
+  def onConfigChange(config: DseRunConfiguration): Unit = {
+    if (displayedConfig.contains(config)) {
+      onConfigUpdate()
+    }
+  }
+
+  def setResults(results: Seq[DseResult], objectiveNames: Seq[String], inProgress: Boolean): Unit = {
+    val combinedResults = new CombinedDseResultSet(results)
+    TreeTableUtils.updateModel(resultsTree, new DseResultTreeTableModel(combinedResults, objectiveNames, inProgress))
+    plot.setResults(combinedResults, objectiveNames)
+  }
 
   // Configuration State
   //

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -1,6 +1,7 @@
 package edg_ide.ui
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.components.{JBScrollPane, JBTabbedPane}
 import com.intellij.ui.dsl.builder.impl.CollapsibleTitledSeparator
@@ -16,7 +17,7 @@ import edg_ide.util.{exceptable, requireExcept}
 import java.awt.event.{MouseAdapter, MouseEvent}
 import java.awt.{GridBagConstraints, GridBagLayout}
 import java.util.concurrent.TimeUnit
-import javax.swing.{JPanel, JPopupMenu, SwingUtilities}
+import javax.swing.{JComboBox, JPanel, JPopupMenu, SwingUtilities}
 import scala.collection.SeqMap
 
 
@@ -60,6 +61,27 @@ class DseObjectivePopupMenu(objective: DseObjective[Any], project: Project) exte
       BlockVisualizerService(project).onDseConfigChanged(dseConfig)
     }
   }, s"Delete"))
+}
+
+
+class DsePlotPanel() extends JPanel {
+  setLayout(new GridBagLayout)
+
+  private val plot = new JScatterPlot[String]()
+  add(plot, Gbc(0, 0, GridBagConstraints.BOTH, 2))
+
+  class AxisItem(val name: String) {
+    override def toString = name
+  }
+
+  private val xSelector = new ComboBox[AxisItem]()
+  xSelector.addItem(new AxisItem("X Axis"))
+  add(xSelector, Gbc(0, 1, GridBagConstraints.HORIZONTAL))
+  private val ySelector = new ComboBox[AxisItem]()
+  ySelector.addItem(new AxisItem("Y Axis"))
+  add(ySelector, Gbc(1, 1, GridBagConstraints.HORIZONTAL))
+
+  plot.setData(Seq((0, 0, ""), (0, 0.5f, ""), (0, 1, ""), (-1, 0, ""), (1, 0, "")))
 }
 
 
@@ -109,7 +131,7 @@ class DsePanel(project: Project) extends JPanel {
   add(mainSplitter, Gbc(0, 1, GridBagConstraints.BOTH))
 
   // GUI: Top plot
-  private val plot = new JScatterPlot[String]()
+  private val plot = new DsePlotPanel()
   mainSplitter.setFirstComponent(plot)
 
   // GUI: Bottom tabs

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -140,7 +140,7 @@ class DsePlotPanel() extends JPanel {
           } else {
             None
           }
-          Some(new plot.Data(resultSet, xVal, yVal, color))
+          Some(new plot.Data(resultSet, xVal, yVal, color, Some(f"${resultSet.size} results")))
         case _ => None
       }
     }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -17,9 +17,8 @@ import edg_ide.util.{exceptable, requireExcept}
 import java.awt.event.{ItemEvent, ItemListener, MouseAdapter, MouseEvent}
 import java.awt.{GridBagConstraints, GridBagLayout}
 import java.util.concurrent.TimeUnit
-import javax.swing.{JComboBox, JPanel, JPopupMenu, SwingUtilities}
+import javax.swing.{JPanel, JPopupMenu, SwingUtilities}
 import scala.collection.SeqMap
-import scala.reflect.runtime.universe.typeOf
 
 
 class DseSearchConfigPopupMenu(searchConfig: DseConfigElement, project: Project) extends JPopupMenu {
@@ -126,7 +125,7 @@ class DsePlotPanel() extends JPanel {
     val points = combinedResults.groupedResults.flatMap { resultSet =>
       val exampleResult = resultSet.head
       (xSelector.getItem.resultToValue(exampleResult), ySelector.getItem.resultToValue(exampleResult)) match {
-        case (Some(xVal), Some(yVal)) => Some((xVal, yVal, resultSet))
+        case (Some(xVal), Some(yVal)) => Some(new plot.Data(resultSet, xVal, yVal))
         case _ => None
       }
     }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -294,11 +294,7 @@ class DsePanel(project: Project) extends JPanel {
   configTree.setRootVisible(false)
   configTree.addMouseListener(new MouseAdapter {
     override def mouseClicked(e: MouseEvent): Unit = {
-      val selectedTreePath = configTree.getTree.getPathForLocation(e.getX, e.getY)
-      if (selectedTreePath == null) {
-        return
-      }
-
+      val selectedTreePath = TreeTableUtils.getPathForRowLocation(configTree, e.getX, e.getY).getOrElse(return)
       selectedTreePath.getLastPathComponent match {
         case node: DseConfigTreeNode.DseSearchConfigNode =>
           if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) {
@@ -321,11 +317,7 @@ class DsePanel(project: Project) extends JPanel {
   resultsTree.setRootVisible(false)
   resultsTree.addMouseListener(new MouseAdapter {
     override def mouseClicked(e: MouseEvent): Unit = {
-      val selectedTreePath = resultsTree.getTree.getPathForLocation(e.getX, e.getY)
-      if (selectedTreePath == null) {
-        return
-      }
-
+      val selectedTreePath = TreeTableUtils.getPathForRowLocation(resultsTree, e.getX, e.getY).getOrElse(return)
       selectedTreePath.getLastPathComponent match {
         case node: DseResultTreeNode#ResultSetNode =>
           if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 1) { // single click, highlight in chart

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -15,7 +15,8 @@ class EdgSettingsComponent {
     "Choose KiCad Footprint Directory", "", null,
     FileChooserDescriptorFactory.createSingleFolderDescriptor()
   )
-  val kicadDirectoryHelp = new JBLabel("IDE restart may be required to take effect.")
+  val kicadDirectoryHelp = new JBLabel("Multiple footprint directories can be separated by semicolons (;). " +
+      "IDE restart may be required to take effect.")
   kicadDirectoryHelp.setEnabled(false)
   val persistBlockCache = new JCheckBox()
   val persistBlockCacheHelp = new JBLabel("Not recommended. "
@@ -43,8 +44,8 @@ class EdgSettingsConfigurable extends Configurable {
 
   override def isModified: Boolean = {
     val settings = EdgSettingsState.getInstance()
-    settings.kicadDirectories.sameElements(component.kicadDirectoryText.getText.split(";"))
-    settings.persistBlockCache != component.persistBlockCache.isSelected
+    !settings.kicadDirectories.sameElements(component.kicadDirectoryText.getText.split(";")) ||
+        settings.persistBlockCache != component.persistBlockCache.isSelected
   }
 
   override def apply(): Unit = {

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -43,19 +43,19 @@ class EdgSettingsConfigurable extends Configurable {
 
   override def isModified: Boolean = {
     val settings = EdgSettingsState.getInstance()
-    settings.kicadDirectory != component.kicadDirectoryText.getText
+    settings.kicadDirectories.sameElements(component.kicadDirectoryText.getText.split(";"))
     settings.persistBlockCache != component.persistBlockCache.isSelected
   }
 
   override def apply(): Unit = {
     val settings = EdgSettingsState.getInstance()
-    settings.kicadDirectory = component.kicadDirectoryText.getText
+    settings.kicadDirectories = component.kicadDirectoryText.getText.split(";")
     settings.persistBlockCache = component.persistBlockCache.isSelected
   }
 
   override def reset(): Unit = {
     val settings = EdgSettingsState.getInstance()
-    component.kicadDirectoryText.setText(settings.kicadDirectory)
+    component.kicadDirectoryText.setText(settings.kicadDirectories.mkString(";"))
     component.persistBlockCache.setSelected(settings.persistBlockCache)
   }
 }

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -52,7 +52,7 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
     private val treeScrollPane = new JScrollPane(tree)
 
     // initialize the contents on startup
-    setLibraryDirectories(EdgSettingsState.getInstance().kicadDirectories)
+    setLibraryDirectories(EdgSettingsState.getInstance().kicadDirectories.toSeq)
 
     def setLibraryDirectories(directories: Seq[String]): Unit = {
       libraryDirectories = directories.map(new File(_))

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -1,6 +1,6 @@
 package edg_ide.ui
 
-import com.intellij.notification.{NotificationGroup, NotificationType}
+import com.intellij.notification.NotificationGroup
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.ui.JBSplitter
@@ -14,7 +14,7 @@ import edg_ide.EdgirUtils
 import edg_ide.psi_edits.{InsertAction, InsertFootprintAction, InsertPinningAction}
 import edg_ide.swing._
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption, ExceptSeq}
-import edg_ide.util.{DesignAnalysisUtils, KicadFootprintUtil, exceptable, exceptionPopup, requireExcept}
+import edg_ide.util._
 import edgir.common.common
 import edgir.elem.elem
 import edgir.expr.expr
@@ -71,9 +71,12 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
 
     tree.addMouseListener(new MouseListener {
       override def mouseClicked(mouseEvent: MouseEvent): Unit = {
-//        val node:FootprintBrowserNode = tree.getTree.getSelectionPath.getLastPathComponent.asInstanceOf[FootprintBrowserNode]
-        if (mouseEvent.getClickCount == 1) {
-          // single click opens the footprint for preview
+        val node = tree.getTree.getSelectionPath.getLastPathComponent match {
+          case node: FootprintBrowserNode => node
+          case _ => return
+        }
+
+        if (mouseEvent.getClickCount == 1) {  // single click opens the footprint for preview
           footprintSynced = false
           visualizer.pinmap = Map()
 
@@ -89,8 +92,7 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
               status.setText(SwingHtmlUtil.wrapInHtml(s"Invalid file: ${node.file.getName}",
                 KicadVizPanel.this.getFont))
           }
-        } else if (mouseEvent.getClickCount == 2) {
-          // double click assigns the footprint to the opened block
+        } else if (mouseEvent.getClickCount == 2) {  // double click assigns the footprint to the opened block
           exceptionPopup(mouseEvent) {
             val footprint = pathToFootprintName(node.file).exceptNone(s"invalid file ${node.file.getName}")
             (insertBlockFootprint(footprint).exceptError)()

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -41,7 +41,7 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
     // TODO flatten out into parent? Or make this its own class with meaningful interfaces / abstractions?
     // TODO use GridBagLayout?
 
-    private var libraryDirectories: Seq[File] = Seq()  // TODO should be private / protected, but is in an object :s
+    private var libraryDirectories: Seq[File] = Seq()
 
     // use something invalid so it doesn't try to index a real directory
     val invalidModel = new FilteredTreeTableModel(new FootprintBrowserTreeTableModel(Seq()))

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -52,9 +52,9 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
     private val treeScrollPane = new JScrollPane(tree)
 
     // initialize the contents on startup
-    setLibraryDirectory(EdgSettingsState.getInstance().kicadDirectory)
+    setLibraryDirectories(EdgSettingsState.getInstance().kicadDirectories)
 
-    def setLibraryDirectory(directory: String): Unit = {
+    def setLibraryDirectories(directories: Seq[String]): Unit = {
       // TODO use File instead of String
       val directoryFile = new File(directory)
       if (directoryFile.exists()) {

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -71,7 +71,7 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
 
     tree.addMouseListener(new MouseListener {
       override def mouseClicked(mouseEvent: MouseEvent): Unit = {
-        val node:FootprintBrowserNode = tree.getTree.getSelectionPath.getLastPathComponent.asInstanceOf[FootprintBrowserNode]
+//        val node:FootprintBrowserNode = tree.getTree.getSelectionPath.getLastPathComponent.asInstanceOf[FootprintBrowserNode]
         if (mouseEvent.getClickCount == 1) {
           // single click opens the footprint for preview
           footprintSynced = false

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -490,11 +490,7 @@ class LibraryPanel(project: Project) extends JPanel {
 
   private val libraryMouseListener = new MouseAdapter {
     override def mousePressed(e: MouseEvent): Unit = {
-      val selectedTreePath = libraryTree.getTree.getPathForLocation(e.getX, e.getY)
-      if (selectedTreePath == null) {
-        return
-      }
-
+      val selectedTreePath = TreeTableUtils.getPathForRowLocation(libraryTree, e.getX, e.getY).getOrElse(return)
       selectedTreePath.getLastPathComponent match {
         case selected: EdgirLibraryTreeNode.BlockNode => // insert actions / menu for blocks
           if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) {

--- a/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
@@ -9,7 +9,7 @@ import edg.wir.{BlockConnectivityAnalysis, Connection, DesignPath, LibraryConnec
 import edg_ide.psi_edits.{InsertAction, InsertBlockAction, InsertConnectAction}
 import edg_ide.ui._
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption, ExceptSeq}
-import edg_ide.util.{ExceptionNotifyException, exceptable, exceptionNotify, exceptionPopup}
+import edg_ide.util.{exceptable, exceptionNotify, exceptionPopup}
 import edg_ide.{EdgirUtils, PsiUtils}
 import edgir.elem.elem
 import edgir.expr.expr
@@ -28,7 +28,7 @@ object ConnectTool {
     case port: elem.Port => port.getSelfClass
     case port: elem.Bundle => port.getSelfClass
     case array: elem.PortArray => array.getSelfClass
-    case isOther => throw ExceptionNotifyException(s"unexpected port ${isOther.getClass}")
+    case isOther => exceptable.fail(s"unexpected port ${isOther.getClass}")
   }}
 
   /** External interface for creating a ConnectTool, which does the needed analysis work and can return an error
@@ -117,7 +117,7 @@ class ConnectPopup(interface: ToolInterface, action: ConnectToolAction,
     } else if (postfix.steps.size == 1) {
       ("", postfix.steps.last.getName)
     } else {
-      throw ExceptionNotifyException(s"invalid postfix to $path")
+      exceptable.fail(s"invalid postfix to $path")
     }
   }
 

--- a/src/main/scala/edg_ide/util/ExceptionNotify.scala
+++ b/src/main/scala/edg_ide/util/ExceptionNotify.scala
@@ -24,6 +24,10 @@ object exceptable {
       case ExceptionNotifyException(errMsg) => Errorable.Error(errMsg)
     }
   }
+
+  def fail(errMsg: String): Nothing = {
+    throw ExceptionNotifyException(errMsg)
+  }
 }
 
 

--- a/src/main/scala/edg_ide/util/ExceptionNotify.scala
+++ b/src/main/scala/edg_ide/util/ExceptionNotify.scala
@@ -10,7 +10,7 @@ import java.awt.event.MouseEvent
 import scala.reflect.ClassTag
 
 
-case class ExceptionNotifyException(errMsg: String) extends Exception(errMsg)
+class ExceptionNotifyException(val errMsg: String) extends Exception(errMsg)
 
 
 object exceptable {
@@ -21,12 +21,12 @@ object exceptable {
     try {
       Errorable.Success(fn)
     } catch {
-      case ExceptionNotifyException(errMsg) => Errorable.Error(errMsg)
+      case e: ExceptionNotifyException => Errorable.Error(e.errMsg)
     }
   }
 
   def fail(errMsg: String): Nothing = {
-    throw ExceptionNotifyException(errMsg)
+    throw new ExceptionNotifyException(errMsg)
   }
 }
 
@@ -77,7 +77,7 @@ object exceptionPopup {
 object requireExcept {
   def apply(cond: Boolean, errMsg: => String): Unit = {
     if (!cond) {
-      throw ExceptionNotifyException(errMsg)
+      exceptable.fail(errMsg)
     }
   }
 }
@@ -91,51 +91,51 @@ object ExceptionNotifyImplicits {
       if (obj != null) {
         obj
       } else {
-        throw ExceptionNotifyException(errMsg)
+        exceptable.fail(errMsg)
       }
     }
 
     def instanceOfExcept[V](errMsg: => String)(implicit tag: ClassTag[V]): V = obj match {
         // Need the implicit tag so this generates a proper runtime check
       case obj: V => obj
-      case _ => throw ExceptionNotifyException(errMsg)
+      case _ => exceptable.fail(errMsg)
     }
   }
 
   implicit class ExceptOption[T](obj: Option[T]) {
     def exceptNone(errMsg: => String): T = obj match {
       case Some(obj) => obj
-      case None => throw ExceptionNotifyException(errMsg)
+      case None => exceptable.fail(errMsg)
     }
   }
 
   implicit class ExceptSeq[T](obj: Seq[T]) {
     def exceptEmpty(errMsg: => String): Seq[T] = obj match {
-      case Seq() => throw ExceptionNotifyException(errMsg)
+      case Seq() => exceptable.fail(errMsg)
       case _ => obj
     }
     def onlyExcept(errMsg: => String): T = obj match {
       case Seq(obj) => obj
-      case _ => throw ExceptionNotifyException(errMsg)
+      case _ => exceptable.fail(errMsg)
     }
   }
 
   implicit class ExceptErrorable[T](obj: Errorable[T]) {
     def exceptError: T = obj match {
       case Errorable.Success(obj) => obj
-      case Errorable.Error(msg) => throw ExceptionNotifyException(msg)
+      case Errorable.Error(msg) => exceptable.fail(msg)
     }
   }
 
   implicit class ExceptBoolean(obj: Boolean) {
     def exceptTrue(errMsg: => String): Boolean = obj match {
-      case true => throw ExceptionNotifyException(errMsg)
+      case true => exceptable.fail(errMsg)
       case false => obj
     }
 
     def exceptFalse(errMsg: => String): Boolean = obj match {
       case true => obj
-      case false => throw ExceptionNotifyException(errMsg)
+      case false => exceptable.fail(errMsg)
     }
   }
 }

--- a/src/main/scala/edg_ide/util/KicadFootprintUtil.scala
+++ b/src/main/scala/edg_ide/util/KicadFootprintUtil.scala
@@ -1,0 +1,51 @@
+package edg_ide.util
+
+import edg.util.Errorable
+import edg_ide.ui.EdgSettingsState
+
+import java.io.File
+import scala.annotation.tailrec
+import scala.util.control.Breaks
+
+
+object KicadFootprintUtil {
+  @tailrec
+  private def filePathJoin(base: File, join: Seq[String]): Option[File] = {
+    join match {
+      case Seq() => Some(base)
+      case Seq(init, tail@_*) =>
+        val nextFile = new File(base, init)
+        if (nextFile.exists()) {
+          filePathJoin(nextFile, tail)
+        } else {
+          None
+        }
+    }
+  }
+
+  // returns the footprint file for a given footprint name (structured as eg, Device_R:R_0603) if it can be found
+  def getFootprintFile(footprintName: String): Errorable[File] = exceptable {
+    val Seq(library, footprint) = footprintName.split(':') match {
+      case x@Array(library, footprint) => x.toSeq
+      case _ => throw ExceptionNotifyException(s"malformed footprint path $footprintName")
+    }
+    val footprintPath = Seq(library + ".pretty", footprint + ".kicad_mod")
+
+    // use a for loop to return the first match, instead of mapping over everything else
+    var footprintFile: Option[File] = None
+    val loop = new Breaks
+    loop.breakable {
+      EdgSettingsState.getInstance().kicadDirectories.foreach { kicadDirectory =>
+        filePathJoin(new File(kicadDirectory), footprintPath) match {
+          case Some(joinedFile) => footprintFile = Some(joinedFile); loop.break()
+          case None => // continue
+        }
+      }
+    }
+
+    footprintFile match {
+      case Some(footprintFile) => footprintFile
+      case None => throw ExceptionNotifyException(s"unable to find footprint file for $footprintName")
+    }
+  }
+}

--- a/src/main/scala/edg_ide/util/KicadFootprintUtil.scala
+++ b/src/main/scala/edg_ide/util/KicadFootprintUtil.scala
@@ -25,11 +25,10 @@ object KicadFootprintUtil {
 
   // returns the footprint file for a given footprint name (structured as eg, Device_R:R_0603) if it can be found
   def getFootprintFile(footprintName: String): Errorable[File] = exceptable {
-    val Seq(library, footprint) = footprintName.split(':') match {
-      case x@Array(library, footprint) => x.toSeq
+    val footprintPath = footprintName match {
+      case s"$libraryName:$footprintName" => Seq(f"$libraryName.pretty", f"$footprintName.kicad_mod")
       case _ => throw ExceptionNotifyException(s"malformed footprint path $footprintName")
     }
-    val footprintPath = Seq(library + ".pretty", footprint + ".kicad_mod")
 
     // use a for loop to return the first match, instead of mapping over everything else
     var footprintFile: Option[File] = None

--- a/src/main/scala/edg_ide/util/KicadFootprintUtil.scala
+++ b/src/main/scala/edg_ide/util/KicadFootprintUtil.scala
@@ -27,7 +27,7 @@ object KicadFootprintUtil {
   def getFootprintFile(footprintName: String): Errorable[File] = exceptable {
     val footprintPath = footprintName match {
       case s"$libraryName:$footprintName" => Seq(f"$libraryName.pretty", f"$footprintName.kicad_mod")
-      case _ => throw ExceptionNotifyException(s"malformed footprint path $footprintName")
+      case _ => exceptable.fail(s"malformed footprint path $footprintName")
     }
 
     // use a for loop to return the first match, instead of mapping over everything else
@@ -44,7 +44,7 @@ object KicadFootprintUtil {
 
     footprintFile match {
       case Some(footprintFile) => footprintFile
-      case None => throw ExceptionNotifyException(s"unable to find footprint file for $footprintName")
+      case None => exceptable.fail(s"unable to find footprint file for $footprintName")
     }
   }
 }


### PR DESCRIPTION
DSE is a work-in-progress feature and not enabled by default.

Adds plotting for DSE results, to visualize design points on a x-y plot with selectable axes from objective functions.
- Restructure the DseObjective type hierarchy: the base one is now untyped and calculate Any, while the subtype DseTypedObjective is type-parameterized on the calculate value
- Add typed DseObjectives for parameters - ends up being a lot of boilerplate code
- Create CombinedDseResultSet, that does aggregating of similar results while preserving order (of first result in each set, and results within sets - prior, .groupBy does not preserve order)
- setDseResults now takes in the objective set
- Create scatterplot Swing widget, that takes in X, Y, value, and optionally color and tooltip text, and supports onClick and onHoverChange.
  - Supports zooming in/out by mousewheel
  - Automatic selection of axis ticks based on level of zoom
  - Hovered over points automatically marked
  - Add concept of Axis that determines how data is mapped to a coordinate
  - Includes Axis selector combo-box for user to select mapping of data to axes
  - Including selection linking between plot <-> results table

Other changes:
- For all TreeTables, clicks anywhere in the row are treated as a click, compared to the prior behavior (getPathForLocation) which requires a click on the tree text entry. This is supported through infrastructural function TreeTableUtils.getPathForRowLocation
- Support multiple KiCad directories for footprint libraries - this breaks existing configs
  - Refactors the footprint browser support this, that flattens the library containing directories into one list much like KiCad's footprint editor behavior
- Support some rotations in KiCad footprint files
- Create infrastructural PicadParser.parseKicadFile that encapsulates KiCad library directory settings
- Use exceptable.fail instead of throw ExceptionNotifyException
- Refactor blendColor into ColorUtil.blendColor