### PR TITLE
DSE: Cleaning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,10 @@ lazy val root = (project in file("."))
         xml.sinceBuild        = (ThisBuild / intellijBuild).value
         xml.untilBuild        = "221.*"
       },
+      intellijVMOptions := intellijVMOptions.value.copy(
+        xmx = 4096,
+        xms = 1024
+      ),
     ).enablePlugins(BuildInfoPlugin)
     .settings(
       buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),

--- a/src/main/scala/edg_ide/dse/DseConfigElement.scala
+++ b/src/main/scala/edg_ide/dse/DseConfigElement.scala
@@ -4,6 +4,7 @@ import edg.EdgirUtils.SimpleLibraryPath
 import edg.compiler.{ArrayValue, BooleanValue, Compiler, ExprValue, FloatValue, IntValue, PartialCompile, RangeValue, TextValue}
 import edg.util.Errorable
 import edg.wir.{DesignPath, Refinements}
+import edg_ide.ui.ParamToUnitsStringUtil
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptBoolean, ExceptErrorable, ExceptOption, ExceptSeq}
 import edg_ide.util.IterableExtensions.IterableExtension
 import edg_ide.util.{exceptable, requireExcept}
@@ -15,7 +16,7 @@ import scala.collection.{SeqMap, mutable}
 object DseConfigElement {
   def valueToString(value: Any): String = value match {
     case value: ref.LibraryPath => value.toSimpleString
-    case value: ExprValue => value.toStringValue
+    case value: ExprValue => ParamToUnitsStringUtil.toString(value)
     case Some(value) => valueToString(value) // drop the "Some" for simplicity
     case value => value.toString
   }

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -1,5 +1,5 @@
 package edg_ide.dse
-import edg.compiler.{ArrayValue, BooleanValue, Compiler, FloatValue, IntValue, RangeEmpty, RangeValue, TextValue}
+import edg.compiler.{ArrayValue, BooleanValue, Compiler, ExprValue, FloatValue, IntValue, RangeEmpty, RangeValue, TextValue}
 import edg.util.Errorable
 import edg.wir.ProtoUtil.ParamProtoToSeqMap
 import edg.wir.{DesignPath, IndirectDesignPath}
@@ -30,66 +30,12 @@ sealed abstract class DseTypedObjective[T] extends DseObjective { self: Serializ
 
 
 // Abstract base class for parameter values
-sealed abstract class DseObjectiveParameter[T] extends DseTypedObjective[Option[T]] with Serializable
+case class DseObjectiveParameter(path: IndirectDesignPath, val exprType: Class[_ <: ExprValue])
+    extends DseTypedObjective[Option[ExprValue]] { self: Serializable =>
+  override def objectiveToString = f"Parameter($path)"
 
-
-case class DseFloatParameter(path: IndirectDesignPath) extends DseObjectiveParameter[Float] {
-  override def objectiveToString = f"FloatParameter($path)"
-
-  override def calculate(design: Design, compiler: Compiler): Option[Float] = {
-    compiler.getParamValue(path) match {
-      case Some(FloatValue(value)) => Some(value)
-      case _ => None
-    }
-  }
-}
-
-
-case class DseIntParameter(path: IndirectDesignPath) extends DseObjectiveParameter[BigInt] {
-  override def objectiveToString = f"IntParameter($path)"
-
-  override def calculate(design: Design, compiler: Compiler): Option[BigInt] = {
-    compiler.getParamValue(path) match {
-      case Some(IntValue(value)) => Some(value)
-      case _ => None
-    }
-  }
-}
-
-
-case class DseRangeParameter(path: IndirectDesignPath) extends DseObjectiveParameter[(Float, Float)] {
-  // TODO support empty range case
-  override def objectiveToString = f"RangeParameter($path)"
-
-  override def calculate(design: Design, compiler: Compiler): Option[(Float, Float)] = {
-    compiler.getParamValue(path) match {
-      case Some(RangeValue(minValue, maxValue)) => Some((minValue, maxValue))
-      case _ => None
-    }
-  }
-}
-
-
-case class DseBooleanParameter(path: IndirectDesignPath) extends DseObjectiveParameter[Boolean] {
-  override def objectiveToString = f"BooleanParameter($path)"
-
-  override def calculate(design: Design, compiler: Compiler): Option[Boolean] = {
-    compiler.getParamValue(path) match {
-      case Some(BooleanValue(value)) => Some(value)
-      case _ => None
-    }
-  }
-}
-
-
-case class DseStringParameter(path: IndirectDesignPath) extends DseObjectiveParameter[String] {
-  override def objectiveToString = f"StringParameter($path)"
-
-  override def calculate(design: Design, compiler: Compiler): Option[String] = {
-    compiler.getParamValue(path) match {
-      case Some(TextValue(value)) => Some(value)
-      case _ => None
-    }
+  override def calculate(design: Design, compiler: Compiler): Option[ExprValue] = {
+    compiler.getParamValue(path)
   }
 }
 

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -68,11 +68,11 @@ class DseCsvWriter(writer: java.io.Writer, csv: CsvWriter, searchConfigs: Seq[Ds
 
   def writeRow(result: DseResult): Unit = {
     val headerCols = Seq(result.index.toString, result.errors.length.toString)
-    val searchValueCols = searchConfigs.map {
-      config => DseConfigElement.valueToString(result.config(config))
+    val searchValueCols = searchConfigs.map { config =>
+      result.config.get(config).map(DseConfigElement.valueToString).getOrElse("")
     }
     val objectiveValueCols = objectiveNames.map { name =>
-      DseConfigElement.valueToString(result.objectives(name))
+      result.objectives.get(name).map(DseConfigElement.valueToString).getOrElse("")
     }
 
     csv.writeRow((headerCols ++ searchValueCols ++ objectiveValueCols).asJava)

--- a/src/main/scala/edg_ide/swing/ExprVarToValue.scala
+++ b/src/main/scala/edg_ide/swing/ExprVarToValue.scala
@@ -10,7 +10,9 @@ object ExprVarToValue {
 
 class ExprVarToValue(compiler: Compiler, designPath: DesignPath) extends ExprToString() {
   override def mapRef(path: ref.LocalPath): String = {
-    val value = ParamToUnitsStringUtil.paramToUnitsString((designPath ++ path).asIndirect, "", compiler)
+    val value = compiler.getParamValue((designPath ++ path).asIndirect)
+        .map(ParamToUnitsStringUtil.toString)
+        .getOrElse("unknown")
     s"${(designPath ++ path).asIndirect} = ${value}"
   }
 }

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -485,11 +485,13 @@ class DesignToolTipTextMap(compiler: Compiler) extends DesignMap[Unit, Unit, Uni
     textMap.put(path, s"<b>$classString</b> at $path")
   }
 
-  def makeDescriptionString(path: DesignPath, description: Seq[elem.StringDescriptionElement]) = {
+  private def makeDescriptionString(path: DesignPath, description: Seq[elem.StringDescriptionElement]) = {
     description.map {
       _.elementType match {
         case elem.StringDescriptionElement.ElementType.Param(value) =>
-          ParamToUnitsStringUtil.paramToUnitsString(path.asIndirect ++ value.path.get, value.unit, compiler)
+          compiler.getParamValue(path.asIndirect ++ value.path.get)
+              .map(ParamToUnitsStringUtil.paramToUnitsString(_, value.unit))
+              .getOrElse("unknown")
         case elem.StringDescriptionElement.ElementType.Text(value) =>
           value
         case elem.StringDescriptionElement.ElementType.Empty =>

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -5,7 +5,7 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.treeStructure.treetable.TreeTable
 import edg.compiler.{BooleanValue, Compiler, FloatValue, IntValue, RangeType, RangeValue, TextValue}
 import edg.wir.{DesignPath, IndirectDesignPath}
-import edg_ide.dse.{DseBooleanParameter, DseFeature, DseFloatParameter, DseIntParameter, DseObjectiveParameter, DseParameterSearch, DseRangeParameter, DseStringParameter}
+import edg_ide.dse.{DseFeature, DseObjectiveParameter, DseParameterSearch}
 import edg_ide.swing
 import edg_ide.swing.{ElementDetailTreeModel, TreeTableUtils}
 import edg_ide.util.ExceptionNotifyImplicits.ExceptOption
@@ -34,12 +34,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
 
   add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
     val objective = compiler.getParamType(path) match {
-      case Some(q) if q == classOf[FloatValue]  => DseFloatParameter(path)
-      case Some(q) if q == classOf[IntValue]  => DseIntParameter(path)
-      case Some(q) if q == classOf[RangeType]  => DseRangeParameter(path)  // RangeType includes EmptyRange as well
-      case Some(q) if q == classOf[BooleanValue]  => DseBooleanParameter(path)
-      case Some(q) if q == classOf[TextValue]  => DseStringParameter(path)
-      case Some(q) => exceptable.fail(f"unknown parameter type ${q.getSimpleName} at $path")
+      case Some(paramType) => DseObjectiveParameter(path, paramType)
       case _ => exceptable.fail(f"no parameter type at $path")
     }
 

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -282,7 +282,9 @@ class DsePanel(project: Project) extends JPanel {
       val treeRootPath = new TreePath(treeRoot)
       treeRoot.children foreach {
         case node: treeRoot.ResultSetNode if data.contains(node.setMembers) =>
-          resultsTree.addSelectedPath(treeRootPath.pathByAddingChild(node))
+          val nodeTreePath = treeRootPath.pathByAddingChild(node)
+          resultsTree.addSelectedPath(nodeTreePath)
+          resultsTree.scrollRectToVisible(resultsTree.getTree.getPathBounds(nodeTreePath))
         case node =>  // ignored
       }
     }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -141,7 +141,17 @@ class DsePlotPanel() extends JPanel {
           } else {
             None
           }
-          Some(new plot.Data(resultSet, xVal, yVal, color, Some(f"${resultSet.size} results")))
+
+          val objectivesStr = exampleResult.objectives.map { case (objective, value) =>
+            f"$objective=${DseConfigElement.valueToString(value)}"
+          }.mkString("\n")
+          val resultsStr = resultSet.map { result =>
+              DseConfigElement.configMapToString(result.config)
+          }.mkString("\n")
+          val tooltipText = objectivesStr + f"\n\n${resultSet.size} results:\n" + resultsStr
+
+          Some(new plot.Data(resultSet, xVal, yVal, color,
+            Some(SwingHtmlUtil.wrapInHtml(tooltipText, this.getFont))))
         case _ => None
       }
     }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -284,9 +284,11 @@ class DsePanel(project: Project) extends JPanel {
         case node: treeRoot.ResultSetNode if data.contains(node.setMembers) =>
           val nodeTreePath = treeRootPath.pathByAddingChild(node)
           resultsTree.addSelectedPath(nodeTreePath)
+          resultsTree.getTree.expandPath(nodeTreePath)
           resultsTree.scrollRectToVisible(resultsTree.getTree.getPathBounds(nodeTreePath))
         case node =>  // ignored
       }
+      setSelection(data)
     }
 
     override def onHoverChange(data: Seq[Seq[DseResult]]): Unit = {

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -7,7 +7,7 @@ import com.intellij.ui.components.{JBScrollPane, JBTabbedPane}
 import com.intellij.ui.dsl.builder.impl.CollapsibleTitledSeparator
 import com.intellij.ui.treeStructure.treetable.TreeTable
 import com.intellij.util.concurrency.AppExecutorUtil
-import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseFloatParameter, DseIntParameter, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseParameterSearch, DseRangeParameter, DseResult, DseTypedObjective}
+import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseParameterSearch, DseResult}
 import edg_ide.runner.DseRunConfiguration
 import edg_ide.swing._
 import edg_ide.swing.dse.{DseConfigTreeNode, DseConfigTreeTableModel, DseResultTreeNode, DseResultTreeTableModel, JScatterPlot}

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -7,7 +7,8 @@ import com.intellij.ui.components.{JBScrollPane, JBTabbedPane}
 import com.intellij.ui.dsl.builder.impl.CollapsibleTitledSeparator
 import com.intellij.ui.treeStructure.treetable.TreeTable
 import com.intellij.util.concurrency.AppExecutorUtil
-import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseParameterSearch, DseResult}
+import edg.compiler.{ExprValue, FloatValue, IntValue, RangeType, RangeValue}
+import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseObjectiveParameter, DseParameterSearch, DseResult}
 import edg_ide.runner.DseRunConfiguration
 import edg_ide.swing._
 import edg_ide.swing.dse.{DseConfigTreeNode, DseConfigTreeTableModel, DseResultTreeNode, DseResultTreeTableModel, JScatterPlot}
@@ -103,24 +104,15 @@ class DsePlotPanel() extends JPanel {
     }
   }
 
-  class DseObjectiveOptionItem(objective: DseObjective, name: String) extends AxisItem {
+  class DseObjectiveParameterItem(objective: DseObjectiveParameter, name: String,
+                                  map: ExprValue => Option[Float]) extends AxisItem {
     override def toString = name
 
-    override def resultToValue(result: DseResult): Option[Float] = objective.calculate(result.compiled, result.compiler) match {
-      case Some(x: Float) => Some(x)
-      case Some(x: Int) => Some(x.toFloat)
-      case _ => None
+    override def resultToValue(result: DseResult): Option[Float] = {
+      objective.calculate(result.compiled, result.compiler).flatMap(map)
     }
   }
 
-  class DseObjectiveRangeOptionItem(objective: DseObjective, isMax: Boolean, name: String) extends AxisItem {
-    override def toString = name
-
-    override def resultToValue(result: DseResult): Option[Float] = objective.calculate(result.compiled, result.compiler) match {
-      case Some((minVal: Float, maxVal: Float)) => if (isMax) Some(maxVal) else Some(minVal)
-      case _ => None
-    }
-  }
 
   private val xSelector = new ComboBox[AxisItem]()
   private val xAxisHeader = new DummyAxisItem("X Axis")
@@ -169,13 +161,22 @@ class DsePlotPanel() extends JPanel {
     val items = objectives flatMap { case (name, objective) => objective match {
       case objective: DseObjectiveFootprintArea => Seq(new DseObjectiveItem(objective, name))
       case objective: DseObjectiveFootprintCount => Seq(new DseObjectiveItem(objective, name))
-      case objective: DseFloatParameter => Seq(new DseObjectiveOptionItem(objective, name))
-      case objective: DseIntParameter => Seq(new DseObjectiveOptionItem(objective, name))
-      case objective: DseRangeParameter => Seq(
-        new DseObjectiveRangeOptionItem(objective, false, name + " (min)"),
-        new DseObjectiveRangeOptionItem(objective, true, name + " (max)")
+      case objective: DseObjectiveParameter if objective.exprType == classOf[FloatValue] =>
+        Seq(new DseObjectiveParameterItem(objective, name, param => Some(param.asInstanceOf[FloatValue].value)))
+      case objective: DseObjectiveParameter if objective.exprType == classOf[IntValue] =>
+        Seq(new DseObjectiveParameterItem(objective, name, param => Some(param.asInstanceOf[IntValue].toFloat)))
+      case objective: DseObjectiveParameter if objective.exprType == classOf[RangeType] => Seq(
+        new DseObjectiveParameterItem(objective, s"$name (min)", {
+          case RangeValue(lower, upper) => Some(lower)
+          case _ => None
+        }),
+        new DseObjectiveParameterItem(objective, s"$name (max)", {
+          case RangeValue(lower, upper) => Some(upper)
+          case _ => None
+        })
       )
-      // TODO parse parameter vals
+      case objective: DseObjectiveParameter =>
+        Seq(new DummyAxisItem(f"unsupported parameter type ${objective.exprType.getSimpleName} $name"))
       case _ => Seq(new DummyAxisItem(f"unknown $name"))
     }
     }

--- a/src/main/scala/edg_ide/ui/ParamToUnitsStringUtil.scala
+++ b/src/main/scala/edg_ide/ui/ParamToUnitsStringUtil.scala
@@ -1,16 +1,15 @@
 package edg_ide.ui
-import edg.compiler.{Compiler, FloatValue, IntValue, RangeValue}
-import edg.wir.IndirectDesignPath
+import edg.compiler.{ExprValue, FloatValue, IntValue, RangeValue}
 import edg_ide.util.SiPrefixUtil
 
 object ParamToUnitsStringUtil {
   private val TOLERANCE_THRESHOLD = 0.25
 
-  def paramToUnitsString(path: IndirectDesignPath, units: String, compiler: Compiler): String = {
-    compiler.getParamValue(path) match {
-      case Some(FloatValue(value)) => SiPrefixUtil.unitsToString(value, units)
-      case Some(IntValue(value)) => SiPrefixUtil.unitsToString(value.toDouble, units)
-      case Some(RangeValue(minValue, maxValue)) =>
+  def paramToUnitsString(value: ExprValue, units: String): String = {
+    value match {
+      case FloatValue(value) => SiPrefixUtil.unitsToString(value, units)
+      case IntValue(value) => SiPrefixUtil.unitsToString(value.toDouble, units)
+      case RangeValue(minValue, maxValue) =>
         val centerValue = (minValue + maxValue) / 2
         if (centerValue != 0) {
           val tolerance = (centerValue - minValue) / centerValue
@@ -22,8 +21,16 @@ object ParamToUnitsStringUtil {
         } else {
           s"±${SiPrefixUtil.unitsToString(maxValue, units)}"
         }
-      case Some(value) => s"unexpected ${value.getClass}(${value.toStringValue})"
-      case None => "unknown"
+      case value => s"unexpected ${value.getClass}(${value.toStringValue})"
+    }
+  }
+
+  def toString(value: ExprValue): String = {
+    value match {
+      case FloatValue(_) => paramToUnitsString(value, "")
+      case IntValue(_) => paramToUnitsString(value, "")
+      case RangeValue(_, _) => paramToUnitsString(value, "")
+      case _ => value.toStringValue
     }
   }
 }

--- a/src/main/scala/edg_ide/util/SiPrefixUtil.scala
+++ b/src/main/scala/edg_ide/util/SiPrefixUtil.scala
@@ -6,6 +6,16 @@ object SiPrefixUtil {
   private val PREFIXES_POW3_HIGH = Seq("k", "M", "G", "T", "P", "E", "Z", "Y")
   private val PREFIXES_POW3_LOW = Seq("m", "μ", "n", "p", "f", "a", "z", "y")
 
+  // prepends a space if the string is nonempty
+  // used to add a space between the number and units, except when it's dimensionless (no units) and no SI prefix
+  private def prependSpaceNonempty(str: String): String = {
+    if (str.nonEmpty) {
+      " " + str
+    } else {
+      str
+    }
+  }
+
   def unitsToString(value: Double, units: String): String = {
     if (value.isPosInfinity) {
       s"+∞ $units"
@@ -14,23 +24,20 @@ object SiPrefixUtil {
     } else {
       val roundedValue = BigDecimal(value).round(new MathContext(3)).doubleValue
 
-
       val pwr3 = math.floor(math.log10(math.abs(roundedValue)) / 3).toInt
-      if (pwr3 > PREFIXES_POW3_HIGH.length || pwr3 < PREFIXES_POW3_LOW.length * -1) {
-        // Out of bounds, render as scientific notation
-        f"$roundedValue%.03g $units"
-      } else if (pwr3 == 0) {
-        f"$roundedValue%.03g $units"
+      if (pwr3 > PREFIXES_POW3_HIGH.length || pwr3 < PREFIXES_POW3_LOW.length * -1 || pwr3 == 0) {
+        // Out of bounds or no prefix, render as scientific notation
+        f"$roundedValue%.03g${prependSpaceNonempty(units)}"
       } else if (pwr3 > 0) {
         // positive power (value >= 1)
         val prefix = PREFIXES_POW3_HIGH(pwr3 - 1)
         val valuePrefixed = roundedValue / math.pow(10, 3 * pwr3)
-        f"$valuePrefixed%.03g $prefix$units"
+        f"$valuePrefixed%.03g${prependSpaceNonempty(prefix + units)}"
       } else {
         // negative power (value < 1)
         val prefix = PREFIXES_POW3_LOW(-pwr3 - 1)
         val valuePrefixed = roundedValue / math.pow(10, 3 * pwr3)
-        f"$valuePrefixed%.03g $prefix$units"
+        f"$valuePrefixed%.03g${prependSpaceNonempty(prefix + units)}"
       }
     }
   }


### PR DESCRIPTION
DSE is a work-in-progress feature and not enabled by default.

Some incremental cleaning and polishing of the DSE feature.
- DSE plot: mouseover now displays data about a point, including objective values and summary of all config points
- DSE plot: on selection also scroll to corresponding result row and expand
- Ups the JVM heap, since large design spaces will cause it to blow past memory limits.
  - In the future this can be optimized by discarding the compiler, just saving solved values.
- Use the new ParamToUnitsStringUtil for rendering values.
- Refactor ParamToUnitsStringUtil, to separate out the numeric-value-units rendering from everything else, so it can be used as a reusable function in other places
  - In the future this (including units) might be better integrated into infrastructure, but that's another refactor for another day
  - Eliminate trailing space when there is neither a SI prefix or units
- Unify DseObjectiveParameter, that now takes the Expr type as an argument and returns a generic ExprValue. Specific unpacking is handled at a higher level.