### PR TITLE
DSE: Support for plotting text values

### DIFF
--- a/src/main/scala/edg_ide/dse/DseResult.scala
+++ b/src/main/scala/edg_ide/dse/DseResult.scala
@@ -28,10 +28,10 @@ case class DseResult(
 class CombinedDseResultSet(results: Seq[DseResult]) {
   // groups similar results while preserving the order of groups (based on first-seen order of results)
   private def combineSimilarResults(results: Seq[DseResult]): Seq[Seq[DseResult]] = {
-    type GroupingKey = (Design, Boolean, SeqMap[String, Any])  // only use error count for simplicity
+    type GroupingKey = (Boolean, SeqMap[String, Any])  // group only by objective values and if there were errors
     val groupedMap = mutable.SeqMap[GroupingKey, mutable.ArrayBuffer[DseResult]]()
     results.foreach { result =>
-      val key = (result.compiled, result.errors.nonEmpty, result.objectives)
+      val key = (result.errors.nonEmpty, result.objectives)
       groupedMap.getOrElseUpdate(key, mutable.ArrayBuffer[DseResult]()).append(result)
     }
     groupedMap.map { case (key, vals) =>

--- a/src/main/scala/edg_ide/dse/DseResult.scala
+++ b/src/main/scala/edg_ide/dse/DseResult.scala
@@ -28,10 +28,10 @@ case class DseResult(
 class CombinedDseResultSet(results: Seq[DseResult]) {
   // groups similar results while preserving the order of groups (based on first-seen order of results)
   private def combineSimilarResults(results: Seq[DseResult]): Seq[Seq[DseResult]] = {
-    type GroupingKey = (Design, Int, SeqMap[String, Any])  // only use error count for simplicity
+    type GroupingKey = (Design, Boolean, SeqMap[String, Any])  // only use error count for simplicity
     val groupedMap = mutable.SeqMap[GroupingKey, mutable.ArrayBuffer[DseResult]]()
     results.foreach { result =>
-      val key = (result.compiled, result.errors.length, result.objectives)
+      val key = (result.compiled, result.errors.nonEmpty, result.objectives)
       groupedMap.getOrElseUpdate(key, mutable.ArrayBuffer[DseResult]()).append(result)
     }
     groupedMap.map { case (key, vals) =>

--- a/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
@@ -40,7 +40,7 @@ class DseResultTreeNode(results: CombinedDseResultSet, objectiveNames: Seq[Strin
   class ResultSetNode(val setMembers: Seq[DseResult]) extends DseResultNodeBase {
     private val exampleResult = setMembers.head
     private val errString = if (exampleResult.errors.nonEmpty) {
-      f", ${exampleResult.errors.length} errors"
+      " (with errors)"
     } else {
       ""
     }

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -146,7 +146,6 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
       DrawAnchored.drawLabel(paintGraphics, tickVal,
         (kTickSizePx, screenY), DrawAnchored.Left)
     }
-
   }
 
   private def paintData(paintGraphics: Graphics): Unit = {

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -137,7 +137,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
 
     // left vertical axis
     paintGraphics.drawLine(0, 0, 0, getHeight-1)
-    val yTicks = xAxis match {
+    val yTicks = yAxis match {
       case Some(yAxis) => yAxis
       case _ => getAxisTicks(yRange, getHeight, kMinTickSpacingPx)
     }

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -5,7 +5,13 @@ import edg_ide.swing.{ColorUtil, DrawAnchored}
 import java.awt.event.{MouseAdapter, MouseEvent, MouseMotionAdapter, MouseWheelEvent, MouseWheelListener}
 import java.awt.{Color, Dimension, Graphics, Rectangle}
 import javax.swing.{JComponent, Scrollable}
-import scala.collection.{SeqMap, mutable}
+import scala.collection.mutable
+
+
+object JScatterPlot {
+  type AxisType = Option[Seq[(Float, String)]]
+
+}
 
 
 /** Scatterplot widget with two numerical axes, with labels inside the plot.
@@ -34,8 +40,8 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   private val kTickSizePx = 4
 
   // data state
-  private var xAxis: Option[Seq[(Float, String)]] = None  // if text labels are specified, instead of dynamic numbers
-  private var yAxis: Option[Seq[(Float, String)]] = None
+  private var xAxis: JScatterPlot.AxisType = None  // if text labels are specified, instead of dynamic numbers
+  private var yAxis: JScatterPlot.AxisType = None
 
   private var data: IndexedSeq[Data] = IndexedSeq()
   private var mouseOverIndices: Seq[Int] = Seq()  // sorted by increasing index
@@ -57,7 +63,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   private def dataToScreenX(dataVal: Float): Int = ((dataVal - xRange._1) * dataScale(xRange, getWidth)).toInt
   private def dataToScreenY(dataVal: Float): Int = ((yRange._2 - dataVal) * dataScale(yRange, getHeight)).toInt
 
-  def setData(xys: IndexedSeq[Data]): Unit = {
+  def setData(xys: IndexedSeq[Data], xAxis: JScatterPlot.AxisType = None, yAxis: JScatterPlot.AxisType = None): Unit = {
     data = xys
     mouseOverIndices = Seq()  // clear
     selectedIndices = Seq()  // clear
@@ -76,17 +82,11 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
     val ys = data.map(_.y)
     yRange = expandedRange(((ys :+ 0f).min, (ys :+ 0f).max), kDefaultRangeMarginFactor)
 
+    this.xAxis = xAxis
+    this.yAxis = yAxis
+
     validate()
     repaint()
-  }
-
-  // Sets a custom axis label as a map of location to string values, or use None to use numerical axes
-  def setXAxis(axis: Option[Seq[(Float, String)]]): Unit = {
-    xAxis = axis
-  }
-
-  def setYAxis(axis: Option[Seq[(Float, String)]]): Unit = {
-    yAxis = axis
   }
 
   // Sets the selected data, which is rendered with a highlight.

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -73,6 +73,11 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
     repaint()
   }
 
+  //
+  def setXAxis(axis: Option[]): Unit = {
+
+  }
+
   // Sets the selected data, which is rendered with a highlight.
   // Unlike the other functions, this just takes values for simplicity and does not require X/Y/etc data.
   // Values not in rendered data are ignored.

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -10,7 +10,6 @@ import scala.collection.mutable
 
 object JScatterPlot {
   type AxisType = Option[Seq[(Float, String)]]
-
 }
 
 

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -123,6 +123,24 @@ class DsePlotPanel() extends JPanel {
     }
   }
 
+  class DseObjectiveParameterStringItem(objective: DseObjectiveParameter, name: String) extends AxisItem {
+    override def toString = name
+
+    override def resultsToValuesAxis(results: Seq[DseResult]): (Seq[Option[Float]], JScatterPlot.AxisType) = {
+      val values = results.map { result =>
+        objective.calculate(result.compiled, result.compiler).map(_.toStringValue)
+      }
+      val stringToPos = values.flatten.sorted.zipWithIndex.map { case (str, index) => (str, index.toFloat) }
+      val axis = stringToPos.map { case (str, index) => (index, str) }
+
+      val stringToPosMap = stringToPos.toMap
+      val positionalValues = values.map { value => value.flatMap { value =>
+        stringToPosMap.get(value)
+      } }
+      (positionalValues, Some(axis))
+    }
+  }
+
 
   private val xSelector = new ComboBox[AxisItem]()
   private val xAxisHeader = new DummyAxisItem("X Axis")
@@ -189,7 +207,7 @@ class DsePlotPanel() extends JPanel {
         })
       )
       case objective: DseObjectiveParameter =>
-        Seq(new DummyAxisItem(f"unsupported parameter type ${objective.exprType.getSimpleName} $name"))
+        Seq(new DseObjectiveParameterStringItem(objective, name))
       case _ => Seq(new DummyAxisItem(f"unknown $name"))
     }
     }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -92,7 +92,7 @@ class DsePlotPanel() extends JPanel {
     override def toString = name
 
     override def resultsToValuesAxis(results: Seq[DseResult]): (Seq[Option[Float]], JScatterPlot.AxisType) = {
-      (results.map(_ => None), None)
+      (results.map(_ => Some(0)), Some(Seq()))
     }
   }
 


### PR DESCRIPTION
DSE is a work-in-progress feature and not enabled by default.

Support plotting text in the plotting view, where text is mapped to evenly spaced positions. Internal refactoring to support this:
- Updating data also allows specification of axes, as mapping of positions to strings. If not specified, the dynamic numerical axes are used. If specified, those points are displayed.
- Refactor the axis-selector internal model to map over all the results instead of point-by-point, so that it can also return an axis definition
- Allow plotting non-numeric parameter values as text

Other changes:
- Aggregate points in the results tree-table by objective values only, lumping different designs
- When the span (range of plotted values for any axis) is empty, default to 1 for sizing purposes and to center the points
- When no axis is selected, default the position to zero (instead of none) so at least a linear plot is shown