### PR TITLE
Remove footprint block indicator, update HDL submodule

### DIFF
--- a/src/main/scala/edg_ide/swing/EdgirLibraryTreeRenderer.scala
+++ b/src/main/scala/edg_ide/swing/EdgirLibraryTreeRenderer.scala
@@ -21,8 +21,6 @@ class EdgirLibraryTreeRenderer extends DefaultTreeCellRenderer {
           setIcon(AllIcons.Nodes.Folder)
         } else if (node.traits.contains(EdgirLibraryNodeTraits.Abstract)) {
           setIcon(AllIcons.Hierarchy.Subtypes)
-        } else if (node.traits.contains(EdgirLibraryNodeTraits.Footprint)) {
-          setIcon(PlatformDebuggerImplIcons.MemoryView.Active)
         } else {
           setIcon(null)
         }

--- a/src/main/scala/edg_ide/swing/EdgirLibraryTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/EdgirLibraryTreeTableModel.scala
@@ -18,7 +18,6 @@ sealed trait EdgirLibraryNodeTraits  // categories to pass to the tree renderer 
 object EdgirLibraryNodeTraits {
   object Abstract extends EdgirLibraryNodeTraits
   object Category extends EdgirLibraryNodeTraits
-  object Footprint extends EdgirLibraryNodeTraits
 }
 
 
@@ -61,8 +60,6 @@ class EdgirLibraryNode(project: Project, library: edg.wir.Library) extends Edgir
       Set(
         if (EdgirUtils.isCategory(path)) Some(EdgirLibraryNodeTraits.Category) else None,
         if (block.isAbstract) Some(EdgirLibraryNodeTraits.Abstract) else None,
-        if (allSuperclassesOf(path).contains(EdgirUtils.FootprintBlockType))
-          Some(EdgirLibraryNodeTraits.Footprint) else None,
       ).flatten
     }
 


### PR DESCRIPTION
The categorization change more or less obliviates the need for the footprint block indicator, so clean that out. Also updates the HDL submodule to include the new categorization of blocks.