### PR TITLE
DSE to refinements generator

### DIFF
--- a/src/main/scala/edg_ide/dse/DseConfigElement.scala
+++ b/src/main/scala/edg_ide/dse/DseConfigElement.scala
@@ -54,10 +54,6 @@ sealed trait DseRefinementElement[+ValueType] extends DseStaticConfig { self: Se
   // Given a value form getValues, returns a human readable representation
   // TODO: this should be properly typed, but then ValueType needs to be invariant
   def valueToString(value: Any): String
-
-  // Generates refinement HDL as a map of kwarg -> [([refinement key expr components], refinement value)],
-  // same type signature as InsertRefinementAction
-  def generateRefinementHdl: Map[String, Seq[(Seq[PyExpression], PyExpression)]]
 }
 
 

--- a/src/main/scala/edg_ide/dse/DseConfigElement.scala
+++ b/src/main/scala/edg_ide/dse/DseConfigElement.scala
@@ -1,5 +1,6 @@
 package edg_ide.dse
 
+import com.jetbrains.python.psi.PyExpression
 import edg.EdgirUtils.SimpleLibraryPath
 import edg.compiler.{ArrayValue, BooleanValue, Compiler, ExprValue, FloatValue, IntValue, PartialCompile, RangeValue, TextValue}
 import edg.util.Errorable
@@ -53,6 +54,10 @@ sealed trait DseRefinementElement[+ValueType] extends DseStaticConfig { self: Se
   // Given a value form getValues, returns a human readable representation
   // TODO: this should be properly typed, but then ValueType needs to be invariant
   def valueToString(value: Any): String
+
+  // Generates refinement HDL as a map of kwarg -> [([refinement key expr components], refinement value)],
+  // same type signature as InsertRefinementAction
+  def generateRefinementHdl: Map[String, Seq[(Seq[PyExpression], PyExpression)]]
 }
 
 

--- a/src/main/scala/edg_ide/dse/DseResult.scala
+++ b/src/main/scala/edg_ide/dse/DseResult.scala
@@ -1,6 +1,7 @@
 package edg_ide.dse
 
 import edg.compiler.{Compiler, CompilerError}
+import edg.wir.Refinements
 import edgir.schema.schema.Design
 
 import scala.collection.{SeqMap, mutable}
@@ -10,6 +11,7 @@ import scala.collection.{SeqMap, mutable}
 case class DseResult(
                         index: Int,
                         config: SeqMap[DseConfigElement, Any],
+                        searchRefinements: Refinements,
                         compiler: Compiler,
                         compiled: Design,
                         errors: Seq[CompilerError],

--- a/src/main/scala/edg_ide/dse/DseSearchGenerator.scala
+++ b/src/main/scala/edg_ide/dse/DseSearchGenerator.scala
@@ -11,6 +11,9 @@ import scala.collection.{SeqMap, mutable}
   * based on the value of evaluated points.
   *
   * This is its own class so the design space behavior is unit-testable.
+  *
+  * TODO: perhaps this should take in the root compiler and handle incremental compiler generation,
+  * instead of asking for the compiler back
   */
 class DseSearchGenerator(configs: Seq[DseConfigElement]) {
   val (staticConfigs, derivedConfigs) = configs.partitionMap {

--- a/src/main/scala/edg_ide/dse/DseSearchGenerator.scala
+++ b/src/main/scala/edg_ide/dse/DseSearchGenerator.scala
@@ -11,9 +11,6 @@ import scala.collection.{SeqMap, mutable}
   * based on the value of evaluated points.
   *
   * This is its own class so the design space behavior is unit-testable.
-  *
-  * TODO: perhaps this should take in the root compiler and handle incremental compiler generation,
-  * instead of asking for the compiler back
   */
 class DseSearchGenerator(configs: Seq[DseConfigElement]) {
   val (staticConfigs, derivedConfigs) = configs.partitionMap {

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -9,6 +9,8 @@ import edg.wir.DesignPath
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptSeq}
 import edg_ide.util.exceptable
 
+import scala.collection.SeqMap
+
 
 object InsertRefinementAction {
   val kRefinementsFunctionName = "refinements"
@@ -165,5 +167,21 @@ object InsertRefinementAction {
 
     createInsertRefinement(kKwargClassRefinements, container, keyExpr, valueExpr,
       s"Refine ${refinedClass.getName} to ${refinementClass.getName}", project).exceptError
+  }
+}
+
+
+class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
+  val psiElementGenerator = PyElementGenerator.getInstance(project)
+  val languageLevel = LanguageLevel.forElement(insertIntoClass)
+
+  // Refinements specified as map of kwarg -> [([refinement key expr components], refinement value)]
+  // for example, "instance_refinements" -> [([Expr(AbstractResistor)], Expr(GenericResistor))]
+  // or, "class_values" -> [([Expr(AbstractResistor), Expr(["resistance"])], Expr(1))]
+  // Returns a function that when called, does the insertion and return the newly inserted expressions
+  // Refinements are inserted as one action
+  // Inserts surrounding infrastructure as needed, handling cases where no refinements block or kwarg is present
+  def createInsertRefinements(refinements: SeqMap[String, Seq[(Seq[PyExpression], PyExpression)]]): Errorable[() => Seq[PyExpression]] = {
+
   }
 }

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -81,10 +81,10 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
                 s"(${keyElts.map(_.getText).mkString(", ")}, ${value.getText}),") // note, trailing comma
               // for some reason, PyElementGenerator.getInstance(project).createNewLine inserts two spaces
               val newline = PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText("\n")
-              val inserted = valueList.add(insertTuple).asInstanceOf[PyExpression]
+              val inserted = valueList.add(insertTuple).asInstanceOf[PyTupleExpression]
               // can't do valueList.addBefore, since that does a check for PyExpr, which whitespace is not
               inserted.addBefore(newline, inserted.getFirstChild)
-              Seq(inserted)
+              Seq(inserted.getElements.last)  // for whatever reason the tuple throws an error when navigating to
             }
           }
         }

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -286,4 +286,12 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
       .withName(s"Add refinements to ${insertIntoClass.getName}")
       .compute(insertRefinementsAction)
   }
+
+  // Utility functions for generating refinement exprs
+  //
+  def keyFromPath(path: DesignPath): PyExpression = psiElementGenerator.createExpressionFromText(languageLevel,
+    s"""[${path.steps.map(step => s"'$step'").mkString(", ")}]""")
+
+  def valueFromClass(cls: PyClass): PyExpression = psiElementGenerator.createExpressionFromText(languageLevel,
+    cls.getName)
 }

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -180,14 +180,14 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
   // Inserts the refinement kwarg and value into the target PyArgumentList
   private def insertRefinementKwarg(into: PyArgumentList, kwarg: String,
                                     refinements: Seq[(Seq[PyExpression], PyExpression)]): Seq[PyStatement] = {
-
+    ???
   }
 
   // Creates a function that when called within a writeCommandAction,
   // merges the target refinements into a PyArgumentList
   private def createMergeRefinementKwarg(into: PyArgumentList, kwarg: String,
                                          refinements: Seq[(Seq[PyExpression], PyExpression)]): Errorable[() => Seq[PyStatement]] = exceptable {
-
+    ???
   }
 
   // Refinements specified as map of kwarg -> [([refinement key expr components], refinement value)]
@@ -201,7 +201,7 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
     val refinementsMethod = insertIntoClass.getMethods.find { method =>
       method.getName == InsertRefinementAction.kRefinementsFunctionName
     }
-    val insertRefinementsAction: ThrowableComputable[Seq[PyFunction], Nothing] = refinementsMethod match {
+    val insertRefinementsAction: ThrowableComputable[Seq[PyStatement], Nothing] = refinementsMethod match {
       case Some(refinementsMethod) =>  // append to existing refinements method
         val argList = refinementsMethod.getStatementList.getStatements.toSeq
           .onlyExcept("unexpected multiple statements in refinements()")
@@ -209,11 +209,11 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
           .getExpression.instanceOfExcept[PyBinaryExpression]("unexpected expr in refinements() return")
           .getRightExpression.instanceOfExcept[PyCallExpression]("unexpected expr in refinements() return rhs")
           .getArgumentList
-        val mergeRefinements = refinements.toSeq { case (kwarg, refinements) =>
+        val mergeRefinements = refinements.toSeq.map { case (kwarg, refinements) =>
           createMergeRefinementKwarg(argList, kwarg, refinements).exceptError
         }
         () => {
-          mergeRefinements.flatMap { fn => fn }
+          mergeRefinements.flatMap { fn => fn() }
         }
       case None =>  // insert new refinements method
         () => {

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -182,6 +182,6 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
   // Refinements are inserted as one action
   // Inserts surrounding infrastructure as needed, handling cases where no refinements block or kwarg is present
   def createInsertRefinements(refinements: SeqMap[String, Seq[(Seq[PyExpression], PyExpression)]]): Errorable[() => Seq[PyExpression]] = {
-
+    ???
   }
 }

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -6,13 +6,13 @@ import com.intellij.openapi.util.ThrowableComputable
 import com.intellij.psi.PsiParserFacade
 import com.jetbrains.python.psi._
 import edg.EdgirUtils.SimpleLibraryPath
-import edg.compiler.{ArrayValue, BooleanValue, ExprToString, ExprValue, FloatValue, IntValue, RangeEmpty, RangeValue, TextValue}
+import edg.compiler._
 import edg.util.Errorable
-import edgir.ref.ref
 import edg.wir.{DesignPath, Refinements}
 import edg_ide.psi_edits.InsertRefinementAction.{kKwargClassRefinements, kKwargClassValues, kKwargInstanceRefinements, kKwargInstanceValues}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptSeq}
-import edg_ide.util.{DesignAnalysisUtils, exceptable}
+import edg_ide.util.exceptable
+import edgir.ref.ref
 
 import scala.collection.SeqMap
 

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -15,10 +15,10 @@ import scala.collection.SeqMap
 
 object InsertRefinementAction {
   val kRefinementsFunctionName = "refinements"
-  val kKwargInstanceRefinements = "instance_refinements" // path-based subclass refinement
-  val kKwargInstanceValues = "instance_values" // path-based value refinement
-  val kKwargClassRefinements = "class_refinements" // class-based subclass refinement (refine all classes of X)
-  val kKwargClassValues = "class_values" // class + subpath-based value refinement
+  val kKwargInstanceRefinements = "instance_refinements"  // path-based subclass refinement
+  val kKwargInstanceValues = "instance_values"  // path-based value refinement
+  val kKwargClassRefinements = "class_refinements"  // class-based subclass refinement (refine all classes of X)
+  val kKwargClassValues = "class_values"  // class + subpath-based value refinement
 }
 
 
@@ -73,7 +73,14 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
               Seq(existingRefinementTuple.getElements.last.replace(value).asInstanceOf[PyExpression])
             }
             case None => () => {
-              insertRefinementKwarg(into, kwargName, refinements)
+              val insertTuple = psiElementGenerator.createExpressionFromText(languageLevel,
+                s"(${keyElts.map(_.getText).mkString(", ")}, ${value.getText}),") // note, trailing comma
+              // for some reason, PyElementGenerator.getInstance(project).createNewLine inserts two spaces
+              val newline = PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText("\n")
+              val inserted = valueList.add(insertTuple).asInstanceOf[PyExpression]
+              // can't do valueList.addBefore, since that does a check for PyExpr, which whitespace is not
+              inserted.addBefore(newline, inserted.getFirstChild)
+              Seq(inserted)
             }
           }
         }

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -15,160 +15,10 @@ import scala.collection.SeqMap
 
 object InsertRefinementAction {
   val kRefinementsFunctionName = "refinements"
-  val kKwargInstanceRefinements = "instance_refinements"  // path-based subclass refinement
-  val kKwargInstanceValues = "instance_values"  // path-based value refinement
-  val kKwargClassRefinements = "class_refinements"  // class-based subclass refinement (refine all classes of X)
-  val kKwargClassValues = "class_values"  // class + subpath-based value refinement
-
-  // Inserts the refinement method into the specified class.
-  // Validation (that the function doesn't exist before, and the class has appropriate superclasses)
-  // should be done prior.
-  protected def insertRefinementsMethod(cls: PyClass, project: Project): PyFunction = {
-    val psiElementGenerator = PyElementGenerator.getInstance(project)
-    val languageLevel = LanguageLevel.forElement(cls)
-    val newMethod = psiElementGenerator.createFromText(languageLevel,
-      classOf[PyFunction],
-      s"""def refinements(self) -> Refinements:
-         |  return super().refinements() + Refinements(
-         |    )
-         |""".stripMargin.replace("\r\n", "\n"))  // avoid a "wrong line separator" assert
-    writeCommandAction(project).withName(s"Add refinements method to ${cls.getName}").compute(() => {
-      cls.getStatementList.add(newMethod).asInstanceOf[PyFunction]
-    })
-  }
-
-  // Given an argument list to Refinements(), the refinement type, and key, returns the expression if it exists.
-  protected def findRefinementsExprByKey(list: PyListLiteralExpression,
-                                         key: PyExpression): Option[PyExpression] = {
-    list.getElements.filter {
-      case elt: PyParenthesizedExpression =>
-        elt.getContainedExpression match {
-          case elt: PyTupleExpression =>
-            elt.getElements.headOption match {
-              case Some(head) => head.textMatches(key)
-              case _ => false
-            }
-          case _ => false
-        }
-      case _ => false
-    }.lastOption
-  }
-
-  /** Creates an action that inserts a refinement in the specified class as a key and value (as PSI exprs).
-    * Validation is done before-hand, and will insert the refinements method if none exists.
-    */
-  protected def createInsertRefinement(kwargName: String, cls: PyClass, key: PyExpression, value: PyExpression,
-                                       actionName: String, project: Project): Errorable[() => PyExpression] = exceptable {
-    val psiElementGenerator = PyElementGenerator.getInstance(project)
-    val languageLevel = LanguageLevel.forElement(cls)
-
-    val refinementsMethod = cls.getMethods.find { method =>
-      method.getName == kRefinementsFunctionName
-    }
-
-    // TODO: seriously dedup this across the create new / insert existing paths, perhaps breaking steps into functions
-    refinementsMethod match {
-      case Some(refinementsMethod) =>
-        val argList = refinementsMethod.getStatementList.getStatements.toSeq
-            .onlyExcept("unexpected multiple statements in refinements()")
-            .instanceOfExcept[PyReturnStatement]("unexpected statement in refinements() body")
-            .getExpression.instanceOfExcept[PyBinaryExpression]("unexpected expr in refinements() return")
-            .getRightExpression.instanceOfExcept[PyCallExpression]("unexpected expr in refinements() return rhs")
-            .getArgumentList
-
-        Option(argList.getKeywordArgument(kwargName)) match {
-          case Some(kwarg) =>  // potentially append to keyword arg
-            val valueList = kwarg.getValueExpression.instanceOfExcept[PyListLiteralExpression](s"Refinements kwarg $kwarg not a list")
-            findRefinementsExprByKey(valueList, key) match {
-              case Some(parenExpr) => // replace existing
-                val insertTuple = psiElementGenerator.createExpressionFromText(languageLevel,
-                  s"(${key.getText}, ${value.getText})")  // note, no trailing comma
-                () => {
-                  writeCommandAction(project).withName(actionName).compute(() => {
-                    parenExpr.replace(insertTuple)
-                  }).asInstanceOf[PyExpression]
-                }
-
-              case None => // create new tuple
-                val insertTuple = psiElementGenerator.createExpressionFromText(languageLevel,
-                  s"(${key.getText}, ${value.getText}),")  // note, trailing comma
-                () => {
-                  // for some reason, PyElementGenerator.getInstance(project).createNewLine inserts two spaces
-                  val newline = PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText("\n")
-
-                  val inserted = writeCommandAction(project).withName(actionName).compute(() => {
-                    val inserted = valueList.add(insertTuple)
-                    // can't do valueList.addBefore, since that does a check for PyExpr, which whitespace is not
-                    inserted.addBefore(newline, inserted.getFirstChild)
-                    inserted
-                  }).asInstanceOf[PyExpression]
-                  inserted
-                }
-            }
-          case None =>  // create new keyword arg
-            // TODO: dedup w/ create kwarg below
-            val kwargExpr = psiElementGenerator.createKeywordArgument(languageLevel,
-              kwargName,
-              s"""[
-                 |  (${key.getText}, ${value.getText}),
-                 |]""".stripMargin.replace("\r\n", "\n")
-            )
-
-            () => {
-              writeCommandAction(project).withName(actionName).compute(() => {
-                argList.addArgument(kwargExpr)
-              })
-              argList.getArguments.head
-            }
-        }
-      case None =>
-        val kwargExpr = psiElementGenerator.createKeywordArgument(languageLevel,
-          kwargName,
-          s"""[
-             |  (${key.getText}, ${value.getText}),
-             |]""".stripMargin.replace("\r\n", "\n")
-        )
-
-        () => {
-          val newRefinements = insertRefinementsMethod(cls, project)
-          val argList = newRefinements.getStatementList.getStatements
-              .head.asInstanceOf[PyReturnStatement]
-              .getExpression.asInstanceOf[PyBinaryExpression]
-              .getRightExpression.asInstanceOf[PyCallExpression]
-              .getArgumentList
-          writeCommandAction(project).withName(actionName).compute(() => {
-            argList.addArgument(kwargExpr)
-          })
-          argList.getArguments.head
-        }
-    }
-  }
-
-  def createInstanceRefinement(container: PyClass, path: DesignPath, refinementClass: PyClass,
-                               project: Project): Errorable[() => PyExpression] = exceptable {
-    val psiElementGenerator = PyElementGenerator.getInstance(project)
-    val languageLevel = LanguageLevel.forElement(container)
-    val keyExpr = psiElementGenerator.createExpressionFromText(languageLevel,
-      s"""[${path.steps.map(step => s"'$step'").mkString(", ")}]""")
-    val valueExpr = psiElementGenerator.createExpressionFromText(languageLevel,
-      refinementClass.getName)
-
-    createInsertRefinement(kKwargInstanceRefinements, container, keyExpr, valueExpr,
-      s"Refine $path to ${refinementClass.getName}", project).exceptError
-  }
-
-  def createClassRefinement(container: PyClass, refinedClass: PyClass, refinementClass: PyClass,
-                               project: Project): Errorable[() => PyExpression] = exceptable {
-    val psiElementGenerator = PyElementGenerator.getInstance(project)
-    val languageLevel = LanguageLevel.forElement(container)
-    val keyExpr = psiElementGenerator.createExpressionFromText(languageLevel,
-      refinedClass.getName)
-    val valueExpr = psiElementGenerator.createExpressionFromText(languageLevel,
-      refinementClass.getName)
-
-    createInsertRefinement(kKwargClassRefinements, container, keyExpr, valueExpr,
-      s"Refine ${refinedClass.getName} to ${refinementClass.getName}", project).exceptError
-  }
+  val kKwargInstanceRefinements = "instance_refinements" // path-based subclass refinement
+  val kKwargInstanceValues = "instance_values" // path-based value refinement
+  val kKwargClassRefinements = "class_refinements" // class-based subclass refinement (refine all classes of X)
+  val kKwargClassValues = "class_values" // class + subpath-based value refinement
 }
 
 
@@ -292,6 +142,6 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
   def keyFromPath(path: DesignPath): PyExpression = psiElementGenerator.createExpressionFromText(languageLevel,
     s"""[${path.steps.map(step => s"'$step'").mkString(", ")}]""")
 
-  def valueFromClass(cls: PyClass): PyExpression = psiElementGenerator.createExpressionFromText(languageLevel,
+  def refFromClass(cls: PyClass): PyExpression = psiElementGenerator.createExpressionFromText(languageLevel,
     cls.getName)
 }

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -11,7 +11,11 @@ import edg_ide.util.exceptable
 
 
 object InsertRefinementAction {
-  val REFINEMENT_FN_NAME = "refinements"
+  val kRefinementsFunctionName = "refinements"
+  val kKwargInstanceRefinements = "instance_refinements"  // path-based subclass refinement
+  val kKwargInstanceValues = "instance_values"  // path-based value refinement
+  val kKwargClassRefinements = "class_refinements"  // class-based subclass refinement (refine all classes of X)
+  val kKwargClassValues = "class_values"  // class + subpath-based value refinement
 
   // Inserts the refinement method into the specified class.
   // Validation (that the function doesn't exist before, and the class has appropriate superclasses)
@@ -56,7 +60,7 @@ object InsertRefinementAction {
     val languageLevel = LanguageLevel.forElement(cls)
 
     val refinementsMethod = cls.getMethods.find { method =>
-      method.getName == REFINEMENT_FN_NAME
+      method.getName == kRefinementsFunctionName
     }
 
     // TODO: seriously dedup this across the create new / insert existing paths, perhaps breaking steps into functions
@@ -146,7 +150,7 @@ object InsertRefinementAction {
     val valueExpr = psiElementGenerator.createExpressionFromText(languageLevel,
       refinementClass.getName)
 
-    createInsertRefinement("instance_refinements", container, keyExpr, valueExpr,
+    createInsertRefinement(kKwargInstanceRefinements, container, keyExpr, valueExpr,
       s"Refine $path to ${refinementClass.getName}", project).exceptError
   }
 
@@ -159,7 +163,7 @@ object InsertRefinementAction {
     val valueExpr = psiElementGenerator.createExpressionFromText(languageLevel,
       refinementClass.getName)
 
-    createInsertRefinement("class_refinements", container, keyExpr, valueExpr,
+    createInsertRefinement(kKwargClassRefinements, container, keyExpr, valueExpr,
       s"Refine ${refinedClass.getName} to ${refinementClass.getName}", project).exceptError
   }
 }

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -182,7 +182,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
           val searchGenerator = new DseSearchGenerator(options.searchConfigs)
           var nextPoint = searchGenerator.nextPoint()
           while (nextPoint.nonEmpty) {
-            val (baseCompilerOpt, partialCompile, pointValues, incrRefinements, completedFraction) = nextPoint.get
+            val (baseCompilerOpt, partialCompile, pointValues, searchRefinements, incrRefinements, completedFraction) = nextPoint.get
 
             indicator.setIndeterminate(false)
             indicator.setFraction(completedFraction)
@@ -207,7 +207,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
               }
 
               val result = DseResult(results.length, pointValues,
-                compiler, compiled, errors, objectiveValues, compileTime)
+                searchRefinements, compiler, compiled, errors, objectiveValues, compileTime)
 
               if (errors.nonEmpty) {
                 console.print(s"Result ${results.length}, ${errors.size} errors ($compileTime ms): ${result.objectiveToString}\n",

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -9,9 +9,8 @@ import edg.ElemBuilder
 import edg.compiler._
 import edg.util.{StreamUtils, timeExec}
 import edg.wir.Refinements
-import edg_ide.dse.{DseConfigElement, DseDerivedConfig, DseObjective, DseRefinementElement, DseResult, DseSearchGenerator}
+import edg_ide.dse.{DseConfigElement, DseObjective, DseResult, DseSearchGenerator}
 import edg_ide.ui.{BlockVisualizerService, EdgCompilerService}
-import edg_ide.util.CrossProductUtils.crossProduct
 import edgir.schema.schema
 
 import java.io.{FileWriter, OutputStream, PrintWriter, StringWriter}

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -388,8 +388,7 @@ class DsePanel(project: Project) extends JPanel {
         case node: DseResultTreeNode#ResultNode =>
           if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) {  // right click popup menu
             new DseResultPopupMenu(node.result, project).show(e.getComponent, e.getX, e.getY)
-          }
-          else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) { // double click
+          } else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) { // double click
             val result = node.result
             BlockVisualizerService(project).setDesignTop(result.compiled, result.compiler,
               result.compiler.refinements.toPb, result.errors, Some(f"DSE ${result.index}: "))

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -9,11 +9,12 @@ import com.intellij.ui.treeStructure.treetable.TreeTable
 import com.intellij.util.concurrency.AppExecutorUtil
 import edg.compiler.{ExprValue, FloatValue, IntValue, RangeType, RangeValue}
 import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseObjectiveParameter, DseParameterSearch, DseResult}
+import edg_ide.psi_edits.{InsertAction, InsertRefinementAction}
 import edg_ide.runner.DseRunConfiguration
 import edg_ide.swing._
 import edg_ide.swing.dse.{DseConfigTreeNode, DseConfigTreeTableModel, DseResultTreeNode, DseResultTreeTableModel, JScatterPlot}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption}
-import edg_ide.util.{exceptable, requireExcept}
+import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
 
 import java.awt.event.{ItemEvent, ItemListener, MouseAdapter, MouseEvent}
 import java.awt.{GridBagConstraints, GridBagLayout}
@@ -63,6 +64,21 @@ class DseObjectivePopupMenu(objective: DseObjective, project: Project) extends J
       BlockVisualizerService(project).onDseConfigChanged(dseConfig)
     }
   }, s"Delete"))
+}
+
+
+class DseResultPopupMenu(result: DseResult, project: Project) extends JPopupMenu {
+  add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
+    val topType = result.compiled.getContents.getSelfClass
+    val topClass = DesignAnalysisUtils.pyClassOf(topType, project).exceptError
+
+    val insertAction = new InsertRefinementAction(project, topClass)
+      .createInsertRefinements(result.searchRefinements).exceptError
+    () => { // TODO standardized continuation?
+      val inserted = insertAction().head
+      InsertAction.navigateToEnd(inserted)
+    }
+  }, s"Insert refinements"))
 }
 
 
@@ -370,7 +386,10 @@ class DsePanel(project: Project) extends JPanel {
             plot.setSelection(Seq(node.setMembers))
           }
         case node: DseResultTreeNode#ResultNode =>
-          if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) { // double click
+          if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) {  // right click popup menu
+            new DseResultPopupMenu(node.result, project).show(e.getComponent, e.getX, e.getY)
+          }
+          else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) { // double click
             val result = node.result
             BlockVisualizerService(project).setDesignTop(result.compiled, result.compiler,
               result.compiler.refinements.toPb, result.errors, Some(f"DSE ${result.index}: "))

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -165,7 +165,7 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
     val insertRefinement = new InsertRefinementAction(project, topClass.exceptError)
     val insertAction = insertRefinement.createInsertRefinements(
       SeqMap(InsertRefinementAction.kKwargInstanceRefinements ->
-          Seq((Seq(insertRefinement.keyFromPath(selectedPath)), insertRefinement.valueFromClass(blockPyClass.exceptError)))))
+          Seq((Seq(insertRefinement.keyFromPath(selectedPath)), insertRefinement.refFromClass(blockPyClass.exceptError)))))
         .exceptError
     () => {  // TODO standardized continuation?
       val inserted = insertAction().head
@@ -178,11 +178,13 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
   private val insertClassRefinementAction: Errorable[() => Unit] = exceptable {
     val (selectedPath, selectedClass) = selectedPathClass.exceptError
 
-    val insertAction = InsertRefinementAction.createClassRefinement(
-      topClass.exceptError, selectedClass, blockPyClass.exceptError, project)
+    val insertRefinement = new InsertRefinementAction(project, topClass.exceptError)
+    val insertAction = insertRefinement.createInsertRefinements(
+      SeqMap(InsertRefinementAction.kKwargClassRefinements ->
+          Seq((Seq(insertRefinement.refFromClass(selectedClass)), insertRefinement.refFromClass(blockPyClass.exceptError)))))
         .exceptError
     () => {  // TODO standardized continuation?
-      val inserted = insertAction()
+      val inserted = insertAction().head
       InsertAction.navigateToEnd(inserted)
     }
   }

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -14,7 +14,7 @@ import edg.EdgirUtils.SimpleLibraryPath
 import edg.ExprBuilder.{Ref, ValueExpr}
 import edg.util.{Errorable, NameCreator}
 import edg.wir
-import edg.wir.DesignPath
+import edg.wir.{DesignPath, Refinements}
 import edg.wir.ProtoUtil._
 import edg_ide.edgir_graph._
 import edg_ide.psi_edits._
@@ -134,7 +134,7 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
   addSeparator()
 
   // Refinements action
-  private val selectedPathClass = exceptable {
+  private val selectedPathLibraryClass = exceptable {
     val visualizerPanel = BlockVisualizerService(project).visualizerPanelOption
         .exceptNone("no visualizer panel")
     val blockClass = blockPyClass.exceptError
@@ -150,7 +150,7 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
     requireExcept(blockClass.isSubclass(selectedClass, TypeEvalContext.codeCompletion(project, null)),
       s"${blockClass.getName} not a subtype of ${selectedClass.getName}")
 
-    (selectedPath, selectedClass)
+    (selectedPath, selectedType, selectedClass)
   }
   private val topClass = exceptable {
     val topType = BlockVisualizerService(project).visualizerPanelOption
@@ -160,35 +160,31 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
     DesignAnalysisUtils.pyClassOf(topType, project).exceptError
   }
   private val insertInstanceRefinementAction: Errorable[() => Unit] = exceptable {
-    val (selectedPath, selectedClass) = selectedPathClass.exceptError
-
-    val insertRefinement = new InsertRefinementAction(project, topClass.exceptError)
-    val insertAction = insertRefinement.createInsertRefinements(
-      SeqMap(InsertRefinementAction.kKwargInstanceRefinements ->
-          Seq((Seq(insertRefinement.keyFromPath(selectedPath)), insertRefinement.refFromClass(blockPyClass.exceptError)))))
-        .exceptError
+    val (selectedPath, selectedLibrary, selectedClass) = selectedPathLibraryClass.exceptError
+    val insertAction = new InsertRefinementAction(project, topClass.exceptError)
+        .createInsertRefinements(Refinements(
+          instanceRefinements=Map(selectedPath -> blockType)
+        )).exceptError
     () => {  // TODO standardized continuation?
       val inserted = insertAction().head
       InsertAction.navigateToEnd(inserted)
     }
   }
-  private val selectedPathName = selectedPathClass.map(_._1.toString).toOption.getOrElse("selection")
+  private val selectedPathName = selectedPathLibraryClass.map(_._1.toString).toOption.getOrElse("selection")
   add(ContextMenuUtils.MenuItemFromErrorable(insertInstanceRefinementAction, s"Refine instance $selectedPathName to $blockTypeName"))
 
   private val insertClassRefinementAction: Errorable[() => Unit] = exceptable {
-    val (selectedPath, selectedClass) = selectedPathClass.exceptError
-
-    val insertRefinement = new InsertRefinementAction(project, topClass.exceptError)
-    val insertAction = insertRefinement.createInsertRefinements(
-      SeqMap(InsertRefinementAction.kKwargClassRefinements ->
-          Seq((Seq(insertRefinement.refFromClass(selectedClass)), insertRefinement.refFromClass(blockPyClass.exceptError)))))
-        .exceptError
+    val (selectedPath, selectedLibrary, selectedClass) = selectedPathLibraryClass.exceptError
+    val insertAction = new InsertRefinementAction(project, topClass.exceptError)
+        .createInsertRefinements(Refinements(
+          classRefinements = Map(selectedLibrary -> blockType)
+        )).exceptError
     () => {  // TODO standardized continuation?
       val inserted = insertAction().head
       InsertAction.navigateToEnd(inserted)
     }
   }
-  private val selectedClassName = selectedPathClass.map(_._2.getName).toOption.getOrElse("of selection")
+  private val selectedClassName = selectedPathLibraryClass.map(_._2.toSimpleString).toOption.getOrElse("of selection")
   add(ContextMenuUtils.MenuItemFromErrorable(insertClassRefinementAction, s"Refine class $selectedClassName to $blockTypeName"))
   addSeparator()
 

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -5,7 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.{PsiElement, PsiFile}
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.treeStructure.treetable.{TreeTable, TreeTableCellRenderer, TreeTableModel}
+import com.intellij.ui.treeStructure.treetable.TreeTable
 import com.intellij.ui.{JBSplitter, TreeTableSpeedSearch}
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.jetbrains.python.psi.types.TypeEvalContext
@@ -14,8 +14,8 @@ import edg.EdgirUtils.SimpleLibraryPath
 import edg.ExprBuilder.{Ref, ValueExpr}
 import edg.util.{Errorable, NameCreator}
 import edg.wir
-import edg.wir.{DesignPath, Refinements}
 import edg.wir.ProtoUtil._
+import edg.wir.{DesignPath, Refinements}
 import edg_ide.edgir_graph._
 import edg_ide.psi_edits._
 import edg_ide.swing._
@@ -33,7 +33,6 @@ import java.util.concurrent.Callable
 import javax.swing._
 import javax.swing.event._
 import javax.swing.tree.TreePath
-import scala.collection.SeqMap
 
 
 class BlockRootPopupMenu(project: Project) extends JPopupMenu {

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -33,6 +33,7 @@ import java.util.concurrent.Callable
 import javax.swing._
 import javax.swing.event._
 import javax.swing.tree.TreePath
+import scala.collection.SeqMap
 
 
 class BlockRootPopupMenu(project: Project) extends JPopupMenu {
@@ -161,11 +162,13 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
   private val insertInstanceRefinementAction: Errorable[() => Unit] = exceptable {
     val (selectedPath, selectedClass) = selectedPathClass.exceptError
 
-    val insertAction = InsertRefinementAction.createInstanceRefinement(
-      topClass.exceptError, selectedPath, blockPyClass.exceptError, project)
+    val insertRefinement = new InsertRefinementAction(project, topClass.exceptError)
+    val insertAction = insertRefinement.createInsertRefinements(
+      SeqMap(InsertRefinementAction.kKwargInstanceRefinements ->
+          Seq((Seq(insertRefinement.keyFromPath(selectedPath)), insertRefinement.valueFromClass(blockPyClass.exceptError)))))
         .exceptError
     () => {  // TODO standardized continuation?
-      val inserted = insertAction()
+      val inserted = insertAction().head
       InsertAction.navigateToEnd(inserted)
     }
   }

--- a/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
+++ b/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
@@ -49,31 +49,38 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     val partialEmpty = PartialCompile()
 
     val generator = new DseSearchGenerator(Seq(config1, config2))
-    generator.nextPoint() should equal(Some(None, partial12, SeqMap(), Refinements(), 0.0))
+    generator.nextPoint() should equal(Some(None, partial12, SeqMap(), Refinements(), Refinements(), 0.0))
     val rootCompiler = new MockCompiler()
     generator.addEvaluatedPoint(rootCompiler)
 
     generator.nextPoint() should equal(Some(Some(rootCompiler), partial2,
       SeqMap(config1 -> IntValue(0)),
-      Refinements(instanceValues=Map(DesignPath() + "param1" -> IntValue(0))),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
       0.0))
     val fork0Compiler = new MockCompiler()
     generator.addEvaluatedPoint(fork0Compiler)
 
     generator.nextPoint() should equal(Some(Some(fork0Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(0), config2 -> IntValue(10)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0),
+        DesignPath() + "param2" -> IntValue(10))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(10))),
       0.0))
     generator.addEvaluatedPoint(rootCompiler)  // dummy - ignore
 
     generator.nextPoint() should equal(Some(Some(fork0Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(0), config2 -> IntValue(11)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0),
+        DesignPath() + "param2" -> IntValue(11))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(11))),
       1.0f/6))
     generator.addEvaluatedPoint(rootCompiler)  // dummy - ignore
 
     generator.nextPoint() should equal(Some(Some(fork0Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(0), config2 -> IntValue(12)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0),
+        DesignPath() + "param2" -> IntValue(12))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(12))),
       2.0f/6))
     generator.addEvaluatedPoint(rootCompiler)  // dummy - ignore
@@ -82,24 +89,31 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.nextPoint() should equal(Some(Some(rootCompiler), partial2,
       SeqMap(config1 -> IntValue(1)),
       Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
       3.0f/6))
     val fork1Compiler = new MockCompiler()
     generator.addEvaluatedPoint(fork1Compiler)
 
     generator.nextPoint() should equal(Some(Some(fork1Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(1), config2 -> IntValue(10)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1),
+        DesignPath() + "param2" -> IntValue(10))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(10))),
       3.0f/6))
     generator.addEvaluatedPoint(rootCompiler)  // dummy - ignore
 
     generator.nextPoint() should equal(Some(Some(fork1Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(1), config2 -> IntValue(11)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1),
+        DesignPath() + "param2" -> IntValue(11))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(11))),
       4.0f/6))
     generator.addEvaluatedPoint(rootCompiler)  // dummy - ignore
 
     generator.nextPoint() should equal(Some(Some(fork1Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(1), config2 -> IntValue(12)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1),
+        DesignPath() + "param2" -> IntValue(12))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(12))),
       5.0f/6))
     generator.addEvaluatedPoint(rootCompiler)  // dummy - ignore
@@ -126,16 +140,18 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.nextPoint() should equal(Some(None, partialEmpty,  // first is the generating compile
       SeqMap(),
       Refinements(),
+      Refinements(),
       0.0))
     val generatingCompiler = new MockCompiler()
     generator.addEvaluatedPoint(generatingCompiler)  // should never be used
 
-    generator.nextPoint() should equal(Some(None, partial12, SeqMap(), Refinements(), 0.0))  // now the root compile
+    generator.nextPoint() should equal(Some(None, partial12, SeqMap(), Refinements(), Refinements(), 0.0))  // now the root compile
     val rootCompiler = new MockCompiler()
     generator.addEvaluatedPoint(rootCompiler)
 
     generator.nextPoint() should equal(Some(Some(rootCompiler), partial2,
       SeqMap(derivedConfig1 -> IntValue(0)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
       Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
       0.0)) // intermediate
     val fork0Compiler = new MockCompiler()
@@ -143,6 +159,8 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
 
     generator.nextPoint() should equal(Some(Some(fork0Compiler), partialEmpty,
       SeqMap(derivedConfig1 -> IntValue(0), derivedConfig2 -> IntValue(10)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0),
+        DesignPath() + "param2" -> IntValue(10))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(10))),
       0.0)) // concrete value
     generator.addEvaluatedPoint(rootCompiler)  // dummy - ignore
@@ -150,12 +168,15 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.nextPoint() should equal(Some(Some(rootCompiler), partial2,
       SeqMap(derivedConfig1 -> IntValue(1)),
       Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
       0.5)) // intermediate
     val fork1Compiler = new MockCompiler()
     generator.addEvaluatedPoint(fork1Compiler)
 
     generator.nextPoint() should equal(Some(Some(fork1Compiler), partialEmpty,
       SeqMap(derivedConfig1 -> IntValue(1), derivedConfig2 -> IntValue(10)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1),
+        DesignPath() + "param2" -> IntValue(10))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(10))),
       0.5)) // concrete value
     generator.addEvaluatedPoint(rootCompiler) // dummy - ignore
@@ -180,12 +201,14 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.nextPoint() should equal(Some(None, partial12, // first is root compile pre-config1
       SeqMap(),
       Refinements(),
+      Refinements(),
       0.0))
     val rootCompiler = new MockCompiler()
     generator.addEvaluatedPoint(rootCompiler)
 
     generator.nextPoint() should equal(Some(Some(rootCompiler), partialEmpty, // generating compile
       SeqMap(config1 -> IntValue(0)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
       Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
       0.0))
     val generatingCompiler1 = new MockCompiler()
@@ -194,12 +217,15 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.nextPoint() should equal(Some(Some(rootCompiler), partial2,
       SeqMap(config1 -> IntValue(0)),
       Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0))),
       0.0)) // intermediate
     val fork0Compiler = new MockCompiler()
     generator.addEvaluatedPoint(fork0Compiler)
 
     generator.nextPoint() should equal(Some(Some(fork0Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(0), derivedConfig2 -> IntValue(10)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(0),
+        DesignPath() + "param2" -> IntValue(10))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(10))),
       0.0)) // concrete value
     generator.addEvaluatedPoint(rootCompiler) // dummy - ignore
@@ -213,6 +239,7 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.nextPoint() should equal(Some(Some(rootCompiler), partialEmpty, // generating compile
       SeqMap(config1 -> IntValue(1)),
       Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
       0.5))
     val generatingCompiler2 = new MockCompiler()
     generator.addEvaluatedPoint(generatingCompiler2) // should never be used
@@ -220,12 +247,15 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.nextPoint() should equal(Some(Some(rootCompiler), partial2,
       SeqMap(config1 -> IntValue(1)),
       Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1))),
       0.5)) // intermediate
     val fork1Compiler = new MockCompiler()
     generator.addEvaluatedPoint(fork1Compiler)
 
     generator.nextPoint() should equal(Some(Some(fork1Compiler), partialEmpty,
       SeqMap(config1 -> IntValue(1), derivedConfig2 -> IntValue(11)),
+      Refinements(instanceValues = Map(DesignPath() + "param1" -> IntValue(1),
+        DesignPath() + "param2" -> IntValue(11))),
       Refinements(instanceValues = Map(DesignPath() + "param2" -> IntValue(11))),
       0.5)) // concrete value
     generator.addEvaluatedPoint(rootCompiler) // dummy - ignore


### PR DESCRIPTION
_DSE is an experimental feature that is not enabled by default._

DSE points can now generate refinements into the design top source HDL.

Infrastructural changes:
- Refactors InsertRefinementAction to take multiple refinements (instead of just one) and insert them simultaneously.
  - Restructures each step in this to be a separate function, so they can be composed together (eg, mixture of modifying existing refinements, adding new refinements tuples, and adding new refinements kwargs) with minimal code dupe
- Add all-search-refinements to the DES search space generator output

