### PR TITLE
Reduce startup time indexing KiCad footprints

### DIFF
--- a/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
@@ -24,19 +24,17 @@ class FootprintBrowserRootNode(directories: Seq[File]) extends FootprintBrowserB
 
 
 class FootprintBrowserNode(val file: File) extends FootprintBrowserBaseNode {
-  def isValidFile(candidateFile: File): Boolean = {
-    val fileName = candidateFile.getName
+  def isValidFileName(fileName: String): Boolean = {
     if (fileName == "." || fileName == "..") return false  // ignore self and up pointers
-    fileName.endsWith(".mod") || fileName.endsWith(".kicad_mod") || candidateFile.isDirectory
+    fileName.endsWith(".kicad_mod") || fileName.endsWith(".mod")
   }
 
   override lazy val children: Seq[FootprintBrowserNode] = {
-    Option(file.list()) match {
+    Option(file.list()) match {  // file.list() can return null
       case Some(filenames) => filenames.toSeq
+        .filter(isValidFileName)
         .sorted
-        .map(new File(file, _))
-        .filter(isValidFile)
-        .map(new FootprintBrowserNode(_))
+        .map(fileName => new FootprintBrowserNode(new File(file, fileName)))
       case None => Seq()
     }
   }

--- a/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
@@ -52,9 +52,7 @@ class FootprintBrowserTreeTableModel(directories: Seq[File]) extends SeqTreeTabl
   private val rootNode: FootprintBrowserRootNode = new FootprintBrowserRootNode(directories)
   private val COLUMNS = Seq("Path")
 
-  override def getNodeChildren(node: FootprintBrowserBaseNode): Seq[FootprintBrowserBaseNode] = {
-    node.children
-  }
+  override def getNodeChildren(node: FootprintBrowserBaseNode): Seq[FootprintBrowserBaseNode] = node.children
 
   override def getRootNode: FootprintBrowserBaseNode = rootNode
 

--- a/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/FootprintBrowserTreeTableModel.scala
@@ -24,23 +24,22 @@ class FootprintBrowserRootNode(directories: Seq[File]) extends FootprintBrowserB
 
 
 class FootprintBrowserNode(val file: File) extends FootprintBrowserBaseNode {
-  def isValidFile(filename: String): Boolean = {
-    if (filename == "." || filename == "..") return false  // ignore self and up pointers
-    val currFile = new File(filename)
-    currFile.exists() && (filename.endsWith(".mod") || filename.endsWith(".kicad_mod") || currFile.isDirectory)
+  def isValidFile(candidateFile: File): Boolean = {
+    val fileName = candidateFile.getName
+    if (fileName == "." || fileName == "..") return false  // ignore self and up pointers
+    fileName.endsWith(".mod") || fileName.endsWith(".kicad_mod") || candidateFile.isDirectory
   }
 
   override lazy val children: Seq[FootprintBrowserNode] = {
     Option(file.list()) match {
       case Some(filenames) => filenames.toSeq
-        .map(filename => file.getCanonicalPath + "/" + filename)
-        .filter(isValidFile)
         .sorted
-        .map(f => new FootprintBrowserNode(new File(f)))
+        .map(new File(file, _))
+        .filter(isValidFile)
+        .map(new FootprintBrowserNode(_))
       case None => Seq()
     }
   }
-
 
   override def equals(obj: Any): Boolean = obj match {
     case obj:FootprintBrowserNode => obj.file.equals(this.file)
@@ -48,14 +47,16 @@ class FootprintBrowserNode(val file: File) extends FootprintBrowserBaseNode {
   }
 
   override def toString: String = file.getName
-
 }
+
 
 class FootprintBrowserTreeTableModel(directories: Seq[File]) extends SeqTreeTableModel[FootprintBrowserBaseNode] {
   private val rootNode: FootprintBrowserRootNode = new FootprintBrowserRootNode(directories)
   private val COLUMNS = Seq("Path")
 
-  override def getNodeChildren(node: FootprintBrowserBaseNode): Seq[FootprintBrowserBaseNode] = node.children
+  override def getNodeChildren(node: FootprintBrowserBaseNode): Seq[FootprintBrowserBaseNode] = {
+    node.children
+  }
 
   override def getRootNode: FootprintBrowserBaseNode = rootNode
 

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -9,7 +9,7 @@ import com.intellij.ui.treeStructure.treetable.TreeTable
 import com.jetbrains.python.psi.types.TypeEvalContext
 import edg.ElemBuilder
 import edg.compiler.{Compiler, ExprToString, TextValue}
-import edg.util.{Errorable, timeExec}
+import edg.util.Errorable
 import edg.wir.DesignPath
 import edg_ide.EdgirUtils
 import edg_ide.psi_edits.{InsertAction, InsertFootprintAction, InsertPinningAction}

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -9,7 +9,7 @@ import com.intellij.ui.treeStructure.treetable.TreeTable
 import com.jetbrains.python.psi.types.TypeEvalContext
 import edg.ElemBuilder
 import edg.compiler.{Compiler, ExprToString, TextValue}
-import edg.util.Errorable
+import edg.util.{Errorable, timeExec}
 import edg.wir.DesignPath
 import edg_ide.EdgirUtils
 import edg_ide.psi_edits.{InsertAction, InsertFootprintAction, InsertPinningAction}
@@ -147,7 +147,7 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
   //
   private val splitter = new JBSplitter(false, 0.5f, 0.1f, 0.9f)
 
-  splitter.setSecondComponent(FootprintBrowser)
+  splitter.setFirstComponent(FootprintBrowser)
 
   private val status = new JEditorPane("text/html",
       SwingHtmlUtil.wrapInHtml("No footprint selected", this.getFont))
@@ -184,7 +184,7 @@ class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
   private val visualizerPanel = new JPanel(new GridBagLayout())
   visualizerPanel.add(status, Gbc(0, 0, GridBagConstraints.HORIZONTAL))
   visualizerPanel.add(visualizer, Gbc(0, 1, GridBagConstraints.BOTH))
-  splitter.setFirstComponent(visualizerPanel)
+  splitter.setSecondComponent(visualizerPanel)
 
 
   setLayout(new BorderLayout())


### PR DESCRIPTION
Previously, this took about ~6000ms, this change gets it down to ~800ms. With no footprints directory specified, the time to construct the model and TreeTable is about 3ms. Probably the primary mechanism is the simplified indexing logic plus using direct File from parent File creation (as opposed to presumably a bunch of long string ops)

It looks like for whatever reason, on initialization the model is traversed to the leaf level, even though the node children is lazy-initialized. A future change (micro-optimization) might be to create a TreeTable that can make use of lazily initialized children. Thought may be needed on how this interacts with filtering, which depends on the leaf nodes being available - maybe lazy index until filtering is asked for, then display a spinny icon as filtering indexes everything?

Also makes the footprint UI consistent with the rest, by putting the list view on the left (instead of prior on the right). Also uses JBScrollPane for UI look and feel consistency.