### PR TITLE
DSE: class-value search

### DIFF
--- a/src/main/scala/edg_ide/dse/DseConfigElement.scala
+++ b/src/main/scala/edg_ide/dse/DseConfigElement.scala
@@ -133,6 +133,8 @@ object DseParameterSearch {
 sealed trait DseParameterSearch extends DseRefinementElement[ExprValue] { self: Serializable =>
   def values: Seq[ExprValue]
 
+  override def valueToString(value: Any): String = value.asInstanceOf[ExprValue].toStringValue
+
   // Returns the values as a string, that will parse back with valuesStringToConfig.
   // This contains special-case code to handle the TextValue case
   def valuesToString(): String = {
@@ -199,7 +201,6 @@ case class DsePathParameterSearch(path: DesignPath, values: Seq[ExprValue])
     extends DseInstanceRefinementElement[ExprValue] with DseParameterSearch with Serializable {
   override def toString = f"${this.getClass.getSimpleName}($path, ${values.map(_.toStringValue).mkString(",")})"
   override def configToString: String = f"Param($path)"
-  def valueToString(value: Any): String = value.asInstanceOf[ExprValue].toStringValue
 
   override def getPartialCompile: PartialCompile = {
     PartialCompile(params=Seq(path))
@@ -221,7 +222,6 @@ case class DseClassParameterSearch(cls: ref.LibraryPath, postfix: ref.LocalPath,
     extends DseParameterSearch with Serializable {
   override def toString = f"${this.getClass.getSimpleName}(${cls.toSimpleString}:${ExprToString(postfix)}, ${values.map(_.toStringValue).mkString(",")})"
   override def configToString: String = f"ClassParams(${cls.toSimpleString}:${ExprToString(postfix)})"
-  def valueToString(value: Any): String = value.asInstanceOf[ExprValue].toStringValue
 
   override def getPartialCompile: PartialCompile = {
     PartialCompile(classParams=Seq((cls, postfix)))

--- a/src/main/scala/edg_ide/dse/DseConfigElement.scala
+++ b/src/main/scala/edg_ide/dse/DseConfigElement.scala
@@ -1,6 +1,5 @@
 package edg_ide.dse
 
-import com.jetbrains.python.psi.PyExpression
 import edg.EdgirUtils.SimpleLibraryPath
 import edg.compiler.{ArrayValue, BooleanValue, Compiler, ExprToString, ExprValue, FloatValue, IntValue, PartialCompile, RangeValue, TextValue}
 import edg.util.Errorable
@@ -229,7 +228,7 @@ case class DseClassParameterSearch(cls: ref.LibraryPath, postfix: ref.LocalPath,
   }
 
   override def getValues: Seq[(ExprValue, Refinements)] = values.map { value =>
-    (value, Refinements(classValues=Map(cls -> Map(postfix -> value))))
+    (value, Refinements(classValues=Map((cls, postfix) -> value)))
   }
 
   override def valuesStringToConfig(str: String): Errorable[DseClassParameterSearch] = exceptable {

--- a/src/main/scala/edg_ide/dse/DseSearchGenerator.scala
+++ b/src/main/scala/edg_ide/dse/DseSearchGenerator.scala
@@ -132,7 +132,9 @@ class DseSearchGenerator(configs: Seq[DseConfigElement]) {
         }
         compilerStack.append(compiler)
       } else {  // just evaluated a concrete design point, pop up the stack
-        searchStack.last.remove(0)  // remove the first (just evaluated) point
+        if (searchStack.nonEmpty) {  // searchStack may be empty for an empty design space
+          searchStack.last.remove(0)  // remove the first (just evaluated) point
+        }
         while (searchStack.nonEmpty && searchStack.last.isEmpty) {  // backtrack as needed
           compilerStack.remove(searchStack.length - 1)
           searchStack.remove(searchStack.length - 1)

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -155,10 +155,8 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
     val instanceRefinementsEntry = refinements.instanceRefinements.map { case (sourcePath, targetClass) =>
       Seq(keyFromPath(sourcePath)) -> refFromLibrary(targetClass)
     }.toSeq
-    val classValuesEntry = refinements.classValues.flatMap { case (sourceClass, targetPathValue) =>
-      targetPathValue.map { case (targetPath, targetValue) =>
-        Seq(refFromLibrary(sourceClass), keyFromLocalPath(targetPath).exceptError) -> valueFromExpr(targetValue).exceptError
-      }
+    val classValuesEntry = refinements.classValues.map { case ((sourceClass, targetPath), targetValue) =>
+      Seq(refFromLibrary(sourceClass), keyFromLocalPath(targetPath).exceptError) -> valueFromExpr(targetValue).exceptError
     }.toSeq
     val instanceValuesEntry = refinements.instanceValues.map { case (sourcePath, targetValue) =>
       Seq(keyFromPath(sourcePath)) -> valueFromExpr(targetValue).exceptError

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -192,6 +192,13 @@ trait HasConsoleStages {
     } catch {
       case e: Exception =>
         console.print(s"Failed: $e\n", ConsoleViewContentType.ERROR_OUTPUT)
+        // By default, the stack trace isn't printed, since most of the internal details
+        // (stack trace elements) aren't relevant for end users
+        // TODO this should be plumbed to a toggle
+        // val sw = new StringWriter
+        // val pw = new PrintWriter(sw)
+        // e.printStackTrace(pw)
+        // console.print(sw.toString, ConsoleViewContentType.ERROR_OUTPUT)
         default
     }
   }

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -275,7 +275,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
 
         val (compiled, compiler, refinements) = runRequiredStage("compile", indicator) {
           val designType = ElemBuilder.LibraryPath(options.designName)
-          val output = EdgCompilerService(project).compile(designType, None)
+          val output = EdgCompilerService(project).compile(designType)
           (output, "")
         }
 

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -300,7 +300,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
             ElemBuilder.LibraryPath("electronics_model.RefdesRefinementPass"),
             compiled, compiler.getAllSolved
           ).mapErr(msg => s"while refdesing: $msg").get
-          compiler.addValues(refdes, "refdes")
+          compiler.addAssignValues(refdes, "refdes")
           f"${refdes.size} components"
         }
 

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -168,7 +168,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
         val (block, refinementsPb) = EdgCompilerService(project).pyLib.getDesignTop(designType)
             .mapErr(msg => s"invalid top-level design: $msg").get // TODO propagate Errorable
         val design = schema.Design(contents = Some(block))
-        val partialCompile = options.searchConfigs.map(_.getPartialCompile).reduce(_ ++ _)
+        val partialCompile = options.searchConfigs.map(_.getPartialCompile).fold(PartialCompile())(_ ++ _)
         val (removedRefinements, refinements) = Refinements(refinementsPb).partitionBy(
           partialCompile.blocks.toSet, partialCompile.params.toSet
         )

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -170,7 +170,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
         val design = schema.Design(contents = Some(block))
         val partialCompile = options.searchConfigs.map(_.getPartialCompile).fold(PartialCompile())(_ ++ _)
         val (removedRefinements, refinements) = Refinements(refinementsPb).partitionBy(
-          partialCompile.blocks.toSet, partialCompile.params.toSet
+          partialCompile.blocks.toSet, partialCompile.params.toSet, partialCompile.classParams.toSet
         )
         if (!removedRefinements.isEmpty) {
           console.print(s"Discarded conflicting refinements $removedRefinements\n", ConsoleViewContentType.SYSTEM_OUTPUT)

--- a/src/main/scala/edg_ide/ui/ContextMenuUtils.scala
+++ b/src/main/scala/edg_ide/ui/ContextMenuUtils.scala
@@ -33,6 +33,22 @@ object ContextMenuUtils {
     item
   }
 
+  def MenuItemNamedFromErrorable(action: Errorable[(() => Unit, String)], fallbackLabel: String): JMenuItem = {
+    val item = action match {
+      case Errorable.Success((action, label)) =>
+        val item = new JMenuItem(label)
+        item.addActionListener((e: ActionEvent) => {
+          action()
+        })
+        item
+      case Errorable.Error(msg) =>
+        val item = new JMenuItem(s"$fallbackLabel ($msg)")
+        item.setEnabled(false)
+        item
+    }
+    item
+  }
+
   def MenuItemsFromErrorableSeq[T](actions: Errorable[Seq[(String, () => Unit)]],
                                    errorLabel: String): Seq[JMenuItem] = {
     actions match {

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -36,7 +36,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
   add(ContextMenuUtils.MenuItemNamedFromErrorable(exceptable {
     val directPath = DesignPath.fromIndirectOption(path).exceptNone("not a direct parameter")
     val (blockPath, block) = EdgirUtils.resolveDeepestBlock(directPath, design)
-    val blockClass = block.getSelfClass
+    val blockClass = block.getPrerefineClass
     val postfix = directPath.postfixFromOption(blockPath).get
     requireExcept(postfix.steps.size == 1, "not a direct parameter of a block")
     val value = compiler.getParamValue(path).exceptNone("no value")

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -4,13 +4,14 @@ import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.treeStructure.treetable.TreeTable
 import edg.EdgirUtils.SimpleLibraryPath
-import edg.compiler.{Compiler, ExprToString}
-import edg.wir.{DesignPath, IndirectDesignPath}
+import edg.compiler.Compiler
+import edg.wir.ProtoUtil.ParamProtoToSeqMap
+import edg.wir.{DesignPath, IndirectDesignPath, Library}
 import edg_ide.dse.{DseClassParameterSearch, DseFeature, DseObjectiveParameter, DsePathParameterSearch}
-import edg_ide.{EdgirUtils, swing}
 import edg_ide.swing.{ElementDetailTreeModel, TreeTableUtils}
-import edg_ide.util.ExceptionNotifyImplicits.ExceptOption
-import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptOption, ExceptSeq}
+import edg_ide.util.{exceptable, requireExcept}
+import edg_ide.{EdgirUtils, swing}
 import edgir.schema.schema
 import edgrpc.hdl.{hdl => edgrpc}
 
@@ -20,7 +21,7 @@ import javax.swing.{JPanel, JPopupMenu, SwingUtilities}
 
 
 class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, compiler: Compiler, project: Project) extends JPopupMenu {
-  val rootClass = design.getContents.getSelfClass
+  private val rootClass = design.getContents.getSelfClass
 
   add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
     val directPath = DesignPath.fromIndirectOption(path).exceptNone("not a direct parameter")
@@ -38,15 +39,32 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
     val (blockPath, block) = EdgirUtils.resolveDeepestBlock(directPath, design)
     val blockClass = block.getPrerefineClass
     val postfix = directPath.postfixFromOption(blockPath).get
-    requireExcept(postfix.steps.size == 1, "not a direct parameter of a block")
+    val paramName = postfix.steps.onlyExcept("not a direct parameter of a block").getName
+    requireExcept(block.params.get(paramName).isDefined, f"${blockClass.toSimpleString} does not have $paramName")
     val value = compiler.getParamValue(path).exceptNone("no value")
     (() => {
       val config = BlockVisualizerService(project).getOrCreateDseRunConfiguration(rootClass)
       config.options.searchConfigs = config.options.searchConfigs ++
           Seq(DseClassParameterSearch(blockClass, postfix, Seq(value)))
       BlockVisualizerService(project).onDseConfigChanged(config)
-    }, s"Search values of class ${blockClass.toSimpleString}:${ExprToString(postfix)}")
-  }, s"Search values of class"))
+    }, s"Search values of specified class ${blockClass.toSimpleString}:$paramName")
+  }, s"Search values of specified class"))
+
+  add(ContextMenuUtils.MenuItemNamedFromErrorable(exceptable {
+    val directPath = DesignPath.fromIndirectOption(path).exceptNone("not a direct parameter")
+    val (blockPath, block) = EdgirUtils.resolveDeepestBlock(directPath, design)
+    val postfix = directPath.postfixFromOption(blockPath).get
+    val paramName = postfix.steps.onlyExcept("not a direct parameter of a block").getName
+    val paramDefiningClass = compiler.library.blockParamGetDefiningSuperclass(block.getSelfClass, paramName)
+        .exceptNone("no param-defining class")
+    val value = compiler.getParamValue(path).exceptNone("no value")
+    (() => {
+      val config = BlockVisualizerService(project).getOrCreateDseRunConfiguration(rootClass)
+      config.options.searchConfigs = config.options.searchConfigs ++
+          Seq(DseClassParameterSearch(paramDefiningClass, postfix, Seq(value)))
+      BlockVisualizerService(project).onDseConfigChanged(config)
+    }, s"Search values of param-defining class ${paramDefiningClass.toSimpleString}:$paramName")
+  }, s"Search values of param-defining class"))
 
   add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
     val objective = compiler.getParamType(path) match {

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -47,8 +47,8 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       config.options.searchConfigs = config.options.searchConfigs ++
           Seq(DseClassParameterSearch(blockClass, postfix, Seq(value)))
       BlockVisualizerService(project).onDseConfigChanged(config)
-    }, s"Search values of specified class ${blockClass.toSimpleString}:$paramName")
-  }, s"Search values of specified class"))
+    }, s"Search values of class ${blockClass.toSimpleString}:$paramName")
+  }, s"Search values of class"))
 
   add(ContextMenuUtils.MenuItemNamedFromErrorable(exceptable {
     val directPath = DesignPath.fromIndirectOption(path).exceptNone("not a direct parameter")

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -126,18 +126,13 @@ class EdgCompilerService(project: Project) extends
 
   // Compiles a top level design
   // progressFn is called (by compiler hook) for each compiler elaborate record
-  def compile(designType: ref.LibraryPath, progressFn: Option[ElaborateRecord => Unit] = None):
+  def compile(designType: ref.LibraryPath):
       (schema.Design, Compiler, edgrpc.Refinements) = {
     val (block, refinements) = EdgCompilerService(project).pyLib.getDesignTop(designType)
         .mapErr(msg => s"invalid top-level design: $msg").get // TODO propagate Errorable
     val design = schema.Design(contents = Some(block))
 
-    val compiler = new Compiler(design, EdgCompilerService(project).pyLib, refinements = Refinements(refinements)) {
-      override def onElaborate(record: ElaborateRecord): Unit = {
-        super.onElaborate(record)
-        progressFn.foreach { fn => fn(record) }
-      }
-    }
+    val compiler = new Compiler(design, EdgCompilerService(project).pyLib, refinements = Refinements(refinements))
     (compiler.compile(), compiler, refinements)
   }
 

--- a/src/test/scala/edg_ide/dse/tests/DsePathParameterSearchTest.scala
+++ b/src/test/scala/edg_ide/dse/tests/DsePathParameterSearchTest.scala
@@ -3,21 +3,21 @@ package edg_ide.dse.tests
 import edg.compiler.{BooleanValue, ExprValue, FloatValue, IntValue, RangeValue, TextValue}
 import edg.util.Errorable
 import edg.wir.DesignPath
-import edg_ide.dse.DseParameterSearch
+import edg_ide.dse.DsePathParameterSearch
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 
-class DseParameterSearchTest extends AnyFlatSpec with Matchers {
-  behavior of "DseParameterSearch"
+class DsePathParameterSearchTest extends AnyFlatSpec with Matchers {
+  behavior of "DsePathParameterSearch"
 
   protected def shouldRoundtrip(values: Seq[ExprValue]): Unit = {
-    val parameter = DseParameterSearch(DesignPath(), values)
+    val parameter = DsePathParameterSearch(DesignPath(), values)
     parameter.valuesStringToConfig(parameter.valuesToString()).get.getValues.map(_._1) should equal(values)
   }
 
   protected def parseString(examples: Seq[ExprValue], str: String): Errorable[Seq[ExprValue]] = {
-    val exampleParameter = DseParameterSearch(DesignPath(), examples)
+    val exampleParameter = DsePathParameterSearch(DesignPath(), examples)
     exampleParameter.valuesStringToConfig(str).map(_.getValues).map(_.map(_._1))
   }
 

--- a/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
+++ b/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
@@ -3,7 +3,7 @@ package edg_ide.dse.tests
 import edg.compiler.{Compiler, IntValue, PartialCompile}
 import edg.util.Errorable
 import edg.wir.{DesignPath, EdgirLibrary, Refinements}
-import edg_ide.dse.{DseDerivedConfig, DseParameterSearch, DseSearchGenerator}
+import edg_ide.dse.{DseDerivedConfig, DsePathParameterSearch, DseSearchGenerator}
 import edgir.schema.schema
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -15,14 +15,14 @@ class MockCompiler extends Compiler(schema.Design(), new EdgirLibrary(schema.Lib
 }
 
 
-case class DseDerivedStatic(path: DesignPath, var value: DseParameterSearch) extends DseDerivedConfig with Serializable {
+case class DseDerivedStatic(path: DesignPath, var value: DsePathParameterSearch) extends DseDerivedConfig with Serializable {
   def configToString: String = f"DerivedStatic($path)"
 
   override def getPartialCompile: PartialCompile = {
     PartialCompile(params=Seq(path))
   }
 
-  override def configFromDesign(compiledDesign: Compiler): Errorable[DseParameterSearch] = {
+  override def configFromDesign(compiledDesign: Compiler): Errorable[DsePathParameterSearch] = {
     Errorable.Success(value)
   }
 }
@@ -32,10 +32,10 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
   behavior of "DseSearchGenerator"
 
   it should "generate a static config space" in {
-    val config1 = DseParameterSearch(DesignPath() + "param1",
+    val config1 = DsePathParameterSearch(DesignPath() + "param1",
       Seq(0, 1).map(IntValue(_))
     )
-    val config2 = DseParameterSearch(DesignPath() + "param2",
+    val config2 = DsePathParameterSearch(DesignPath() + "param2",
       Seq(10, 11, 12).map(IntValue(_))
     )
 
@@ -123,11 +123,11 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
 
   it should "generate a derived config space" in {
     // we can't test dynamic behavior here since the derived space is generated only once at the test start
-    val containedConfig1 = DseParameterSearch(DesignPath() + "param1",
+    val containedConfig1 = DsePathParameterSearch(DesignPath() + "param1",
       Seq(0, 1).map(IntValue(_))
     )
     val derivedConfig1 = DseDerivedStatic(DesignPath() + "param1", containedConfig1)
-    val containedConfig2 = DseParameterSearch(DesignPath() + "param2",
+    val containedConfig2 = DsePathParameterSearch(DesignPath() + "param2",
       Seq(10).map(IntValue(_))
     )
     val derivedConfig2 = DseDerivedStatic(DesignPath() + "param2", containedConfig2)
@@ -185,10 +185,10 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
   }
 
   it should "generate a hybrid derived config space" in {
-    val config1 = DseParameterSearch(DesignPath() + "param1",
+    val config1 = DsePathParameterSearch(DesignPath() + "param1",
       Seq(0, 1).map(IntValue(_))
     )
-    val containedConfig2 = DseParameterSearch(DesignPath() + "param2",
+    val containedConfig2 = DsePathParameterSearch(DesignPath() + "param2",
       Seq(10).map(IntValue(_))
     )
     val derivedConfig2 = DseDerivedStatic(DesignPath() + "param2", containedConfig2)
@@ -231,7 +231,7 @@ class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
     generator.addEvaluatedPoint(rootCompiler) // dummy - ignore
 
     // create a new dynamic value which should take effect
-    val containedConfig2new = DseParameterSearch(DesignPath() + "param2",
+    val containedConfig2new = DsePathParameterSearch(DesignPath() + "param2",
       Seq(11).map(IntValue(_))
     )
     derivedConfig2.value = containedConfig2new

--- a/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
+++ b/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
@@ -30,6 +30,15 @@ case class DseDerivedStatic(path: DesignPath, var value: DsePathParameterSearch)
 
 class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
   behavior of "DseSearchGenerator"
+  
+  it should "generate a single point for empty input" in {
+    val generator = new DseSearchGenerator(Seq())
+    generator.nextPoint() should equal(Some(None, PartialCompile(), SeqMap(), Refinements(), Refinements(), 0.0))
+    val rootCompiler = new MockCompiler()
+    generator.addEvaluatedPoint(rootCompiler)
+
+    generator.nextPoint() should equal(None)
+  }
 
   it should "generate a static config space" in {
     val config1 = DsePathParameterSearch(DesignPath() + "param1",

--- a/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
+++ b/src/test/scala/edg_ide/dse/tests/DseSearchGeneratorTest.scala
@@ -30,7 +30,7 @@ case class DseDerivedStatic(path: DesignPath, var value: DsePathParameterSearch)
 
 class DseSearchGeneratorTest extends AnyFlatSpec with Matchers {
   behavior of "DseSearchGenerator"
-  
+
   it should "generate a single point for empty input" in {
     val generator = new DseSearchGenerator(Seq())
     generator.nextPoint() should equal(Some(None, PartialCompile(), SeqMap(), Refinements(), Refinements(), 0.0))

--- a/src/test/scala/edg_ide/util/tests/ObjectSerializerTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ObjectSerializerTest.scala
@@ -3,7 +3,7 @@ package edg_ide.util.tests
 import edg.ElemBuilder
 import edg.compiler.RangeValue
 import edg.wir.DesignPath
-import edg_ide.dse.{DseParameterSearch, DseSubclassSearch}
+import edg_ide.dse.{DsePathParameterSearch, DseSubclassSearch}
 import edg_ide.util.ObjectSerializer
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -18,7 +18,7 @@ class ObjectSerializerTest extends AnyFlatSpec with Matchers {
           "electronics_lib.BuckConverter_TexasInstruments.Tps54202h",
         ).map(value => ElemBuilder.LibraryPath(value))
       ),
-      DseParameterSearch(DesignPath() + "reg_5v" + "ripple_current_factor",
+      DsePathParameterSearch(DesignPath() + "reg_5v" + "ripple_current_factor",
         Seq(0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5).map(value => RangeValue(value - 0.05, value + 0.05))
       ),
     )


### PR DESCRIPTION
_DSE is an experimental feature that is not enabled by default._

Allows searching class-value refinements, for example minimum-SMD package for all standard SMD devices.

Infrastructural changes:
- Rename `DseParameterSearch` -> `DsePathParameterSearch`, to distinguish from the class-value search
- Support empty search configurations, it's equivalent to compile
- Other updates to be consistent with API changes in HDL submodule