### PR TITLE
Compilation flow and UI cleanup

### DIFF
--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -88,7 +88,7 @@ class LoggingPythonInterface(serverFile: File, pythonInterpreter: String, consol
 
   override def onLibraryRequest(element: ref.LibraryPath): Unit = {
     // this needs to be here to only print on requests that made it to Python (instead of just hit cache)
-    console.print(s"Compile ${element.toSimpleString}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
+    console.print(s"Compile ${element.toSimpleString}\n", ConsoleViewContentType.LOG_DEBUG_OUTPUT)
   }
 
   override def onLibraryRequestComplete(element: ref.LibraryPath,
@@ -105,7 +105,7 @@ class LoggingPythonInterface(serverFile: File, pythonInterpreter: String, consol
     val valuesString = values.map { case (path, value) => s"${ExprToString(path)}: ${value.toStringValue}" }
         .mkString(", ")
     console.print(s"Generate ${element.toSimpleString} ($valuesString)\n",
-      ConsoleViewContentType.LOG_INFO_OUTPUT)
+      ConsoleViewContentType.LOG_DEBUG_OUTPUT)
   }
 
   override def onElaborateGeneratorRequestComplete(element: ref.LibraryPath,
@@ -176,7 +176,7 @@ trait HasConsoleStages {
       fn
     }
     val addedStr = if (fnResultStr.nonEmpty) f": $fnResultStr" else ""
-    console.print(s"Completed: $name$addedStr ($fnTime ms)\n", ConsoleViewContentType.SYSTEM_OUTPUT)
+    console.print(s"Completed: $name$addedStr ($fnTime ms)\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
     fnResult
   }
 
@@ -237,7 +237,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
   private def runCompile(indicator: ProgressIndicator): Unit = {
     runThread = Some(Thread.currentThread())
     startNotify()
-    console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.SYSTEM_OUTPUT)
+    console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
 
     // This structure is quite nasty, but is needed to give a stream handle in case something crashes,
     // in which case pythonInterface is not a valid reference

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -191,7 +191,7 @@ trait HasConsoleStages {
       }
     } catch {
       case e: Exception =>
-        console.print(s"Failed: $e\n", ConsoleViewContentType.ERROR_OUTPUT)
+        console.print(s"Failed: $name: $e\n", ConsoleViewContentType.ERROR_OUTPUT)
         // By default, the stack trace isn't printed, since most of the internal details
         // (stack trace elements) aren't relevant for end users
         // TODO this should be plumbed to a toggle

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -178,6 +178,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
         val results = mutable.ListBuffer[DseResult]()
         runFailableStage("search", indicator) {
+          var index: Int = 0
           val searchGenerator = new DseSearchGenerator(options.searchConfigs)
           var nextPoint = searchGenerator.nextPoint()
           while (nextPoint.nonEmpty) {
@@ -192,7 +193,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
                 refinements = refinements ++ incrRefinements, partial = partialCompile)
             }
 
-            runFailableStage(s"point ${results.length}", indicator) {
+            runFailableStage(s"point $index", indicator) {
               val (compiled, compileTime) = timeExec {
                 compiler.compile()
               }
@@ -205,7 +206,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
                   objective -> objective.calculate(compiled, compiler)
                 })
 
-                val result = DseResult(results.length, pointValues,
+                val result = DseResult(index, pointValues,
                   searchRefinements, compiler, compiled, errors, objectiveValues, compileTime)
 
                 results.append(result)
@@ -230,6 +231,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
             searchGenerator.addEvaluatedPoint(compiler)
             nextPoint = searchGenerator.nextPoint()
+            index = index + 1
           }
           s"${results.length} configurations"
         }

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -182,52 +182,50 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
           var nextPoint = searchGenerator.nextPoint()
           while (nextPoint.nonEmpty) {
             val (baseCompilerOpt, partialCompile, pointValues, searchRefinements, incrRefinements, completedFraction) = nextPoint.get
-
             indicator.setIndeterminate(false)
             indicator.setFraction(completedFraction)
 
-            val ((compiler, compiled), compileTime) = timeExec {
-              val compiler = baseCompilerOpt match {
-                case Some(baseCompiler) => baseCompiler.fork(
-                  additionalRefinements = incrRefinements, partial = partialCompile)
-                case None => new Compiler(design, EdgCompilerService(project).pyLib,
-                  refinements = refinements ++ incrRefinements, partial = partialCompile)
-              }
-              val compiled = compiler.compile()
-              (compiler, compiled)
+            val compiler = baseCompilerOpt match {
+              case Some(baseCompiler) => baseCompiler.fork(
+                additionalRefinements = incrRefinements, partial = partialCompile)
+              case None => new Compiler(design, EdgCompilerService(project).pyLib,
+                refinements = refinements ++ incrRefinements, partial = partialCompile)
             }
 
-            if (partialCompile.isEmpty) { // only evaluate the point if it's a full point
-              val errors = compiler.getErrors() ++ new DesignAssertionCheck(compiler).map(compiled) ++
-                  new DesignStructuralValidate().map(compiled) ++ new DesignRefsValidate().validate(compiled)
+            runFailableStage(s"point ${results.length}", indicator) {
+              val (compiled, compileTime) = timeExec {
+                compiler.compile()
+              }
 
-              val objectiveValues = SeqMap.from(options.objectives.map { objective =>
-                objective -> objective.calculate(compiled, compiler)
-              })
+              if (partialCompile.isEmpty) { // only evaluate the point if it's a full point
+                val errors = compiler.getErrors() ++ new DesignAssertionCheck(compiler).map(compiled) ++
+                    new DesignStructuralValidate().map(compiled) ++ new DesignRefsValidate().validate(compiled)
 
-              val result = DseResult(results.length, pointValues,
-                searchRefinements, compiler, compiled, errors, objectiveValues, compileTime)
+                val objectiveValues = SeqMap.from(options.objectives.map { objective =>
+                  objective -> objective.calculate(compiled, compiler)
+                })
 
-              if (errors.nonEmpty) {
-                console.print(s"Result ${results.length}, ${errors.size} errors ($compileTime ms): ${result.objectiveToString}\n",
-                  ConsoleViewContentType.ERROR_OUTPUT)
+                val result = DseResult(results.length, pointValues,
+                  searchRefinements, compiler, compiled, errors, objectiveValues, compileTime)
+
+                results.append(result)
+                csvFile.foreach { csvFile =>
+                  csvFile.writeRow(result)
+                }
+
+                uiUpdater.runIfIdle { // only have one UI update in progress at any time
+                  System.gc() // clean up after this compile run
+                  BlockVisualizerService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, true)
+                }
+
+                if (errors.nonEmpty) {
+                  f"${errors.size} errors, ${result.objectiveToString}"
+                } else {
+                  result.objectiveToString
+                }
               } else {
-                console.print(s"Result ${results.length} ($compileTime ms): ${result.objectiveToString}\n",
-                  ConsoleViewContentType.SYSTEM_OUTPUT)
+                "intermediate point"
               }
-
-              results.append(result)
-              csvFile.foreach { csvFile =>
-                csvFile.writeRow(result)
-              }
-
-              uiUpdater.runIfIdle { // only have one UI update in progress at any time
-                System.gc() // clean up after this compile run
-                BlockVisualizerService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, true)
-              }
-            } else {
-              console.print(s"Intermediate point ($compileTime ms)\n",
-                ConsoleViewContentType.SYSTEM_OUTPUT)
             }
 
             searchGenerator.addEvaluatedPoint(compiler)

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -108,7 +108,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
   private def runCompile(indicator: ProgressIndicator): Unit = {
     runThread = Some(Thread.currentThread())
     startNotify()
-    console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.SYSTEM_OUTPUT)
+    console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
 
     // the UI update is in a thread so it doesn't block the main search loop
     val uiUpdater = new SingleThreadRunner()
@@ -122,7 +122,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
       DseCsvWriter(new FileWriter(options.resultCsvFile), options.searchConfigs, options.objectives) match {
         case Some(csv) =>
           console.print(s"Opening results CSV at ${options.resultCsvFile}\n",
-            ConsoleViewContentType.SYSTEM_OUTPUT)
+            ConsoleViewContentType.LOG_INFO_OUTPUT)
           Some(csv)
         case None =>
           console.print(s"Failed to open results CSV at ${options.resultCsvFile}\n",
@@ -173,7 +173,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
           partialCompile.blocks.toSet, partialCompile.params.toSet, partialCompile.classParams.toSet
         )
         if (!removedRefinements.isEmpty) {
-          console.print(s"Discarded conflicting refinements $removedRefinements\n", ConsoleViewContentType.SYSTEM_OUTPUT)
+          console.print(s"Discarded conflicting refinements $removedRefinements\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
         }
 
         val results = mutable.ListBuffer[DseResult]()

--- a/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
+++ b/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
@@ -51,7 +51,8 @@ object DesignAnalysisUtils {
 
   def isPyClassAbstract(pyClass: PyClass): Boolean = {
     val hasAbstractDecorator = Option(pyClass.getDecoratorList).map { decoratorList =>
-      decoratorList.getDecorators.exists(_.getName == "abstract_block")
+      decoratorList.getDecorators.exists(_.getName == "abstract_block") ||
+          decoratorList.getDecorators.exists(_.getName == "abstract_block_default")
     }
     hasAbstractDecorator.getOrElse(false)
   }


### PR DESCRIPTION
Various changes.
- Change console output to use LOG_* type, effectively green (debug level - for blocks being compiled) and yellow (info level - compiler output) to distinguish it from user Python prints (uncolored)
- Add name to failed log message in runFailableStage
- DSE: allow design points to fail without failing the whole thing
- DSE: include abstract_block_default when finding subclasses