### PR TITLE
Move UI operations to UI thread

### DIFF
--- a/src/main/scala/edg_ide/swing/TreeTableUtils.scala
+++ b/src/main/scala/edg_ide/swing/TreeTableUtils.scala
@@ -14,9 +14,11 @@ object TreeTableUtils {
   def updateModel(treeTable: TreeTable, newModel: TreeTableModel): Unit = {
     val savedNodes = getExpandedNodes(treeTable.getTree)
     val isRootVisible = treeTable.getTree.isRootVisible
+    val savedRenderer = treeTable.getTree.getCellRenderer
     treeTable.setModel(newModel)  // note that setModel resets TreeTable.getTree, so we need to get a fresh tree handle
     restoreExpandedNodes(treeTable.getTree, savedNodes)
     treeTable.setRootVisible(isRootVisible)
+    treeTable.getTree.setCellRenderer(savedRenderer)
   }
 
   // Returns the tree path of all expanded nodes (as sequence of node objects).

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -237,19 +237,17 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   private var dsePanelShown = false
   AppExecutorUtil.getAppScheduledExecutorService.scheduleWithFixedDelay(() => {
     val dseConfigSelected = BlockVisualizerService(project).getDseRunConfiguration.isDefined
-    println(s"$dseConfigSelected ? saved $dsePanelShown")
     if (dsePanelShown != dseConfigSelected) {
-      if (dseConfigSelected) {
-        mainSplitter.setSecondComponent(dseSplitter)
-        println(s"$dseConfigSelected SSC")
-        dseSplitter.setFirstComponent(bottomSplitter)
-        println(s"$dseConfigSelected SFC")
-      } else {
-        dseSplitter.setFirstComponent(null)
-        mainSplitter.setSecondComponent(bottomSplitter)
-      }
-      dsePanelShown = dseConfigSelected
-      println(s"$dseConfigSelected UPD")
+      dsePanelShown = dseConfigSelected  // set it now, so we don't get multiple invocations of the update
+      ApplicationManager.getApplication.invokeLater(() => {
+        if (dseConfigSelected) {
+          mainSplitter.setSecondComponent(dseSplitter)
+          dseSplitter.setFirstComponent(bottomSplitter)
+        } else {
+          dseSplitter.setFirstComponent(null)
+          mainSplitter.setSecondComponent(bottomSplitter)
+        }
+      })
     }
   }, 333, 333, TimeUnit.MILLISECONDS) // seems flakey without initial delay
 

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -237,15 +237,19 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   private var dsePanelShown = false
   AppExecutorUtil.getAppScheduledExecutorService.scheduleWithFixedDelay(() => {
     val dseConfigSelected = BlockVisualizerService(project).getDseRunConfiguration.isDefined
+    println(s"$dseConfigSelected ? saved $dsePanelShown")
     if (dsePanelShown != dseConfigSelected) {
       if (dseConfigSelected) {
         mainSplitter.setSecondComponent(dseSplitter)
+        println(s"$dseConfigSelected SSC")
         dseSplitter.setFirstComponent(bottomSplitter)
+        println(s"$dseConfigSelected SFC")
       } else {
         dseSplitter.setFirstComponent(null)
         mainSplitter.setSecondComponent(bottomSplitter)
       }
       dsePanelShown = dseConfigSelected
+      println(s"$dseConfigSelected UPD")
     }
   }, 333, 333, TimeUnit.MILLISECONDS) // seems flakey without initial delay
 

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -12,7 +12,7 @@ import edg_ide.dse._
 import edg_ide.psi_edits.{InsertAction, InsertRefinementAction}
 import edg_ide.runner.DseRunConfiguration
 import edg_ide.swing._
-import edg_ide.swing.dse.{DseConfigTreeNode, DseConfigTreeTableModel, DseResultNodeBase, DseResultTreeNode, DseResultTreeTableModel}
+import edg_ide.swing.dse.{DseConfigTreeNode, DseConfigTreeTableModel, DseResultNodeBase, DseResultTreeNode, DseResultTreeRenderer, DseResultTreeTableModel}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption}
 import edg_ide.util.{DesignAnalysisUtils, exceptable, exceptionPopup}
 
@@ -193,6 +193,7 @@ class DsePanel(project: Project) extends JPanel {
   // GUI: Bottom Tabs: Results
   //
   private val resultsTree = new TreeTable(new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false))
+  resultsTree.setTreeCellRenderer(new DseResultTreeRenderer)
   resultsTree.setShowColumns(true)
   resultsTree.setRootVisible(false)
   resultsTree.addMouseListener(new MouseAdapter {

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -102,13 +102,18 @@ class DsePanel(project: Project) extends JPanel {
   }, 333, 333, TimeUnit.MILLISECONDS)  // seems flakey without initial delay
 
   protected def onConfigUpdate(): Unit = {
+    println("onConfigChange")
     displayedConfig match {
       case Some(config) =>
+        println("setText")
         separator.setText(f"Design Space Exploration: ${config.getName}")
+        println("updateconfig")
         TreeTableUtils.updateModel(configTree,
           new DseConfigTreeTableModel(config.options.searchConfigs, config.options.objectives))
+        println("updateResults")
         TreeTableUtils.updateModel(resultsTree,
           new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false))  // clear existing data
+        println("OCU DONE")
       case _ =>
         separator.setText(f"Design Space Exploration: no run config selected")
         TreeTableUtils.updateModel(configTree,

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -1,5 +1,6 @@
 package edg_ide.ui
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.components.{JBScrollPane, JBTabbedPane}
@@ -102,24 +103,21 @@ class DsePanel(project: Project) extends JPanel {
   }, 333, 333, TimeUnit.MILLISECONDS)  // seems flakey without initial delay
 
   protected def onConfigUpdate(): Unit = {
-    println("onConfigChange")
-    displayedConfig match {
-      case Some(config) =>
-        println("setText")
-        separator.setText(f"Design Space Exploration: ${config.getName}")
-        println("updateconfig")
-        TreeTableUtils.updateModel(configTree,
-          new DseConfigTreeTableModel(config.options.searchConfigs, config.options.objectives))
-        println("updateResults")
-        TreeTableUtils.updateModel(resultsTree,
-          new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false))  // clear existing data
-        println("OCU DONE")
-      case _ =>
-        separator.setText(f"Design Space Exploration: no run config selected")
-        TreeTableUtils.updateModel(configTree,
-          new DseConfigTreeTableModel(Seq(), Seq()))
-        TreeTableUtils.updateModel(resultsTree,
-          new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false))  // clear existing data
+    ApplicationManager.getApplication.invokeLater(() => {
+      displayedConfig match {
+        case Some(config) =>
+          separator.setText(f"Design Space Exploration: ${config.getName}")
+          TreeTableUtils.updateModel(configTree,
+            new DseConfigTreeTableModel(config.options.searchConfigs, config.options.objectives))
+          TreeTableUtils.updateModel(resultsTree,
+            new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false)) // clear existing data
+        case _ =>
+          separator.setText(f"Design Space Exploration: no run config selected")
+          TreeTableUtils.updateModel(configTree,
+            new DseConfigTreeTableModel(Seq(), Seq()))
+          TreeTableUtils.updateModel(resultsTree,
+            new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false)) // clear existing data
+      }
     }
   }
 

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -118,7 +118,7 @@ class DsePanel(project: Project) extends JPanel {
           TreeTableUtils.updateModel(resultsTree,
             new DseResultTreeTableModel(new CombinedDseResultSet(Seq()), Seq(), false)) // clear existing data
       }
-    }
+    })
   }
 
   setLayout(new GridBagLayout())
@@ -231,8 +231,10 @@ class DsePanel(project: Project) extends JPanel {
   def setResults(results: Seq[DseResult], search: Seq[DseConfigElement], objectives: Seq[DseObjective],
                  inProgress: Boolean): Unit = {
     val combinedResults = new CombinedDseResultSet(results)
-    TreeTableUtils.updateModel(resultsTree,
-      new DseResultTreeTableModel(combinedResults, objectives, inProgress))
+    ApplicationManager.getApplication.invokeLater(() => {
+      TreeTableUtils.updateModel(resultsTree,
+        new DseResultTreeTableModel(combinedResults, objectives, inProgress))
+    })
     plot.setResults(combinedResults, search, objectives)
   }
 

--- a/src/main/scala/edg_ide/ui/DsePlotPanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePlotPanel.scala
@@ -1,5 +1,6 @@
 package edg_ide.ui
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.ComboBox
 import edg.compiler.{ExprValue, FloatValue, IntValue, RangeType, RangeValue}
 import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseObjectiveParameter, DseParameterSearch, DseResult}
@@ -155,7 +156,10 @@ class DsePlotPanel() extends JPanel {
           Some(SwingHtmlUtil.wrapInHtml(tooltipText, this.getFont))))
       case _ => Seq()
     }
-    plot.setData(points, xAxis, yAxis)
+
+    ApplicationManager.getApplication.invokeLater(() => {
+      plot.setData(points, xAxis, yAxis)
+    })
   }
 
   private def updateAxisSelectors(search: Seq[DseConfigElement], objectives: Seq[DseObjective]): Unit = {
@@ -211,27 +215,28 @@ class DsePlotPanel() extends JPanel {
         Seq(new DseObjectiveParamOrdinalAxis(objective))
       case objective => Seq(new DummyAxis(f"unknown ${objective.objectiveToString}"))
     }
-
-    xSelector.removeItemListener(axisSelectorListener)
-    ySelector.removeItemListener(axisSelectorListener)
-
-    xSelector.removeAllItems()
-    ySelector.removeAllItems()
-
-    xSelector.addItem(xAxisHeader)
-    ySelector.addItem(yAxisHeader)
-    items.foreach { item =>
-      xSelector.addItem(item)
-      ySelector.addItem(item)
-    }
-
-    xSelector.addItemListener(axisSelectorListener)
-    ySelector.addItemListener(axisSelectorListener)
     displayAxisSelector = (search, objectives)
 
-    // restore prior selection by name matching
-    items.find { item => item.toString == selectedX.toString }.foreach { item => xSelector.setItem(item) }
-    items.find { item => item.toString == selectedY.toString }.foreach { item => ySelector.setItem(item) }
+    ApplicationManager.getApplication.invokeLater(() => {
+      xSelector.removeItemListener(axisSelectorListener)
+      ySelector.removeItemListener(axisSelectorListener)
+
+      xSelector.removeAllItems()
+      ySelector.removeAllItems()
+
+      xSelector.addItem(xAxisHeader)
+      ySelector.addItem(yAxisHeader)
+      items.foreach { item =>
+        xSelector.addItem(item)
+        ySelector.addItem(item)
+      }
+
+      xSelector.addItemListener(axisSelectorListener)
+      ySelector.addItemListener(axisSelectorListener)
+      // restore prior selection by name matching
+      items.find { item => item.toString == selectedX.toString }.foreach { item => xSelector.setItem(item) }
+      items.find { item => item.toString == selectedY.toString }.foreach { item => ySelector.setItem(item) }
+    })
   }
 
   private val axisSelectorListener = new ItemListener() {

--- a/src/main/scala/edg_ide/ui/DsePlotPanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePlotPanel.scala
@@ -2,7 +2,7 @@ package edg_ide.ui
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.ComboBox
-import edg.compiler.{ExprValue, FloatValue, IntValue, RangeType, RangeValue}
+import edg.compiler.{CompilerError, ExprValue, FloatValue, IntValue, RangeType, RangeValue}
 import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseObjectiveParameter, DseParameterSearch, DseResult}
 import edg_ide.swing.SwingHtmlUtil
 import edg_ide.swing.dse.JScatterPlot
@@ -110,6 +110,8 @@ class DseConfigOrdinalAxis(config: DseConfigElement) extends PlotAxis {
 
 
 class DsePlotPanel() extends JPanel {
+  val kIdealConstraintName = "ideal model"
+
   // Data State
   private var combinedResults = new CombinedDseResultSet(Seq())  // reflects the data points
   private var displayAxisSelector: (Seq[DseConfigElement], Seq[DseObjective]) = (Seq(), Seq())  // reflects the widget display
@@ -146,10 +148,14 @@ class DsePlotPanel() extends JPanel {
 
     val points = flatResults.zip(xPoints.zip(yPoints)).toIndexedSeq.flatMap {
       case (result, (Some(xVal), Some(yVal))) =>
-        val color = if (result.errors.nonEmpty) {
-          Some(com.intellij.ui.JBColor.RED)
-        } else {
-          None
+        val (idealErrors, otherErrors) = result.errors.partition {
+          case CompilerError.FailedAssertion(_, constrName, _, _, _) if constrName == kIdealConstraintName => true
+          case _ => false
+        }
+        val color = (idealErrors.nonEmpty, otherErrors.nonEmpty) match {
+          case (_, true) => Some(com.intellij.ui.JBColor.RED)
+          case (true, false) => Some(com.intellij.ui.JBColor.ORANGE)
+          case (false, false) => None
         }
         val tooltipText = DseConfigElement.configMapToString(result.config)
         Some(new plot.Data(result, xVal, yVal, color,

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -527,8 +527,7 @@ class LibraryPanel(project: Project) extends JPanel {
   libraryTree.addMouseListener(libraryMouseListener)
   libraryTree.setRootVisible(false)
   libraryTree.setShowColumns(true)
-  private val libraryTreeRenderer = new EdgirLibraryTreeRenderer()
-  libraryTree.setTreeCellRenderer(libraryTreeRenderer)
+  libraryTree.setTreeCellRenderer(new EdgirLibraryTreeRenderer())
 
   private val libraryTreeScrollPane = new JBScrollPane(libraryTree)
   libraryTreePanel.add(libraryTreeScrollPane, Gbc(0, 1, GridBagConstraints.BOTH, xsize = 2))
@@ -583,7 +582,6 @@ class LibraryPanel(project: Project) extends JPanel {
     TreeTableUtils.updateModel(libraryTree, this.libraryTreeModel)
     updateFilter()
     libraryTree.getTree.addTreeSelectionListener(libraryTreeListener)
-    libraryTree.setTreeCellRenderer(libraryTreeRenderer)
   }
 
   // Configuration State


### PR DESCRIPTION
... otherwise the DSE UI panel would randomly stop working, without as much as an error message 🙃

Other changes:
- Infrastructure: save and restore tree cell renderer for TreeTable in updateModel util
  - Changes the library panel TreeTable to use this
- Update HDL repository, mainly updates names of converters and uses the base VoltageRegulator in the example
- DSE: color ideal points separately (orange) from error points (red)
- Color the DSE results TreeTable by the above