### PR TITLE
Unify mouse behavior with plot and tree view

### DIFF
--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -206,7 +206,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   addMouseListener(new MouseAdapter {
     override def mouseClicked(e: MouseEvent): Unit = {
       val clickedPoints = getPointsForLocation(e.getX, e.getY, kSnapDistancePx)
-      onClick(clickedPoints.sortBy(_._2).map(pair => data(pair._1)))
+      onClick(e, clickedPoints.sortBy(_._2).map(pair => data(pair._1)))
     }
   })
 
@@ -257,7 +257,7 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
   //
   // called when this widget clicked, for all points within some hover radius of the cursor
   // sorted by distance from cursor (earlier = closer), and may be empty
-  def onClick(data: Seq[Data]): Unit = { }
+  def onClick(e: MouseEvent, data: Seq[Data]): Unit = { }
 
   // called when the hovered-over data changes, for all points within some hover radius of the cursor
   // may be empty (when hovering over nothing)

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -164,11 +164,19 @@ class DsePanel(project: Project) extends JPanel {
 
         setSelection(data)
       } else if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) { // right click popup menu
-        if (data.size == 1) {
-          new DseResultPopupMenu(data.head, project).show(e.getComponent, e.getX, e.getY)
-        } else {
+        if (data.size != 1) {
           PopupUtils.createErrorPopupAtMouse("must select exactly one point", this)
+          return
         }
+        new DseResultPopupMenu(data.head, project).show(e.getComponent, e.getX, e.getY)
+      } else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) { // double click view result
+        if (data.size != 1) {
+          PopupUtils.createErrorPopupAtMouse("must select exactly one point", this)
+          return
+        }
+        val result = data.head
+        BlockVisualizerService(project).setDesignTop(result.compiled, result.compiler,
+          result.compiler.refinements.toPb, result.errors, Some(f"DSE ${result.index}: "))
       }
     }
 

--- a/src/main/scala/edg_ide/ui/DsePlotPanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePlotPanel.scala
@@ -8,7 +8,7 @@ import edg_ide.dse._
 import edg_ide.swing.SwingHtmlUtil
 import edg_ide.swing.dse.{DseResultModel, JScatterPlot}
 
-import java.awt.event.{ItemEvent, ItemListener}
+import java.awt.event.{ItemEvent, ItemListener, MouseEvent}
 import java.awt.{GridBagConstraints, GridBagLayout}
 import javax.swing.JPanel
 
@@ -118,8 +118,8 @@ class DsePlotPanel() extends JPanel {
   setLayout(new GridBagLayout)
 
   private val plot = new JScatterPlot[DseResult]() {
-    override def onClick(data: Seq[Data]): Unit = {
-      DsePlotPanel.this.onClick(data.map(_.value))
+    override def onClick(e: MouseEvent, data: Seq[Data]): Unit = {
+      DsePlotPanel.this.onClick(e, data.map(_.value))
     }
 
     override def onHoverChange(data: Seq[Data]): Unit = {
@@ -267,7 +267,7 @@ class DsePlotPanel() extends JPanel {
   //
   // called when this widget clicked, for all points within some hover radius of the cursor
   // sorted by distance from cursor (earlier = closer), and may be empty
-  def onClick(results: Seq[DseResult]): Unit = {}
+  def onClick(e: MouseEvent, results: Seq[DseResult]): Unit = {}
 
   // called when the hovered-over data changes, for all points within some hover radius of the cursor
   // may be empty (when hovering over nothing)


### PR DESCRIPTION
Both can now insert refinements and go to the main block diagram visualizer