### PR TITLE
UI refactoring and cleanup

### DIFF
--- a/src/main/java/edg_ide/ui/BlockVisualizerServiceWrapper.java
+++ b/src/main/java/edg_ide/ui/BlockVisualizerServiceWrapper.java
@@ -15,9 +15,6 @@ class BlockVisualizerServiceState {
   public int panelTabIndex = 0;
   public float libraryPreviewSplitterPos = 0.5f;
   public float dseSplitterPos = 0.66f;
-
-  // DSE Panel
-  public int dseTabIndex = 0;
 }
 
 

--- a/src/main/java/edg_ide/ui/DseServiceWrapper.java
+++ b/src/main/java/edg_ide/ui/DseServiceWrapper.java
@@ -1,0 +1,22 @@
+package edg_ide.ui;
+
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.components.StoragePathMacros;
+import com.intellij.openapi.project.Project;
+
+
+// PersistentStateComponent doesn't seem to like Scala classes, so here it is in Java.
+class DseServiceState {
+  // DSE Panel
+  public int dseTabIndex = 0;
+}
+
+
+// Needed separate from DseService because IntelliJ doesn't seem to like the Scala class.
+@State(name = "DseServiceWrapper", storages = @Storage(StoragePathMacros.WORKSPACE_FILE))
+public class DseServiceWrapper extends DseService {
+  public DseServiceWrapper(Project project) {
+    super(project);
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,7 @@
             displayName="EDG IDE"/>
 
     <projectService serviceImplementation="edg_ide.ui.BlockVisualizerServiceWrapper"/>
+    <projectService serviceImplementation="edg_ide.ui.DseServiceWrapper"/>
     <projectService serviceImplementation="edg_ide.ui.EdgCompilerServiceWrapper"/>
 
     <codeInsight.lineMarkerProvider language="Python"

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -10,7 +10,7 @@ import edg.compiler._
 import edg.util.{StreamUtils, timeExec}
 import edg.wir.Refinements
 import edg_ide.dse.{DseConfigElement, DseObjective, DseResult, DseSearchGenerator}
-import edg_ide.ui.{BlockVisualizerService, EdgCompilerService}
+import edg_ide.ui.{BlockVisualizerService, DseService, EdgCompilerService}
 import edgir.schema.schema
 
 import java.io.{FileWriter, OutputStream, PrintWriter, StringWriter}
@@ -113,7 +113,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
     // the UI update is in a thread so it doesn't block the main search loop
     val uiUpdater = new SingleThreadRunner()
     uiUpdater.runIfIdle {  // show searching in UI
-      BlockVisualizerService(project).setDseResults(Seq(), options.searchConfigs, options.objectives, true)
+      DseService(project).setDseResults(Seq(), options.searchConfigs, options.objectives, true)
     }
 
     // Open a CSV file (if desired) and write result rows as they are computed.
@@ -222,7 +222,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
                 }
 
                 uiUpdater.runIfIdle { // only have one UI update in progress at any time
-                  BlockVisualizerService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, true)
+                  DseService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, true)
                 }
 
                 if (errors.nonEmpty) {
@@ -244,7 +244,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
         runFailableStage("update visualization", indicator) {
           uiUpdater.join()  // wait for pending UI updates to finish before updating to final value
-          BlockVisualizerService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, false)
+          DseService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, false)
           System.gc() // clean up after this compile run  TODO: we can GC more often if we can prune the completed compiler
           ""
         }

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -113,7 +113,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
     // the UI update is in a thread so it doesn't block the main search loop
     val uiUpdater = new SingleThreadRunner()
     uiUpdater.runIfIdle {  // show searching in UI
-      DseService(project).setDseResults(Seq(), options.searchConfigs, options.objectives, true)
+      DseService(project).setResults(Seq(), options.searchConfigs, options.objectives, true, true)
     }
 
     // Open a CSV file (if desired) and write result rows as they are computed.
@@ -222,7 +222,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
                 }
 
                 uiUpdater.runIfIdle { // only have one UI update in progress at any time
-                  DseService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, true)
+                  DseService(project).setResults(results.toSeq, options.searchConfigs, options.objectives, true, false)
                 }
 
                 if (errors.nonEmpty) {
@@ -244,7 +244,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
 
         runFailableStage("update visualization", indicator) {
           uiUpdater.join()  // wait for pending UI updates to finish before updating to final value
-          DseService(project).setDseResults(results.toSeq, options.searchConfigs, options.objectives, false)
+          DseService(project).setResults(results.toSeq, options.searchConfigs, options.objectives, false, false)
           System.gc() // clean up after this compile run  TODO: we can GC more often if we can prune the completed compiler
           ""
         }

--- a/src/main/scala/edg_ide/swing/ProvenTableRenderer.scala
+++ b/src/main/scala/edg_ide/swing/ProvenTableRenderer.scala
@@ -1,12 +1,13 @@
 package edg_ide.swing
 
-import com.intellij.ui.treeStructure.treetable.TreeTable
+import com.intellij.ui.treeStructure.treetable.{TreeTable, TreeTableModel}
 import edg_ide.proven.ProvenStatus
 
 import java.awt.Component
 import java.awt.event.MouseEvent
 import javax.swing.JTable
 import javax.swing.table.DefaultTableCellRenderer
+import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 // Mixin that adds hover tooltip and cell coloring for TreeTable cells with a Proven column
 trait ProvenTreeTableMixin extends TreeTable {
@@ -17,6 +18,15 @@ trait ProvenTreeTableMixin extends TreeTable {
     getValueAt(rowAtPoint(e.getPoint), columnAtPoint(e.getPoint)) match {
       case cell: BlockProven => SwingHtmlUtil.wrapInHtml(cell.htmlDescription, getFont)
       case _ => super.getToolTipText(e)
+    }
+  }
+
+  override def setModel(treeTableModel: TreeTableModel): Unit = {
+    super.setModel(treeTableModel)
+    getColumnModel.getColumns.asScala.foreach { column =>  // must support the case where the column isn't shown
+      if (column.getIdentifier == "Proven") {
+        column.setPreferredWidth(32)
+      }
     }
   }
 }

--- a/src/main/scala/edg_ide/swing/ZoomDragScrollPanel.scala
+++ b/src/main/scala/edg_ide/swing/ZoomDragScrollPanel.scala
@@ -1,6 +1,6 @@
 package edg_ide.swing
 
-import java.awt.{Event, Point}
+import java.awt.Point
 import java.awt.event.{MouseAdapter, MouseEvent, MouseWheelEvent}
 import javax.swing.{JComponent, JScrollPane, SwingUtilities}
 

--- a/src/main/scala/edg_ide/swing/dse/DseConfigTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/dse/DseConfigTreeTableModel.scala
@@ -35,10 +35,10 @@ object DseConfigTreeNode {
   class Root(configs: Seq[DseConfigElement], objectives: Seq[DseObjective]) extends DseConfigTreeNode {
     override val path = ""
     override val value = ""
-    override lazy val children = Seq(
-      new SearchConfigs(configs),
-      new Objectives(objectives)
-    )
+
+    lazy val searchConfigNode = new SearchConfigs(configs)
+    lazy val objectivesNode = new Objectives(objectives)
+    override lazy val children = Seq(searchConfigNode, objectivesNode)
   }
 
   class SearchConfigs(configs: Seq[DseConfigElement]) extends DseConfigTreeNode {
@@ -90,7 +90,7 @@ object DseConfigTreeNode {
 
 class DseConfigTreeTableModel(searchConfigs: Seq[DseConfigElement], objectives: Seq[DseObjective])
     extends SeqTreeTableModel[SeqNodeBase] {
-  val rootNode: SeqNodeBase = new DseConfigTreeNode.Root(searchConfigs, objectives)
+  val rootNode = new DseConfigTreeNode.Root(searchConfigs, objectives)
   val COLUMNS = Seq("Path", "Value")
 
   // TreeView abstract methods

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -248,26 +248,26 @@ class JScatterPlot[ValueType] extends JComponent with Scrollable {
 
   // TODO unify w/ ZoomDragScrollPanel
   private val dragListener = new MouseAdapter {
-    var dragOrigin: Option[Point] = None  // mouse origin, viewport origin
+    var dragLastPos: Option[Point] = None
 
     override def mousePressed(e: MouseEvent): Unit = {
       if (SwingUtilities.isLeftMouseButton(e)) {
-        dragOrigin = Some(e.getPoint)
+        dragLastPos = Some(e.getPoint)
       }
     }
 
     override def mouseReleased(e: MouseEvent): Unit = {
-      dragOrigin = None
+      dragLastPos = None
     }
 
     override def mouseDragged(e: MouseEvent): Unit = {
       if (SwingUtilities.isLeftMouseButton(e)) {
-        dragOrigin.foreach { dragOrigin =>
-          val dx = (dragOrigin.getX - e.getX).toFloat * (xRange._2 - xRange._1) / getWidth
-          val dy = (dragOrigin.getY - e.getY).toFloat * (yRange._2 - yRange._1) / getHeight
+        dragLastPos.foreach { lastPos =>
+          val dx = (lastPos.getX - e.getX).toFloat * (xRange._2 - xRange._1) / getWidth
+          val dy = (lastPos.getY - e.getY).toFloat * (yRange._2 - yRange._1) / getHeight
           xRange = (xRange._1 + dx, xRange._2 + dx)
           yRange = (yRange._1 - dy, yRange._2 - dy)
-          this.dragOrigin = Some(e.getPoint)
+          this.dragLastPos = Some(e.getPoint)
 
           validate()
           repaint()

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -236,7 +236,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   // Regularly check the selected run config and show the DSE panel if a DSE config is selected
   private var dsePanelShown = false
   AppExecutorUtil.getAppScheduledExecutorService.scheduleWithFixedDelay(() => {
-    val dseConfigSelected = BlockVisualizerService(project).getDseRunConfiguration.isDefined
+    val dseConfigSelected = DseService(project).getDseRunConfiguration.isDefined
     if (dsePanelShown != dseConfigSelected) {
       dsePanelShown = dseConfigSelected  // set it now, so we don't get multiple invocations of the update
       ApplicationManager.getApplication.invokeLater(() => {
@@ -494,7 +494,6 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     detailPanel.saveState(state)
     errorPanel.saveState(state)
     kicadVizPanel.saveState(state)
-    dsePanel.saveState(state)
   }
 
   def loadState(state: BlockVisualizerServiceState): Unit = {
@@ -507,7 +506,6 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     detailPanel.loadState(state)
     errorPanel.loadState(state)
     kicadVizPanel.loadState(state)
-    dsePanel.loadState(state)
   }
 }
 

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -395,6 +395,23 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     updateDisplay()
   }
 
+  /** Clears the existing design
+    */
+  def clearDesign(): Unit = {
+    this.refinements = edgrpc.Refinements()
+    setDesign(schema.Design(), new Compiler(schema.Design(), EdgCompilerService(project).pyLib))
+    tabbedPane.setTitleAt(TAB_INDEX_ERRORS, s"Errors")
+    errorPanel.setErrors(Seq(), compiler)
+
+    ApplicationManager.getApplication.invokeLater(() => {
+      toolWindow.setTitle("")
+    })
+
+    if (activeTool != defaultTool) { // revert to the default tool
+      toolInterface.endTool() // TODO should we also preserve state like selected?
+    }
+  }
+
   /** Updates the visualizations / trees / other displays, without recompiling or changing (explicit) state.
     * Does not update visualizations that are unaffected by operations that don't change the design.
     */

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -236,7 +236,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   // Regularly check the selected run config and show the DSE panel if a DSE config is selected
   private var dsePanelShown = false
   AppExecutorUtil.getAppScheduledExecutorService.scheduleWithFixedDelay(() => {
-    val dseConfigSelected = DseService(project).getDseRunConfiguration.isDefined
+    val dseConfigSelected = DseService(project).getRunConfiguration.isDefined
     if (dsePanelShown != dseConfigSelected) {
       dsePanelShown = dseConfigSelected  // set it now, so we don't get multiple invocations of the update
       ApplicationManager.getApplication.invokeLater(() => {

--- a/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
@@ -60,6 +60,10 @@ class BlockVisualizerService(project: Project) extends
     visualizerPanelOption.foreach(_.setDesignTop(design, compiler, refinements, errors, namePrefix))
   }
 
+  def clearDesign(): Unit = {
+    visualizerPanelOption.foreach(_.clearDesign())
+  }
+
   def getDesign: Option[schema.Design] = {
     visualizerPanelOption.map(_.getDesign)
   }

--- a/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
@@ -1,26 +1,17 @@
 package edg_ide.ui
 
-import com.intellij.execution.RunManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
-import edg.EdgirUtils.SimpleLibraryPath
 import edg.compiler.{Compiler, CompilerError, PythonInterfaceLibrary}
-import edg.util.Errorable
-import edgir.schema.schema
-import edgir.elem.elem
-import edgir.ref.ref
 import edg.wir.DesignPath
-import edg_ide.dse.{DseConfigElement, DseObjective, DseResult}
 import edg_ide.proven.{ProvenDataReader, ProvenDatabase}
-import edg_ide.runner.{DseConfigurationFactory, DseRunConfiguration, DseRunConfigurationType}
-import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption}
-import edg_ide.util.exceptable
+import edgir.elem.elem
+import edgir.schema.schema
 import edgrpc.hdl.{hdl => edgrpc}
 
 import java.io.File
-import scala.collection.SeqMap
 
 
 // Note: the implementation is here, but the actual service in plugin.xml is a Java class,
@@ -73,60 +64,13 @@ class BlockVisualizerService(project: Project) extends
     visualizerPanelOption.map(_.getDesign)
   }
 
-  // DSE Feature
-  //
-  // TODO maybe separate DSE functionality into its own class / service?
-  // but this is mixed into the block diagram visualizer panel and the two are quite linked
-
-  // Called when the run configuration changes
-  def onDseConfigChanged(config: DseRunConfiguration): Unit = {
-    dsePanelOption.foreach(_.onConfigChange(config))
-  }
-
-  // Returns the currently selected run configuration, if it is a DSE configuration
-  def getDseRunConfiguration: Option[DseRunConfiguration] = {
-    Option(RunManager.getInstance(project).getSelectedConfiguration)
-        .map(_.getConfiguration)
-        .collect { case config: DseRunConfiguration => config }
-  }
-
-  def getOrCreateDseRunConfiguration(blockType: ref.LibraryPath): DseRunConfiguration = {
-    val existingConfig = Option(RunManager.getInstance(project).getSelectedConfiguration)
-        .map(_.getConfiguration)
-        .collect { case config: DseRunConfiguration => config } match {
-      case Some(existingConfig) if existingConfig.options.designName == blockType.toFullString =>
-        Some(existingConfig)
-      case _ => None
-    }
-    existingConfig.getOrElse {  // if no existing config of the type, create a new one
-      val runManager = RunManager.getInstance(project)
-      val newRunnerConfig = runManager.createConfiguration(
-        blockType.toFullString, new DseConfigurationFactory(new DseRunConfigurationType))
-      runManager.addConfiguration(newRunnerConfig)
-      runManager.setSelectedConfiguration(newRunnerConfig)
-
-      val newConfig = newRunnerConfig.getConfiguration.asInstanceOf[DseRunConfiguration]
-      newConfig.options.designName = blockType.toFullString
-      newConfig
-    }
-  }
-
-  def addDseConfig(blockType: ref.LibraryPath, newConfig: DseConfigElement): Unit = {
-    val config = getOrCreateDseRunConfiguration(blockType)
-    config.options.searchConfigs = config.options.searchConfigs ++ Seq(newConfig)
-    onDseConfigChanged(config)
-  }
-
-  def setDseResults(results: Seq[DseResult], search: Seq[DseConfigElement], objectives: Seq[DseObjective],
-                    inProgress: Boolean): Unit = {
-    dsePanelOption.foreach(_.setResults(results, search, objectives, inProgress))
-  }
 
   // Proven feature
   //
   lazy val getProvenDatabase: ProvenDatabase = {
     ProvenDataReader.read(new File("src/main/resources/proven-designs/data.csv"))
   }
+
 
   // State management
   //

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -91,7 +91,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DsePathParameterSearch(directPath, Seq(value))
       DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        DseService(project).addDseConfig(rootClass, newConfig)
+        DseService(project).addConfig(rootClass, newConfig)
       }).exceptError
     }, s"Search values for instance $path"))
 
@@ -100,7 +100,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DseClassParameterSearch(blockClass, postfix, Seq(value))
       (DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        DseService(project).addDseConfig(rootClass, newConfig)
+        DseService(project).addConfig(rootClass, newConfig)
       }).exceptError, s"Search values of class ${blockClass.toSimpleString}:${ExprToString(postfix)}")
     }, s"Search values of class"))
 
@@ -109,7 +109,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DseClassParameterSearch(paramDefiningClass, postfix, Seq(value))
       (DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        DseService(project).addDseConfig(rootClass, newConfig)
+        DseService(project).addConfig(rootClass, newConfig)
       }).exceptError, s"Search values of param-defining class ${paramDefiningClass.toSimpleString}:${ExprToString(postfix)}")
     }, s"Search values of param-defining class"))
 
@@ -121,9 +121,9 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       }
 
       () => {
-        val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
+        val config = DseService(project).getOrCreateRunConfiguration(rootClass)
         config.options.objectives = config.options.objectives :+ objective
-        DseService(project).onDseConfigChanged(config)
+        DseService(project).onObjectiveConfigChanged(config)
       }
     }, "Add objective"))
   }

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -91,7 +91,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DsePathParameterSearch(directPath, Seq(value))
       DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        BlockVisualizerService(project).addDseConfig(rootClass, newConfig)
+        DseService(project).addDseConfig(rootClass, newConfig)
       }).exceptError
     }, s"Search values for instance $path"))
 
@@ -100,7 +100,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DseClassParameterSearch(blockClass, postfix, Seq(value))
       (DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        BlockVisualizerService(project).addDseConfig(rootClass, newConfig)
+        DseService(project).addDseConfig(rootClass, newConfig)
       }).exceptError, s"Search values of class ${blockClass.toSimpleString}:${ExprToString(postfix)}")
     }, s"Search values of class"))
 
@@ -109,7 +109,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DseClassParameterSearch(paramDefiningClass, postfix, Seq(value))
       (DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        BlockVisualizerService(project).addDseConfig(rootClass, newConfig)
+        DseService(project).addDseConfig(rootClass, newConfig)
       }).exceptError, s"Search values of param-defining class ${paramDefiningClass.toSimpleString}:${ExprToString(postfix)}")
     }, s"Search values of param-defining class"))
 
@@ -121,9 +121,9 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       }
 
       () => {
-        val config = BlockVisualizerService(project).getOrCreateDseRunConfiguration(rootClass)
+        val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
         config.options.objectives = config.options.objectives :+ objective
-        BlockVisualizerService(project).onDseConfigChanged(config)
+        DseService(project).onDseConfigChanged(config)
       }
     }, "Add objective"))
   }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -268,17 +268,27 @@ class DsePanel(project: Project) extends JPanel {
   def focusConfigSearch(): Unit = {
     tabbedPane.setSelectedIndex(kTabConfig)
 
-    val treeRoot = configTree.getTableModel.asInstanceOf[DseConfigTreeTableModel].rootNode
-    val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.searchConfigNode)
-    configTree.getTree.expandPath(nodePath)
+    // this makes the expansion fire AFTER the model is set (on the UI thread too), otherwise it
+    // tries (and fails) to expand a node with no children (yet)
+    // TODO this is kind of ugly
+    ApplicationManager.getApplication.invokeLater(() => {
+      val treeRoot = configTree.getTableModel.asInstanceOf[DseConfigTreeTableModel].rootNode
+      val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.searchConfigNode)
+      configTree.getTree.expandPath(nodePath)
+    })
   }
 
   def focusConfigObjective(): Unit = {
     tabbedPane.setSelectedIndex(kTabConfig)
 
-    val treeRoot = configTree.getTableModel.asInstanceOf[DseConfigTreeTableModel].rootNode
-    val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.objectivesNode)
-    configTree.getTree.expandPath(nodePath)
+    // this makes the expansion fire AFTER the model is set (on the UI thread too), otherwise it
+    // tries (and fails) to expand a node with no children (yet)
+    // TODO this is kind of ugly
+    ApplicationManager.getApplication.invokeLater(() => {
+      val treeRoot = configTree.getTableModel.asInstanceOf[DseConfigTreeTableModel].rootNode
+      val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.objectivesNode)
+      configTree.getTree.expandPath(nodePath)
+    })
   }
 
   def focusResults(): Unit = {

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -2,7 +2,7 @@ package edg_ide.ui
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
-import com.intellij.ui.JBSplitter
+import com.intellij.ui.{JBSplitter, TitledSeparator}
 import com.intellij.ui.components.{JBScrollPane, JBTabbedPane}
 import com.intellij.ui.dsl.builder.impl.CollapsibleTitledSeparator
 import com.intellij.ui.treeStructure.treetable.TreeTable
@@ -129,8 +129,7 @@ class DsePanel(project: Project) extends JPanel {
 
   setLayout(new GridBagLayout())
 
-  // TODO make the collapse function actually work
-  private val separator = new CollapsibleTitledSeparator("Design Space Exploration")
+  private val separator = new TitledSeparator("Design Space Exploration")
   add(separator, Gbc(0, 0, GridBagConstraints.HORIZONTAL))
 
   private val mainSplitter = new JBSplitter(true, 0.5f, 0.1f, 0.9f)

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -39,24 +39,24 @@ object DseSearchConfigPopupMenu {
 
 class DseSearchConfigPopupMenu(searchConfig: DseConfigElement, project: Project) extends JPopupMenu {
   add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
-    val dseConfig = DseService(project).getDseRunConfiguration.exceptNone("no run config")
+    val dseConfig = DseService(project).getRunConfiguration.exceptNone("no run config")
     val originalSearchConfigs = dseConfig.options.searchConfigs
     val found = originalSearchConfigs.find(searchConfig == _).exceptNone("search config not in config")
     () => {
       dseConfig.options.searchConfigs = originalSearchConfigs.filter(_ != found)
-      DseService(project).onDseConfigChanged(dseConfig)
+      DseService(project).onSearchConfigChanged(dseConfig)
     }
   }, s"Delete"))
 
   add(ContextMenuUtils.MenuItemFromErrorable(
     DseSearchConfigPopupMenu.createParamSearchEditPopup(searchConfig, project, { newConfig =>
         exceptionPopup.atMouse(this) {
-          val dseConfig = DseService(project).getDseRunConfiguration.exceptNone("no run config")
+          val dseConfig = DseService(project).getRunConfiguration.exceptNone("no run config")
           val originalSearchConfigs = dseConfig.options.searchConfigs
           val index = originalSearchConfigs.indexOf(searchConfig).exceptEquals(-1, "config not found")
           val newSearchConfigs = originalSearchConfigs.patch(index, Seq(newConfig), 1)
           dseConfig.options.searchConfigs = newSearchConfigs
-          DseService(project).onDseConfigChanged(dseConfig)
+          DseService(project).onSearchConfigChanged(dseConfig)
         }
     }), s"Edit"))
 }
@@ -64,11 +64,11 @@ class DseSearchConfigPopupMenu(searchConfig: DseConfigElement, project: Project)
 
 class DseObjectivePopupMenu(objective: DseObjective, project: Project) extends JPopupMenu {
   add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
-    val dseConfig = DseService(project).getDseRunConfiguration.exceptNone("no run config")
+    val dseConfig = DseService(project).getRunConfiguration.exceptNone("no run config")
     val originalObjectives = dseConfig.options.objectives
     () => {
       dseConfig.options.objectives = originalObjectives.filter(_ != objective)
-      DseService(project).onDseConfigChanged(dseConfig)
+      DseService(project).onObjectiveConfigChanged(dseConfig)
     }
   }, s"Delete"))
 }
@@ -101,7 +101,7 @@ class DsePanel(project: Project) extends JPanel {
 
   // Regularly check the selected run config so the panel contents are kept in sync
   AppExecutorUtil.getAppScheduledExecutorService.scheduleWithFixedDelay(() => {
-    val newConfig = DseService(project).getDseRunConfiguration
+    val newConfig = DseService(project).getRunConfiguration
     if (newConfig != displayedConfig) {
       displayedConfig = newConfig
       onConfigUpdate()
@@ -273,7 +273,7 @@ class DsePanel(project: Project) extends JPanel {
     tabbedPane.setSelectedIndex(kTabConfig)
   }
 
-  def focusConfigResults(): Unit = {
+  def focusResults(): Unit = {
     tabbedPane.setSelectedIndex(kTabResults)
   }
 

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -267,10 +267,18 @@ class DsePanel(project: Project) extends JPanel {
 
   def focusConfigSearch(): Unit = {
     tabbedPane.setSelectedIndex(kTabConfig)
+
+    val treeRoot = configTree.getTableModel.asInstanceOf[DseConfigTreeTableModel].rootNode
+    val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.searchConfigNode)
+    configTree.getTree.expandPath(nodePath)
   }
 
   def focusConfigObjective(): Unit = {
     tabbedPane.setSelectedIndex(kTabConfig)
+
+    val treeRoot = configTree.getTableModel.asInstanceOf[DseConfigTreeTableModel].rootNode
+    val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.objectivesNode)
+    configTree.getTree.expandPath(nodePath)
   }
 
   def focusResults(): Unit = {

--- a/src/main/scala/edg_ide/ui/DseService.scala
+++ b/src/main/scala/edg_ide/ui/DseService.scala
@@ -76,6 +76,7 @@ class DseService(project: Project) extends
   }
 
   override def loadState(state: DseServiceState): Unit = {
+    // TODO: nothing actually propagates this to the panel, and state doesn't get saved
     initialState = Some(state)
   }
 

--- a/src/main/scala/edg_ide/ui/DseService.scala
+++ b/src/main/scala/edg_ide/ui/DseService.scala
@@ -1,0 +1,83 @@
+package edg_ide.ui
+
+import com.intellij.execution.RunManager
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.project.Project
+import edg.EdgirUtils.SimpleLibraryPath
+import edg_ide.dse.{DseConfigElement, DseObjective, DseResult}
+import edg_ide.runner.{DseConfigurationFactory, DseRunConfiguration, DseRunConfigurationType}
+import edgir.ref.ref
+
+
+object DseService {
+  def apply(project: Project): DseService = {
+    project.getService(classOf[DseServiceWrapper]).asInstanceOf[DseService]
+  }
+}
+
+class DseService(project: Project) extends
+    PersistentStateComponent[DseServiceState] with Disposable {
+  private def dsePanelOption: Option[DsePanel] = BlockVisualizerService(project).visualizerPanelOption.map(_.getDsePanel)
+  private var initialState: Option[DseServiceState] = None
+
+  // Called when the run configuration changes
+  def onDseConfigChanged(config: DseRunConfiguration): Unit = {
+    dsePanelOption.foreach(_.onConfigChange(config))
+  }
+
+  // Returns the currently selected run configuration, if it is a DSE configuration
+  def getDseRunConfiguration: Option[DseRunConfiguration] = {
+    Option(RunManager.getInstance(project).getSelectedConfiguration)
+        .map(_.getConfiguration)
+        .collect { case config: DseRunConfiguration => config }
+  }
+
+  def getOrCreateDseRunConfiguration(blockType: ref.LibraryPath): DseRunConfiguration = {
+    val existingConfig = Option(RunManager.getInstance(project).getSelectedConfiguration)
+        .map(_.getConfiguration)
+        .collect { case config: DseRunConfiguration => config } match {
+      case Some(existingConfig) if existingConfig.options.designName == blockType.toFullString =>
+        Some(existingConfig)
+      case _ => None
+    }
+    existingConfig.getOrElse { // if no existing config of the type, create a new one
+      val runManager = RunManager.getInstance(project)
+      val newRunnerConfig = runManager.createConfiguration(
+        blockType.toFullString, new DseConfigurationFactory(new DseRunConfigurationType))
+      runManager.addConfiguration(newRunnerConfig)
+      runManager.setSelectedConfiguration(newRunnerConfig)
+
+      val newConfig = newRunnerConfig.getConfiguration.asInstanceOf[DseRunConfiguration]
+      newConfig.options.designName = blockType.toFullString
+      newConfig
+    }
+  }
+
+  def addDseConfig(blockType: ref.LibraryPath, newConfig: DseConfigElement): Unit = {
+    val config = getOrCreateDseRunConfiguration(blockType)
+    config.options.searchConfigs = config.options.searchConfigs ++ Seq(newConfig)
+    onDseConfigChanged(config)
+  }
+
+  def setDseResults(results: Seq[DseResult], search: Seq[DseConfigElement], objectives: Seq[DseObjective],
+                    inProgress: Boolean): Unit = {
+    dsePanelOption.foreach(_.setResults(results, search, objectives, inProgress))
+  }
+
+  // State management
+  //
+  override def getState: DseServiceState = {
+    val state = new DseServiceState
+    dsePanelOption.foreach {
+      _.saveState(state)
+    }
+    state
+  }
+
+  override def loadState(state: DseServiceState): Unit = {
+    initialState = Some(state)
+  }
+
+  override def dispose(): Unit = {}
+}

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -128,11 +128,11 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
           if (subclasses.isEmpty) {
             PopupUtils.createErrorPopupAtMouse(s"${blockPyClass.getName} has no non-abstract subclasses", this)
           } else {
-            val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
+            val config = DseService(project).getOrCreateRunConfiguration(rootClass)
             config.options.searchConfigs = config.options.searchConfigs ++ Seq(
               DseSubclassSearch(path, subclasses.toSeq)
             )
-            DseService(project).onDseConfigChanged(config)
+            DseService(project).onSearchConfigChanged(config)
           }
         }).inSmartMode(project).submit(AppExecutorUtil.getAppExecutorService)
       }
@@ -140,20 +140,20 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
     add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
       requireExcept(block.params.toSeqMap.contains("matching_parts"), "block must have matching_parts")
       () => {
-        val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
+        val config = DseService(project).getOrCreateRunConfiguration(rootClass)
         config.options.searchConfigs = config.options.searchConfigs ++ Seq(DseDerivedPartSearch(path))
-        DseService(project).onDseConfigChanged(config)
+        DseService(project).onSearchConfigChanged(config)
     }}, "Search matching parts"))
 
     add(ContextMenuUtils.MenuItem(() => {
-      val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
+      val config = DseService(project).getOrCreateRunConfiguration(rootClass)
       config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintArea(path))
-      DseService(project).onDseConfigChanged(config)
+      DseService(project).onObjectiveConfigChanged(config)
     }, "Add objective contained footprint area"))
     add(ContextMenuUtils.MenuItem(() => {
-      val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
+      val config = DseService(project).getOrCreateRunConfiguration(rootClass)
       config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintCount(path))
-      DseService(project).onDseConfigChanged(config)
+      DseService(project).onObjectiveConfigChanged(config)
     }, "Add objective contained footprint count"))
   }
 }

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -9,7 +9,7 @@ import edg.util.Errorable
 import edg.wir.DesignPath
 import edg.wir.ProtoUtil.ParamProtoToSeqMap
 import edg_ide.dse._
-import edg_ide.ui.{BlockVisualizerService, ContextMenuUtils, PopupUtils}
+import edg_ide.ui.{BlockVisualizerService, ContextMenuUtils, DseService, PopupUtils}
 import edg_ide.util.ExceptionNotifyImplicits.ExceptErrorable
 import edg_ide.util._
 import edg_ide.{EdgirUtils, PsiUtils}
@@ -128,11 +128,11 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
           if (subclasses.isEmpty) {
             PopupUtils.createErrorPopupAtMouse(s"${blockPyClass.getName} has no non-abstract subclasses", this)
           } else {
-            val config = BlockVisualizerService(project).getOrCreateDseRunConfiguration(rootClass)
+            val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
             config.options.searchConfigs = config.options.searchConfigs ++ Seq(
               DseSubclassSearch(path, subclasses.toSeq)
             )
-            BlockVisualizerService(project).onDseConfigChanged(config)
+            DseService(project).onDseConfigChanged(config)
           }
         }).inSmartMode(project).submit(AppExecutorUtil.getAppExecutorService)
       }
@@ -140,20 +140,20 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
     add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
       requireExcept(block.params.toSeqMap.contains("matching_parts"), "block must have matching_parts")
       () => {
-        val config = BlockVisualizerService(project).getOrCreateDseRunConfiguration(rootClass)
+        val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
         config.options.searchConfigs = config.options.searchConfigs ++ Seq(DseDerivedPartSearch(path))
-        BlockVisualizerService(project).onDseConfigChanged(config)
+        DseService(project).onDseConfigChanged(config)
     }}, "Search matching parts"))
 
     add(ContextMenuUtils.MenuItem(() => {
-      val config = BlockVisualizerService(project).getOrCreateDseRunConfiguration(rootClass)
+      val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
       config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintArea(path))
-      BlockVisualizerService(project).onDseConfigChanged(config)
+      DseService(project).onDseConfigChanged(config)
     }, "Add objective contained footprint area"))
     add(ContextMenuUtils.MenuItem(() => {
-      val config = BlockVisualizerService(project).getOrCreateDseRunConfiguration(rootClass)
+      val config = DseService(project).getOrCreateDseRunConfiguration(rootClass)
       config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintCount(path))
-      BlockVisualizerService(project).onDseConfigChanged(config)
+      DseService(project).onDseConfigChanged(config)
     }, "Add objective contained footprint count"))
   }
 }


### PR DESCRIPTION
_DSE is an experimental feature and is not enabled by default_

DSE UI cleanup from pretesting.

- Refactors DSE operations out of BlockVisualizerService and into DseService.
- On DSE start, focus into the results panel and clear the block diagram visualizer.
- On a DSE config change, focus into the config panel and expand the relevant tree category
- If DSE has an empty config, automatically load that in the block diagram visualizer.
- Set the default proven column width to be small.
- Support dragging in the scatterplot
- TODO (future PR): DSE load state is broken.