### PR TITLE
UI improvements

### DIFF
--- a/src/main/java/edg_ide/ui/BlockVisualizerServiceWrapper.java
+++ b/src/main/java/edg_ide/ui/BlockVisualizerServiceWrapper.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.project.Project;
 
 // PersistentStateComponent doesn't seem to like Scala classes, so here it is in Java.
 class BlockVisualizerServiceState {
-  public int depthSpinner = 1;
   public float panelMainSplitterPos = 0.5f;
   public float panelBottomSplitterPos = 0.33f;
   public float panelLibrarySplitterPos = 0.5f;

--- a/src/main/java/edg_ide/ui/EdgSettingsState.java
+++ b/src/main/java/edg_ide/ui/EdgSettingsState.java
@@ -17,6 +17,7 @@ public class EdgSettingsState implements PersistentStateComponent<EdgSettingsSta
     public String[] kicadDirectories = {};
     public boolean persistBlockCache = false;
     public boolean showProvenStatus = false;
+    public boolean showInternalBlocks = false;
 
 
     public static EdgSettingsState getInstance() {

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -119,7 +119,7 @@ case class DseObjectiveUnprovenCount(rootPath: DesignPath) extends DseIntObjecti
     new DesignBlockMap[Int] {
       override def mapBlock(path: DesignPath, block: HierarchyBlock, blocks: SeqMap[String, Int]): Int = {
         val thisProven = BlockVisualizerService(project).getProvenDatabase.getRecords(block.getSelfClass)
-        val thisUnprovenCount = thisProven.getLatestStatus match {
+        val thisUnprovenCount = thisProven.latestStatus match {
           case ProvenStatus.Working => 0
           case _ => 1
         }

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -1,11 +1,12 @@
 package edg_ide.dse
+import com.intellij.openapi.project.Project
 import edg.ElemBuilder
-import edg.compiler.{ArrayValue, BooleanValue, Compiler, ExprValue, FloatValue, IntValue, PythonInterface, RangeEmpty, RangeValue, TextValue}
+import edg.compiler.{Compiler, ExprValue, PythonInterface, TextValue}
 import edg.util.Errorable
 import edg.wir.ProtoUtil.ParamProtoToSeqMap
 import edg.wir.{DesignPath, IndirectDesignPath}
-import edg_ide.runner.CompileProcessHandler
-import edg_ide.ui.KicadParser
+import edg_ide.proven.ProvenStatus
+import edg_ide.ui.{BlockVisualizerService, KicadParser}
 import edg_ide.util.KicadFootprintUtil
 import edgir.elem.elem.HierarchyBlock
 import edgir.schema.schema
@@ -21,22 +22,22 @@ import scala.collection.{SeqMap, mutable}
 sealed trait DseObjective { self: Serializable =>
   def objectiveToString: String  // short human-friendly string describing this configuration
 
-  def calculate(design: schema.Design, compiler: Compiler, pythonInterface: PythonInterface): Any
+  def calculate(design: schema.Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Any
 }
 
 
 // Abstract base class that defines the calculation type
-sealed abstract class DseTypedObjective[T] extends DseObjective { self: Serializable =>
-  def calculate(design: schema.Design, compiler: Compiler, pythonInterface: PythonInterface): T
+sealed abstract class DseNumericObjective extends DseObjective { self: Serializable =>
+  def calculate(design: schema.Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float
 }
 
 
 // Abstract base class for parameter values
-case class DseObjectiveParameter(path: IndirectDesignPath, val exprType: Class[_ <: ExprValue])
-    extends DseTypedObjective[Option[ExprValue]] { self: Serializable =>
+case class DseObjectiveParameter(path: IndirectDesignPath, exprType: Class[_ <: ExprValue])
+    extends DseObjective { self: Serializable =>
   override def objectiveToString = f"Parameter($path)"
 
-  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface): Option[ExprValue] = {
+  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Option[ExprValue] = {
     compiler.getParamValue(path)
   }
 }
@@ -59,11 +60,10 @@ object DseObjectiveFootprintArea {
 }
 
 
-case class DseObjectiveFootprintArea(rootPath: DesignPath = DesignPath())
-    extends DseTypedObjective[Float] with Serializable {
+case class DseObjectiveFootprintArea(rootPath: DesignPath) extends DseNumericObjective with Serializable {
   override def objectiveToString = f"FootprintArea($rootPath)"
 
-  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface): Float = {
+  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
     new DesignBlockMap[Float] {
       override def mapBlock(path: DesignPath, block: HierarchyBlock, blocks: SeqMap[String, Float]): Float = {
         val thisArea = if (path.startsWith(rootPath)) {
@@ -82,28 +82,44 @@ case class DseObjectiveFootprintArea(rootPath: DesignPath = DesignPath())
 
 
 // Counts the total number of footprints
-case class DseObjectiveFootprintCount(rootPath: DesignPath = DesignPath())
-    extends DseTypedObjective[Int] with Serializable {
+case class DseObjectiveFootprintCount(rootPath: DesignPath) extends DseNumericObjective with Serializable {
   override def objectiveToString = f"FootprintCount($rootPath)"
 
-  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface): Int = {
+  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
     new DesignBlockMap[Int] {
       override def mapBlock(path: DesignPath, block: HierarchyBlock, blocks: SeqMap[String, Int]): Int = {
         val thisValue = if (path.startsWith(rootPath) && block.params.toSeqMap.contains("fp_footprint")) 1 else 0
         thisValue + blocks.values.sum
       }
-    }.map(design)
+    }.map(design).toFloat
   }
 }
 
 
-case class DseObjectiveFootprintPrice(rootPath: DesignPath = DesignPath())
-  extends DseTypedObjective[Float] with Serializable {
-  override def objectiveToString = f"FootprintPrice($rootPath)"
+case class DseObjectivePrice() extends DseNumericObjective with Serializable {
+  override def objectiveToString = f"Price"
 
-  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface): Float = {
+  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
     pythonInterface.runBackend(
       ElemBuilder.LibraryPath("electronics_lib.PriceGetter.GeneratePrice"), design, compiler.getAllSolved, Map()
-    ).toOption.map(value => value(rootPath).toFloat).getOrElse(0)
+    ).toOption.map(value => value(DesignPath()).toFloat).getOrElse(0)
+  }
+}
+
+
+case class DseObjectiveUnprovenCount(rootPath: DesignPath) extends DseNumericObjective with Serializable {
+  override def objectiveToString = f"UnprovenCount($rootPath)"
+
+  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
+    new DesignBlockMap[Int] {
+      override def mapBlock(path: DesignPath, block: HierarchyBlock, blocks: SeqMap[String, Int]): Int = {
+        val thisProven = BlockVisualizerService(project).getProvenDatabase.getRecords(block.getSelfClass)
+        val thisUnprovenCount = thisProven.getLatestStatus match {
+          case ProvenStatus.Working => 0
+          case _ => 1
+        }
+        thisUnprovenCount + blocks.values.sum
+      }
+    }.map(design).toFloat
   }
 }

--- a/src/main/scala/edg_ide/dse/DseObjective.scala
+++ b/src/main/scala/edg_ide/dse/DseObjective.scala
@@ -26,9 +26,14 @@ sealed trait DseObjective { self: Serializable =>
 }
 
 
-// Abstract base class that defines the calculation type
-sealed abstract class DseNumericObjective extends DseObjective { self: Serializable =>
+// Abstract base class for numeric calculation results
+sealed abstract class DseFloatObjective extends DseObjective { self: Serializable =>
   def calculate(design: schema.Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float
+}
+
+
+sealed abstract class DseIntObjective extends DseObjective { self: Serializable =>
+  def calculate(design: schema.Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Int
 }
 
 
@@ -60,7 +65,7 @@ object DseObjectiveFootprintArea {
 }
 
 
-case class DseObjectiveFootprintArea(rootPath: DesignPath) extends DseNumericObjective with Serializable {
+case class DseObjectiveFootprintArea(rootPath: DesignPath) extends DseFloatObjective with Serializable {
   override def objectiveToString = f"FootprintArea($rootPath)"
 
   override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
@@ -82,21 +87,21 @@ case class DseObjectiveFootprintArea(rootPath: DesignPath) extends DseNumericObj
 
 
 // Counts the total number of footprints
-case class DseObjectiveFootprintCount(rootPath: DesignPath) extends DseNumericObjective with Serializable {
+case class DseObjectiveFootprintCount(rootPath: DesignPath) extends DseIntObjective with Serializable {
   override def objectiveToString = f"FootprintCount($rootPath)"
 
-  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
+  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Int = {
     new DesignBlockMap[Int] {
       override def mapBlock(path: DesignPath, block: HierarchyBlock, blocks: SeqMap[String, Int]): Int = {
         val thisValue = if (path.startsWith(rootPath) && block.params.toSeqMap.contains("fp_footprint")) 1 else 0
         thisValue + blocks.values.sum
       }
-    }.map(design).toFloat
+    }.map(design)
   }
 }
 
 
-case class DseObjectivePrice() extends DseNumericObjective with Serializable {
+case class DseObjectivePrice() extends DseFloatObjective with Serializable {
   override def objectiveToString = f"Price"
 
   override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
@@ -107,10 +112,10 @@ case class DseObjectivePrice() extends DseNumericObjective with Serializable {
 }
 
 
-case class DseObjectiveUnprovenCount(rootPath: DesignPath) extends DseNumericObjective with Serializable {
+case class DseObjectiveUnprovenCount(rootPath: DesignPath) extends DseIntObjective with Serializable {
   override def objectiveToString = f"UnprovenCount($rootPath)"
 
-  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Float = {
+  override def calculate(design: Design, compiler: Compiler, pythonInterface: PythonInterface, project: Project): Int = {
     new DesignBlockMap[Int] {
       override def mapBlock(path: DesignPath, block: HierarchyBlock, blocks: SeqMap[String, Int]): Int = {
         val thisProven = BlockVisualizerService(project).getProvenDatabase.getRecords(block.getSelfClass)
@@ -120,6 +125,6 @@ case class DseObjectiveUnprovenCount(rootPath: DesignPath) extends DseNumericObj
         }
         thisUnprovenCount + blocks.values.sum
       }
-    }.map(design).toFloat
+    }.map(design)
   }
 }

--- a/src/main/scala/edg_ide/proven/ProvenDataReader.scala
+++ b/src/main/scala/edg_ide/proven/ProvenDataReader.scala
@@ -170,7 +170,7 @@ class BlockProvenRecords(val data: SeqMap[(File, String), Seq[(ProvenRecord, Des
     records.nonEmpty
   }
 
-  lazy val getLatestStatus = testedData.headOption.map(_._2.head._1.status).getOrElse(ProvenStatus.Untested)
+  lazy val latestStatus = testedData.headOption.map(_._2.head._1.status).getOrElse(ProvenStatus.Untested)
 
   def getDataOfStatus(status: ProvenStatus.Status): SeqMap[(File, String), Seq[(ProvenRecord, DesignPath)]] = {
     val dataSeq = data

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -256,6 +256,8 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
         console))
 
       EdgCompilerService(project).pyLib.withPythonInterface(pythonInterface.get) {
+        BlockVisualizerService(project).setDesignStale()
+
         runFailableStage("discard stale", indicator) {
           val discarded = EdgCompilerService(project).discardStale()
           if (discarded.nonEmpty) {

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -239,6 +239,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
     runThread = Some(Thread.currentThread())
     startNotify()
     console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
+    BlockVisualizerService(project).setDesignStale()
 
     // This structure is quite nasty, but is needed to give a stream handle in case something crashes,
     // in which case pythonInterface is not a valid reference
@@ -257,8 +258,6 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
         console))
 
       EdgCompilerService(project).pyLib.withPythonInterface(pythonInterface.get) {
-        BlockVisualizerService(project).setDesignStale()
-
         runFailableStage("discard stale", indicator) {
           val discarded = EdgCompilerService(project).discardStale()
           if (discarded.nonEmpty) {

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -170,6 +170,7 @@ trait HasConsoleStages {
     */
   protected def runRequiredStage[ReturnType](name: String, indicator: ProgressIndicator)
                                           (fn: => (ReturnType, String)): ReturnType = {
+    if (Thread.interrupted()) throw new InterruptedException  // TODO cleaner way to stop compile process?
     indicator.setText(f"EDG compiling: $name")
     indicator.setIndeterminate(true)
     val ((fnResult, fnResultStr), fnTime) = timeExec {
@@ -190,7 +191,7 @@ trait HasConsoleStages {
         fn
       }
     } catch {
-      case e: Exception =>
+      case e: Exception if !e.isInstanceOf[InterruptedException] =>
         console.print(s"Failed: $name: $e\n", ConsoleViewContentType.ERROR_OUTPUT)
         // By default, the stack trace isn't printed, since most of the internal details
         // (stack trace elements) aren't relevant for end users

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -161,8 +161,6 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
       pythonInterfaceOption = Some(pythonInterface)
 
       EdgCompilerService(project).pyLib.withPythonInterface(pythonInterface) {
-        BlockVisualizerService(project).clearDesign()
-
         // compared to the single design compiler the debug info is a lot sparser here
         runFailableStage("discard stale", indicator) {
           val discarded = EdgCompilerService(project).discardStale()

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -110,6 +110,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
     runThread = Some(Thread.currentThread())
     startNotify()
     console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
+    BlockVisualizerService(project).setDesignStale()
 
     // the UI update is in a thread so it doesn't block the main search loop
     val uiUpdater = new SingleThreadRunner()
@@ -159,8 +160,6 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
         console))
 
       EdgCompilerService(project).pyLib.withPythonInterface(pythonInterface.get) {
-        BlockVisualizerService(project).setDesignStale()
-
         // compared to the single design compiler the debug info is a lot sparser here
         runFailableStage("discard stale", indicator) {
           val discarded = EdgCompilerService(project).discardStale()

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -213,7 +213,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
                     new DesignStructuralValidate().map(compiled) ++ new DesignRefsValidate().validate(compiled)
 
                 val objectiveValues = SeqMap.from(options.objectives.map { objective =>
-                  objective -> objective.calculate(compiled, compiler, pythonInterface)
+                  objective -> objective.calculate(compiled, compiler, pythonInterface, project)
                 })
 
                 val result = DseResult(index, pointValues,

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -247,6 +247,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
         runFailableStage("update visualization", indicator) {
           uiUpdater.join()  // wait for pending UI updates to finish before updating to final value
           DseService(project).setResults(results.toSeq, options.searchConfigs, options.objectives, false, false)
+          BlockVisualizerService(project).setLibrary(EdgCompilerService(project).pyLib)
 
           if (options.searchConfigs.isEmpty && results.length == 1) {
             val result = results.head

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -159,7 +159,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
         console))
 
       EdgCompilerService(project).pyLib.withPythonInterface(pythonInterface.get) {
-        BlockVisualizerService(project).clearDesign()
+        BlockVisualizerService(project).setDesignStale()
 
         // compared to the single design compiler the debug info is a lot sparser here
         runFailableStage("discard stale", indicator) {

--- a/src/main/scala/edg_ide/swing/BlockTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/BlockTreeTableModel.scala
@@ -16,7 +16,13 @@ import javax.swing.tree._
 class HierarchyBlockNode(project: Project, val path: DesignPath, val block: elem.HierarchyBlock) {
   import edgir.elem.elem.BlockLike
 
-  lazy val children: Seq[HierarchyBlockNode] = block.blocks.asPairs.map { case (name, subblock) =>
+  lazy val children: Seq[HierarchyBlockNode] = block.blocks.asPairs.filter { case (name, subblock) =>
+    if (!EdgSettingsState.getInstance().showInternalBlocks) {
+      !(name.startsWith("(bridge)") || name.startsWith("(adapter)"))
+    } else {
+      true
+    }
+  }.map { case (name, subblock) =>
     (name, subblock.`type`)
   }.collect {
     case (name, BlockLike.Type.Hierarchy(subblock)) => new HierarchyBlockNode(project, path + name, subblock)

--- a/src/main/scala/edg_ide/swing/BlockTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/BlockTreeTableModel.scala
@@ -18,7 +18,7 @@ class HierarchyBlockNode(project: Project, val path: DesignPath, val block: elem
 
   lazy val children: Seq[HierarchyBlockNode] = block.blocks.asPairs.filter { case (name, subblock) =>
     if (!EdgSettingsState.getInstance().showInternalBlocks) {
-      !(name.startsWith("(bridge)") || name.startsWith("(adapter)"))
+      !(name.startsWith("(bridge)") || name.startsWith("(adapter)") || name.startsWith("(not_connected)"))
     } else {
       true
     }

--- a/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
+++ b/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
@@ -11,9 +11,10 @@ import edgir.schema.schema
 import edg.wir._
 import edg.EdgirUtils.SimpleLibraryPath
 import edg.ExprBuilder
-import edg.compiler.{ArrayValue, Compiler, ExprResult, ExprToString, ExprValue}
+import edg.compiler.{ArrayValue, Compiler, ExprResult, ExprToString, ExprValue, FloatValue, IntValue, RangeValue}
 import edg.wir.ProtoUtil._
 import edg_ide.EdgirUtils
+import edg_ide.ui.ParamToUnitsStringUtil
 
 import javax.swing.JTree
 import javax.swing.event.TreeModelListener
@@ -280,23 +281,14 @@ class ElementDetailNodes(val root: schema.Design, val compiler: Compiler, val re
     }
 
     override def getColumns(index: Int): String = {
-      def valInitName(valInit: init.ValInit): String = valInit.`val` match {
-        case init.ValInit.Val.Floating(_) => "float"
-        case init.ValInit.Val.Boolean(_) => "boolean"
-        case init.ValInit.Val.Integer(_) => "integer"
-        case init.ValInit.Val.Range(_) => "range"
-        case init.ValInit.Val.Text(_) => "text"
-        case init.ValInit.Val.Array(arrayValInit) => s"array[${valInitName(arrayValInit)}]"
-        case init.ValInit.Val.Set(_) => "set"
-        case init.ValInit.Val.Struct(_) => "set"
-        case init.ValInit.Val.Empty => "empty"
-      }
-      val typeName = valInitName(param)
       val value = compiler.getParamValue(path) match {
+        case Some(value @ FloatValue(_)) => ParamToUnitsStringUtil.paramToUnitsString(value, "")
+        case Some(value @ IntValue(_)) => ParamToUnitsStringUtil.paramToUnitsString(value, "")
+        case Some(value @ RangeValue(_, _)) => ParamToUnitsStringUtil.paramToUnitsString(value, "")
         case Some(value) => value.toStringValue
-        case None => "Unsolved"
+        case None => "(unsolved)"
       }
-      s"$value ($typeName)"
+      s"$value"
     }
   }
 
@@ -384,8 +376,8 @@ class ElementDetailNodes(val root: schema.Design, val compiler: Compiler, val re
     override def getColumns(index: Int): String = meta.meta match {
       case common.Metadata.Meta.Members(members) => "(dict)"
       case common.Metadata.Meta.BinLeaf(binary) => s"(binary, ${binary.size()} long)"
-      case common.Metadata.Meta.TextLeaf(text) => s"$text (text)"
-      case common.Metadata.Meta.Empty => s"empty"
+      case common.Metadata.Meta.TextLeaf(text) => s"$text"
+      case common.Metadata.Meta.Empty => s"(empty)"
       case other => s"(unknown ${other.getClass.getSimpleName})"
     }
   }

--- a/src/main/scala/edg_ide/swing/ProvenTableModel.scala
+++ b/src/main/scala/edg_ide/swing/ProvenTableModel.scala
@@ -11,15 +11,22 @@ object EmptyProven extends ProvenNodeBase {
   override def toString = ""
 }
 
-class BlockProven(path: ref.LibraryPath,
+class BlockProven(blockClass: ref.LibraryPath,
                   val records: BlockProvenRecords) extends ProvenNodeBase {
+  private val latestData = records.getDataOfStatus(records.latestStatus)
+  private val latestRecords = latestData.flatMap { case (design, records) => records }
+
   override lazy val toString: String = if (records.isEmpty) {
     ""
-  } else {
-    records.getDataOfStatus(records.getLatestStatus).flatMap { case (design, records) => records }.size.toString
+  } else {  // get all instance-level records
+    latestRecords.size.toString
   }
 
   lazy val htmlDescription = {
+    val latestStatus = records.latestStatus
+    val latestStatusColor = SwingHtmlUtil.colorToHtml(ProvenStatus.colorOf(records.latestStatus))
+    val header = f"""<b>${latestRecords.size} <font style="color:$latestStatusColor;">$latestStatus</font> instances across ${latestData.size} designs:</b>"""
+
     val dataFormatted = records.data.map { case ((file, version), records) =>
       val statusCountString = records.groupBy(_._1.status).map { case (status, records) =>
         val statusColor = SwingHtmlUtil.colorToHtml(ProvenStatus.colorOf(status))
@@ -29,15 +36,15 @@ class BlockProven(path: ref.LibraryPath,
       val comments = records.map(_._1).collect {
         case record: UserProvenRecord => record.comments
       }.flatten.map { comment =>
-        s"- $comment"
-      }.mkString("<br/>")
-      val commentsString = if (comments.nonEmpty) s"<br/>$comments" else ""
+        s"- - $comment"
+      }.mkString("\n")
+      val commentsString = if (comments.nonEmpty) s"\n$comments" else ""
 
-      s"""<b>${file.getName}</b>@${version.substring(0, 7)}: $statusCountString$commentsString"""
+      s"""- <b>${file.getName}</b>@${version.substring(0, 7)}: $statusCountString$commentsString"""
     }.toSeq.reverse  // most recent first
 
-    f"""<b>${path.toSimpleString}</b><hr>
-        ${dataFormatted.mkString("<br/>")}
+    f"""<b>${blockClass.toSimpleString}</b><hr>$header
+        ${dataFormatted.mkString("\n")}
         """
   }
 }

--- a/src/main/scala/edg_ide/swing/ProvenTableRenderer.scala
+++ b/src/main/scala/edg_ide/swing/ProvenTableRenderer.scala
@@ -37,7 +37,7 @@ class ProvenTableRenderer extends DefaultTableCellRenderer {
     val component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
     value match {
       case cell: BlockProven =>
-        component.setForeground(ProvenStatus.colorOf(cell.records.getLatestStatus))
+        component.setForeground(ProvenStatus.colorOf(cell.records.latestStatus))
       case _ =>
     }
     component

--- a/src/main/scala/edg_ide/swing/ProvenTableRenderer.scala
+++ b/src/main/scala/edg_ide/swing/ProvenTableRenderer.scala
@@ -25,7 +25,7 @@ trait ProvenTreeTableMixin extends TreeTable {
     super.setModel(treeTableModel)
     getColumnModel.getColumns.asScala.foreach { column =>  // must support the case where the column isn't shown
       if (column.getIdentifier == "Proven") {
-        column.setPreferredWidth(32)
+        column.setMaxWidth(48)
       }
     }
   }

--- a/src/main/scala/edg_ide/swing/SeqTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/SeqTreeTableModel.scala
@@ -26,7 +26,7 @@ abstract class ParameterizedTreeTableModel[NodeType <: Object](implicit tag: Cla
     case null =>
       logger.error(s"isLeaf got node of unexpected null")
       true
-    case None =>
+    case _ =>
       logger.error(s"isLeaf got node of unexpected type ${node.getClass}")
       true
   }

--- a/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
@@ -15,7 +15,7 @@ object JDsePlot {
   val kPointSelectedSizePx: Int = 6 // diameter in px
   val kPointHoverOutlinePx: Int = 12 // diameter in px
   val kLineSelectedSizePx: Int = 2 // width in px
-  val kLineHoverOutlinePx: Int = 8 // width in px
+  val kLineHoverOutlinePx: Int = 7 // width in px
   val kHoverOutlineColor: Color = JBColor.YELLOW
 
   val kTickBrightness: Float = 0.25f

--- a/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
@@ -1,0 +1,75 @@
+package edg_ide.swing.dse
+
+import com.intellij.ui.JBColor
+
+import java.awt.Color
+import scala.collection.mutable
+
+
+object JDsePlot {
+  // GUI constants
+  private val kDefaultRangeMarginFactor = 1.1f // factor to extend the default range by
+
+  val kPointSizePx: Int = 4 // diameter in px
+  val kSnapDistancePx: Int = 6 // distance (radius) to snap for a click
+  val kPointSelectedSizePx: Int = 6 // diameter in px
+  val kPointHoverOutlinePx: Int = 12 // diameter in px
+  val kLineSelectedSizePx: Int = 2 // width in px
+  val kLineHoverOutlinePx: Int = 8 // width in px
+  val kHoverOutlineColor: Color = JBColor.YELLOW
+
+  val kTickBrightness: Float = 0.25f
+  val kTickSpacingIntervals: Seq[Int] = Seq(1, 2, 5)
+  val kMinTickSpacingPx: Int = 64 // min spacing between axis ticks, used to determine tick resolution
+  val kTickSizePx: Int = 4
+
+  def defaultValuesRange(values: Seq[Float], factor: Float = kDefaultRangeMarginFactor): (Float, Float) = {
+    val rangingValues = values.filter { value =>  // ignore invalid values for ranging
+      value != Float.NegativeInfinity && value != Float.PositiveInfinity && value != Float.NaN
+    } :+ 0f
+    val range = (rangingValues.min, rangingValues.max) // 0 in case values is empty, and forces the scale to include 0
+    val span = range._2 - range._1
+    val expansion = if (span > 0) { // range units to expand on each side
+      span * (factor - 1) / 2
+    } else { // if span is empty, arbitrarily expand by 1 on each side and center the data
+      1
+    }
+    (range._1 - expansion, range._2 + expansion)
+  }
+
+  // calculates a new range after applying some scaling factor, but keeping some fractional point of
+  // the old and new range static (eg, the point the mouse is over)
+  def scrollNewRange(oldRange: (Float, Float), scaleFactor: Float, staticFrac: Float): (Float, Float) = {
+    val span = oldRange._2 - oldRange._1
+    val mouseValue = oldRange._1 + (span * staticFrac)
+    val newSpan = span * scaleFactor
+    (mouseValue - (newSpan * staticFrac), mouseValue + (newSpan * (1 - staticFrac)))
+  }
+
+  // multiply data by this to get screen coordinates
+  def dataScale(dataRange: (Float, Float), screenSize: Int): Float = {
+    if (dataRange._1 != dataRange._2) {
+      screenSize / (dataRange._2 - dataRange._1)
+    } else {
+      1
+    }
+  }
+
+  // Returns all the axis ticks given some scale, screen origin, screen size, and min screen spacing
+  def getAxisTicks(range: (Float, Float), screenSize: Int, minScreenSpacing: Int = kMinTickSpacingPx):
+  Seq[(Float, String)] = {
+    val minDataSpacing = math.abs(minScreenSpacing / dataScale(range, screenSize)) // min tick spacing in data units
+    val tickSpacings = kTickSpacingIntervals.map { factor => // try all the spacings and take the minimum
+      math.pow(10, math.log10(minDataSpacing / factor).ceil) * factor
+    }
+    val tickSpacing = tickSpacings.min
+
+    var tickPos = (math.floor(range._1 / tickSpacing) * tickSpacing).toFloat
+    val ticksBuilder = mutable.ArrayBuffer[(Float, String)]()
+    while (tickPos <= range._2) {
+      ticksBuilder.append((tickPos, f"$tickPos%.02g"))
+      tickPos = (tickPos + tickSpacing).toFloat
+    }
+    ticksBuilder.toSeq
+  }
+}

--- a/src/main/scala/edg_ide/swing/dse/JParallelCoordinatesPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JParallelCoordinatesPlot.scala
@@ -41,7 +41,7 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
           Some(elt.positions(index))
         }
       }
-      JScatterPlot.defaultValuesRange(values.flatten)
+      JDsePlot.defaultValuesRange(values.flatten)
     }
 
     validate()
@@ -70,13 +70,13 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
 
       val ticks = axis match {
         case Some(axis) => axis
-        case _ => JScatterPlot.getAxisTicks(range, getHeight)
+        case _ => JDsePlot.getAxisTicks(range, getHeight)
       }
       ticks.foreach { case (tickPos, tickVal) =>
-        val screenPos = ((range._2 - tickPos) * JScatterPlot.dataScale(range, getHeight)).toInt
-        paintGraphics.drawLine(axisX, screenPos, axisX + JScatterPlot.kTickSizePx, screenPos)
+        val screenPos = ((range._2 - tickPos) * JDsePlot.dataScale(range, getHeight)).toInt
+        paintGraphics.drawLine(axisX, screenPos, axisX + JDsePlot.kTickSizePx, screenPos)
         DrawAnchored.drawLabel(paintGraphics, tickVal,
-          (axisX + JScatterPlot.kTickSizePx, screenPos), DrawAnchored.Left)
+          (axisX + JDsePlot.kTickSizePx, screenPos), DrawAnchored.Left)
       }
     }
   }
@@ -95,10 +95,10 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
     val axisPos = getPositionForAxis(axisIndex)
     val dataPos = getPositionForValue(axisIndex, value)
 
-    paintGraphics.drawOval(axisPos - JScatterPlot.kPointSizePx / 2, dataPos - JScatterPlot.kPointSizePx / 2,
-      JScatterPlot.kPointSizePx, JScatterPlot.kPointSizePx)
-    paintGraphics.fillOval(axisPos - JScatterPlot.kPointSizePx / 2, dataPos - JScatterPlot.kPointSizePx / 2,
-      JScatterPlot.kPointSizePx, JScatterPlot.kPointSizePx)
+    paintGraphics.drawOval(axisPos - JDsePlot.kPointSizePx / 2, dataPos - JDsePlot.kPointSizePx / 2,
+      JDsePlot.kPointSizePx, JDsePlot.kPointSizePx)
+    paintGraphics.fillOval(axisPos - JDsePlot.kPointSizePx / 2, dataPos - JDsePlot.kPointSizePx / 2,
+      JDsePlot.kPointSizePx, JDsePlot.kPointSizePx)
   }
 
   private def paintData(paintGraphics: Graphics, data: IndexedSeq[Data], noColor: Boolean = false,
@@ -145,12 +145,12 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
     paintData(paintGraphics, normalData, colorBlend = normalDataBlend)
 
     val selectedGraphics = paintGraphics.create().asInstanceOf[Graphics2D]
-    selectedGraphics.setStroke(new BasicStroke(JScatterPlot.kLineSelectedSizePx.toFloat))
+    selectedGraphics.setStroke(new BasicStroke(JDsePlot.kLineSelectedSizePx.toFloat))
     paintData(selectedGraphics, selectedData)
 
     val hoverGraphics = paintGraphics.create().asInstanceOf[Graphics2D]
-    hoverGraphics.setColor(ColorUtil.blendColor(getBackground, JScatterPlot.kHoverOutlineColor, 0.5))
-    hoverGraphics.setStroke(new BasicStroke(JScatterPlot.kLineHoverOutlinePx.toFloat))
+    hoverGraphics.setColor(ColorUtil.blendColor(getBackground, JDsePlot.kHoverOutlineColor, 0.5))
+    hoverGraphics.setStroke(new BasicStroke(JDsePlot.kLineHoverOutlinePx.toFloat))
     paintData(hoverGraphics, mouseoverData, noColor = true)
 
     paintData(selectedGraphics, mouseoverData)  // TODO: separate out selected from mouseover? idk
@@ -158,7 +158,7 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
 
   override def paintComponent(paintGraphics: Graphics): Unit = {
     val axesGraphics = paintGraphics.create()
-    axesGraphics.setColor(ColorUtil.blendColor(getBackground, paintGraphics.getColor, JScatterPlot.kTickBrightness))
+    axesGraphics.setColor(ColorUtil.blendColor(getBackground, paintGraphics.getColor, JDsePlot.kTickBrightness))
     paintAxes(axesGraphics)
 
     paintAllData(paintGraphics)
@@ -203,12 +203,12 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
       return Int.MinValue
     }
     val range = axesRange(axisIndex)
-    ((range._2 - value) * JScatterPlot.dataScale(range, getHeight)).toInt
+    ((range._2 - value) * JDsePlot.dataScale(range, getHeight)).toInt
   }
 
   addMouseListener(new MouseAdapter {
     override def mouseClicked(e: MouseEvent): Unit = {
-      val clickedPoints = getPointsForLocation(e.getX, e.getY, JScatterPlot.kSnapDistancePx)
+      val clickedPoints = getPointsForLocation(e.getX, e.getY, JDsePlot.kSnapDistancePx)
       val newPoints = if (selectedIndices.nonEmpty) {  // if selection, subset from selection
         clickedPoints.filter { case (index, dist) =>
           selectedIndices.contains(index)
@@ -224,7 +224,7 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
   addMouseMotionListener(new MouseMotionAdapter {
     override def mouseMoved(e: MouseEvent): Unit = {
       super.mouseMoved(e)
-      val mouseoverPoints = getPointsForLocation(e.getX, e.getY, JScatterPlot.kSnapDistancePx)
+      val mouseoverPoints = getPointsForLocation(e.getX, e.getY, JDsePlot.kSnapDistancePx)
       val newPoints = if (selectedIndices.nonEmpty) {  // if selection, subset from selection
         mouseoverPoints.filter { case (index, dist) =>
           selectedIndices.contains(index)
@@ -250,7 +250,7 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
       val zoomFactor = Math.pow(1.1, 1 * e.getPreciseWheelRotation).toFloat
 
       val axisIndex = getAxisForLocation(e.getX)
-      val newRange = JScatterPlot.scrollNewRange(axesRange(axisIndex), zoomFactor, 1 - (e.getY.toFloat / getHeight))
+      val newRange = JDsePlot.scrollNewRange(axesRange(axisIndex), zoomFactor, 1 - (e.getY.toFloat / getHeight))
       axesRange = axesRange.updated(axisIndex, newRange)
 
       validate()
@@ -294,7 +294,7 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
   addMouseMotionListener(dragListener) // this registers the dragged
 
   override def getToolTipText(e: MouseEvent): String = {
-    getPointsForLocation(e.getX, e.getY, JScatterPlot.kSnapDistancePx).headOption match {
+    getPointsForLocation(e.getX, e.getY, JDsePlot.kSnapDistancePx).headOption match {
       case Some((index, distance)) => data(index).tooltipText.orNull
       case None => null
     }

--- a/src/main/scala/edg_ide/swing/dse/JParallelCoordinatesPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JParallelCoordinatesPlot.scala
@@ -202,8 +202,14 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
     if (axisIndex >= axesRange.length) {
       return Int.MinValue
     }
-    val range = axesRange(axisIndex)
-    ((range._2 - value) * JDsePlot.dataScale(range, getHeight)).toInt
+    value match {
+      case Float.PositiveInfinity => 1
+      case Float.NegativeInfinity => getHeight - 2
+      case _ =>
+        val range = axesRange(axisIndex)
+        ((range._2 - value) * JDsePlot.dataScale(range, getHeight)).toInt
+    }
+
   }
 
   addMouseListener(new MouseAdapter {

--- a/src/main/scala/edg_ide/swing/dse/JParallelCoordinatesPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JParallelCoordinatesPlot.scala
@@ -101,8 +101,8 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
       JScatterPlot.kPointSizePx, JScatterPlot.kPointSizePx)
   }
 
-  private def paintData(paintGraphics: Graphics, data: IndexedSeq[(Data, Int)], noColor: Boolean = false): Unit = {
-    data.foreach { case (data, dataIndex) =>
+  private def paintData(paintGraphics: Graphics, data: IndexedSeq[Data], noColor: Boolean = false): Unit = {
+    data.foreach { data =>
       val dataGraphics = if (noColor) {
         paintGraphics
       } else {
@@ -131,13 +131,13 @@ class JParallelCoordinatesPlot[ValueType] extends JComponent {
     // paint order: (bottom) normal -> selected -> mouseover
     val normalData = data.zipWithIndex.filter { case (data, dataIndex) =>
       !mouseOverIndices.contains(dataIndex) && !selectedIndices.contains(dataIndex)
-    }
+    }.map(_._1)
     val selectedData = data.zipWithIndex.filter { case (data, dataIndex) =>
       !mouseOverIndices.contains(dataIndex) && selectedIndices.contains(dataIndex)
-    }
+    }.map(_._1)
     val mouseoverData = data.zipWithIndex.filter { case (data, dataIndex) =>
       mouseOverIndices.contains(dataIndex)
-    }
+    }.map(_._1)
 
     paintData(paintGraphics, normalData)
     val selectedGraphics = paintGraphics.create().asInstanceOf[Graphics2D]

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -17,8 +17,8 @@ object JScatterPlot {
   val kSnapDistancePx: Int = 6 // distance (radius) to snap for a click
   val kPointSelectedSizePx: Int = 6 // diameter in px
   val kPointHoverOutlinePx: Int = 12 // diameter in px
-  val kLineSelectedSizePx: Int = kPointSelectedSizePx / 2 // width in px
-  val kLineHoverOutlinePx: Int = kPointHoverOutlinePx / 2 // width in px
+  val kLineSelectedSizePx: Int = 3 // width in px
+  val kLineHoverOutlinePx: Int = 8 // width in px
   val kHoverOutlineColor: Color = JBColor.YELLOW
 
   val kTickBrightness: Float = 0.25f

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -17,7 +17,7 @@ object JScatterPlot {
   val kSnapDistancePx: Int = 6 // distance (radius) to snap for a click
   val kPointSelectedSizePx: Int = 6 // diameter in px
   val kPointHoverOutlinePx: Int = 12 // diameter in px
-  val kLineSelectedSizePx: Int = 3 // width in px
+  val kLineSelectedSizePx: Int = 2 // width in px
   val kLineHoverOutlinePx: Int = 8 // width in px
   val kHoverOutlineColor: Color = JBColor.YELLOW
 

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -1,79 +1,10 @@
 package edg_ide.swing.dse
 
-import com.intellij.ui.JBColor
 import edg_ide.swing.{ColorUtil, DrawAnchored}
 
 import java.awt.event._
 import java.awt.{Color, Graphics, Point}
 import javax.swing.{JComponent, SwingUtilities}
-import scala.collection.mutable
-
-
-object JScatterPlot {
-  // GUI constants
-  private val kDefaultRangeMarginFactor = 1.1f // factor to extend the default range by
-
-  val kPointSizePx: Int = 4 // diameter in px
-  val kSnapDistancePx: Int = 6 // distance (radius) to snap for a click
-  val kPointSelectedSizePx: Int = 6 // diameter in px
-  val kPointHoverOutlinePx: Int = 12 // diameter in px
-  val kLineSelectedSizePx: Int = 2 // width in px
-  val kLineHoverOutlinePx: Int = 8 // width in px
-  val kHoverOutlineColor: Color = JBColor.YELLOW
-
-  val kTickBrightness: Float = 0.25f
-  val kTickSpacingIntervals: Seq[Int] = Seq(1, 2, 5)
-  val kMinTickSpacingPx: Int = 64 // min spacing between axis ticks, used to determine tick resolution
-  val kTickSizePx: Int = 4
-
-  def defaultValuesRange(values: Seq[Float], factor: Float = kDefaultRangeMarginFactor): (Float, Float) = {
-    val range = ((values :+ 0f).min, (values :+ 0f).max)  // 0 in case values is empty, and forces the scale to include 0
-    val span = range._2 - range._1
-    val expansion = if (span > 0) { // range units to expand on each side
-      span * (factor - 1) / 2
-    } else { // if span is empty, arbitrarily expand by 1 on each side and center the data
-      1
-    }
-    (range._1 - expansion, range._2 + expansion)
-  }
-
-  // calculates a new range after applying some scaling factor, but keeping some fractional point of
-  // the old and new range static (eg, the point the mouse is over)
-  def scrollNewRange(oldRange: (Float, Float), scaleFactor: Float, staticFrac: Float): (Float, Float) = {
-    val span = oldRange._2 - oldRange._1
-    val mouseValue = oldRange._1 + (span * staticFrac)
-    val newSpan = span * scaleFactor
-    (mouseValue - (newSpan * staticFrac), mouseValue + (newSpan * (1 - staticFrac)))
-  }
-
-  // multiply data by this to get screen coordinates
-  def dataScale(dataRange: (Float, Float), screenSize: Int): Float = {
-    if (dataRange._1 != dataRange._2) {
-      screenSize / (dataRange._2 - dataRange._1)
-    } else {
-      1
-    }
-  }
-
-  // Returns all the axis ticks given some scale, screen origin, screen size, and min screen spacing
-  def getAxisTicks(range: (Float, Float), screenSize: Int, minScreenSpacing: Int = kMinTickSpacingPx):
-      Seq[(Float, String)] = {
-    val minDataSpacing = math.abs(minScreenSpacing / dataScale(range, screenSize)) // min tick spacing in data units
-    val tickSpacings = JScatterPlot.kTickSpacingIntervals.map { factor => // try all the spacings and take the minimum
-      math.pow(10, math.log10(minDataSpacing / factor).ceil) * factor
-    }
-    val tickSpacing = tickSpacings.min
-
-    var tickPos = (math.floor(range._1 / tickSpacing) * tickSpacing).toFloat
-    val ticksBuilder = mutable.ArrayBuffer[(Float, String)]()
-    while (tickPos <= range._2) {
-      ticksBuilder.append((tickPos, f"$tickPos%.02g"))
-      tickPos = (tickPos + tickSpacing).toFloat
-    }
-    ticksBuilder.toSeq
-  }
-
-}
 
 
 /** Scatterplot widget with two numerical axes, with labels inside the plot.
@@ -101,16 +32,16 @@ class JScatterPlot[ValueType] extends JComponent {
   private var xRange = (-1.0f, 1.0f)
   private var yRange = (-1.0f, 1.0f)
 
-  private def dataToScreenX(dataVal: Float): Int = ((dataVal - xRange._1) * JScatterPlot.dataScale(xRange, getWidth)).toInt
-  private def dataToScreenY(dataVal: Float): Int = ((yRange._2 - dataVal) * JScatterPlot.dataScale(yRange, getHeight)).toInt
+  private def dataToScreenX(dataVal: Float): Int = ((dataVal - xRange._1) * JDsePlot.dataScale(xRange, getWidth)).toInt
+  private def dataToScreenY(dataVal: Float): Int = ((yRange._2 - dataVal) * JDsePlot.dataScale(yRange, getHeight)).toInt
 
   def setData(xys: IndexedSeq[Data], xAxis: PlotAxis.AxisType = None, yAxis: PlotAxis.AxisType = None): Unit = {
     data = xys
     mouseOverIndices = Seq()  // clear
     selectedIndices = Seq()  // clear
 
-    xRange = JScatterPlot.defaultValuesRange(data.map(_.x))
-    yRange = JScatterPlot.defaultValuesRange(data.map(_.y))
+    xRange = JDsePlot.defaultValuesRange(data.map(_.x))
+    yRange = JDsePlot.defaultValuesRange(data.map(_.y))
 
     this.xAxis = xAxis
     this.yAxis = yAxis
@@ -141,13 +72,13 @@ class JScatterPlot[ValueType] extends JComponent {
     }
     val xTicks = xAxis match {
       case Some(xAxis) => xAxis
-      case _ => JScatterPlot.getAxisTicks(xRange, getWidth)
+      case _ => JDsePlot.getAxisTicks(xRange, getWidth)
     }
     xTicks.foreach { case (tickPos, tickVal) =>
       val screenX = dataToScreenX(tickPos)
-      paintGraphics.drawLine(screenX, getHeight - 1, screenX, getHeight - 1 - JScatterPlot.kTickSizePx)
+      paintGraphics.drawLine(screenX, getHeight - 1, screenX, getHeight - 1 - JDsePlot.kTickSizePx)
       DrawAnchored.drawLabel(paintGraphics, tickVal,
-        (screenX, getHeight - 1 - JScatterPlot.kTickSizePx), DrawAnchored.Bottom)
+        (screenX, getHeight - 1 - JDsePlot.kTickSizePx), DrawAnchored.Bottom)
     }
 
     if (yAxis.isEmpty) { // bottom horizontal axis - only on numeric axis
@@ -156,13 +87,13 @@ class JScatterPlot[ValueType] extends JComponent {
     }
     val yTicks = yAxis match {
       case Some(yAxis) => yAxis
-      case _ => JScatterPlot.getAxisTicks(yRange, getHeight)
+      case _ => JDsePlot.getAxisTicks(yRange, getHeight)
     }
     yTicks.foreach { case (tickPos, tickVal) =>
       val screenY = dataToScreenY(tickPos)
-      paintGraphics.drawLine(0, screenY, JScatterPlot.kTickSizePx, screenY)
+      paintGraphics.drawLine(0, screenY, JDsePlot.kTickSizePx, screenY)
       DrawAnchored.drawLabel(paintGraphics, tickVal,
-        (JScatterPlot.kTickSizePx, screenY), DrawAnchored.Left)
+        (JDsePlot.kTickSizePx, screenY), DrawAnchored.Left)
     }
   }
 
@@ -177,23 +108,23 @@ class JScatterPlot[ValueType] extends JComponent {
 
       if (mouseOverIndices.contains(index)) { // mouseover: highlight
         val hoverGraphics = paintGraphics.create()
-        hoverGraphics.setColor(ColorUtil.blendColor(getBackground, JScatterPlot.kHoverOutlineColor, 0.5))
-        hoverGraphics.fillOval(screenX - JScatterPlot.kPointHoverOutlinePx / 2, screenY - JScatterPlot.kPointHoverOutlinePx / 2,
-          JScatterPlot.kPointHoverOutlinePx, JScatterPlot.kPointHoverOutlinePx)
+        hoverGraphics.setColor(ColorUtil.blendColor(getBackground, JDsePlot.kHoverOutlineColor, 0.5))
+        hoverGraphics.fillOval(screenX - JDsePlot.kPointHoverOutlinePx / 2, screenY - JDsePlot.kPointHoverOutlinePx / 2,
+          JDsePlot.kPointHoverOutlinePx, JDsePlot.kPointHoverOutlinePx)
       }
       if (selectedIndices.contains(index)) { // selected: thicker
-        dataGraphics.fillOval(screenX - JScatterPlot.kPointSelectedSizePx / 2, screenY - JScatterPlot.kPointSelectedSizePx / 2,
-          JScatterPlot.kPointSelectedSizePx, JScatterPlot.kPointSelectedSizePx)
+        dataGraphics.fillOval(screenX - JDsePlot.kPointSelectedSizePx / 2, screenY - JDsePlot.kPointSelectedSizePx / 2,
+          JDsePlot.kPointSelectedSizePx, JDsePlot.kPointSelectedSizePx)
       } else {
-        dataGraphics.fillOval(screenX - JScatterPlot.kPointSizePx / 2, screenY - JScatterPlot.kPointSizePx / 2,
-          JScatterPlot.kPointSizePx, JScatterPlot.kPointSizePx)
+        dataGraphics.fillOval(screenX - JDsePlot.kPointSizePx / 2, screenY - JDsePlot.kPointSizePx / 2,
+          JDsePlot.kPointSizePx, JDsePlot.kPointSizePx)
       }
     }
   }
 
   override def paintComponent(paintGraphics: Graphics): Unit = {
     val axesGraphics = paintGraphics.create()
-    axesGraphics.setColor(ColorUtil.blendColor(getBackground, paintGraphics.getColor, JScatterPlot.kTickBrightness))
+    axesGraphics.setColor(ColorUtil.blendColor(getBackground, paintGraphics.getColor, JDsePlot.kTickBrightness))
     paintAxes(axesGraphics)
 
     paintData(paintGraphics)
@@ -216,7 +147,7 @@ class JScatterPlot[ValueType] extends JComponent {
 
   addMouseListener(new MouseAdapter {
     override def mouseClicked(e: MouseEvent): Unit = {
-      val clickedPoints = getPointsForLocation(e.getX, e.getY, JScatterPlot.kSnapDistancePx)
+      val clickedPoints = getPointsForLocation(e.getX, e.getY, JDsePlot.kSnapDistancePx)
       onClick(e, clickedPoints.sortBy(_._2).map(pair => data(pair._1)))
     }
   })
@@ -224,7 +155,7 @@ class JScatterPlot[ValueType] extends JComponent {
   addMouseMotionListener(new MouseMotionAdapter {
     override def mouseMoved(e: MouseEvent): Unit = {
       super.mouseMoved(e)
-      val newPoints = getPointsForLocation(e.getX, e.getY, JScatterPlot.kSnapDistancePx)
+      val newPoints = getPointsForLocation(e.getX, e.getY, JDsePlot.kSnapDistancePx)
       val newIndices = newPoints.map(_._1)
       if (mouseOverIndices != newIndices) {
         mouseOverIndices = newIndices
@@ -240,8 +171,8 @@ class JScatterPlot[ValueType] extends JComponent {
   addMouseWheelListener(new MouseWheelListener {
     override def mouseWheelMoved(e: MouseWheelEvent): Unit = {
       val zoomFactor = Math.pow(1.1, 1 * e.getPreciseWheelRotation).toFloat
-      xRange = JScatterPlot.scrollNewRange(xRange, zoomFactor, e.getX.toFloat / getWidth)
-      yRange = JScatterPlot.scrollNewRange(yRange, zoomFactor, 1 - (e.getY.toFloat / getHeight))
+      xRange = JDsePlot.scrollNewRange(xRange, zoomFactor, e.getX.toFloat / getWidth)
+      yRange = JDsePlot.scrollNewRange(yRange, zoomFactor, 1 - (e.getY.toFloat / getHeight))
 
       validate()
       repaint()
@@ -281,7 +212,7 @@ class JScatterPlot[ValueType] extends JComponent {
   addMouseMotionListener(dragListener)  // this registers the dragged
 
   override def getToolTipText(e: MouseEvent): String = {
-    getPointsForLocation(e.getX, e.getY, JScatterPlot.kSnapDistancePx).headOption match {
+    getPointsForLocation(e.getX, e.getY, JDsePlot.kSnapDistancePx).headOption match {
       case Some((index, distance)) => data(index).tooltipText.orNull
       case None => null
     }

--- a/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JScatterPlot.scala
@@ -32,8 +32,16 @@ class JScatterPlot[ValueType] extends JComponent {
   private var xRange = (-1.0f, 1.0f)
   private var yRange = (-1.0f, 1.0f)
 
-  private def dataToScreenX(dataVal: Float): Int = ((dataVal - xRange._1) * JDsePlot.dataScale(xRange, getWidth)).toInt
-  private def dataToScreenY(dataVal: Float): Int = ((yRange._2 - dataVal) * JDsePlot.dataScale(yRange, getHeight)).toInt
+  private def dataToScreenX(dataVal: Float): Int = dataVal match {
+    case Float.PositiveInfinity => getWidth - 2
+    case Float.NegativeInfinity => 1
+    case _ => ((dataVal - xRange._1) * JDsePlot.dataScale(xRange, getWidth)).toInt
+  }
+  private def dataToScreenY(dataVal: Float): Int = dataVal match {
+    case Float.PositiveInfinity => 1
+    case Float.NegativeInfinity => getHeight - 2
+    case _ => ((yRange._2 - dataVal) * JDsePlot.dataScale(yRange, getHeight)).toInt
+  }
 
   def setData(xys: IndexedSeq[Data], xAxis: PlotAxis.AxisType = None, yAxis: PlotAxis.AxisType = None): Unit = {
     data = xys

--- a/src/main/scala/edg_ide/swing/dse/PlotAxis.scala
+++ b/src/main/scala/edg_ide/swing/dse/PlotAxis.scala
@@ -1,7 +1,7 @@
 package edg_ide.swing.dse
 
 import edg.compiler.{ExprValue, FloatValue, IntValue, RangeType, RangeValue}
-import edg_ide.dse.{DseConfigElement, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseObjectiveParameter, DseParameterSearch, DseRefinementElement, DseResult}
+import edg_ide.dse.{DseConfigElement, DseNumericObjective, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseObjectiveParameter, DseParameterSearch, DseRefinementElement, DseResult}
 
 
 object PlotAxis {
@@ -32,8 +32,7 @@ object PlotAxis {
 
   // creates plot axes for an objective function
   def fromObjective(objective: DseObjective): Seq[PlotAxis] = objective match {
-    case objective: DseObjectiveFootprintArea => Seq(new DseObjectiveAxis(objective))
-    case objective: DseObjectiveFootprintCount => Seq(new DseObjectiveAxis(objective))
+    case objective: DseNumericObjective => Seq(new DseObjectiveAxis(objective))
     case objective: DseObjectiveParameter if objective.exprType == classOf[FloatValue] =>
       Seq(new DseObjectiveParamAxis(objective, "", param => Some(param.asInstanceOf[FloatValue].value)))
     case objective: DseObjectiveParameter if objective.exprType == classOf[IntValue] =>

--- a/src/main/scala/edg_ide/swing/dse/PlotAxis.scala
+++ b/src/main/scala/edg_ide/swing/dse/PlotAxis.scala
@@ -1,7 +1,7 @@
 package edg_ide.swing.dse
 
-import edg.compiler.{ExprValue, FloatValue, IntValue, RangeType, RangeValue}
-import edg_ide.dse.{DseConfigElement, DseNumericObjective, DseObjective, DseObjectiveFootprintArea, DseObjectiveFootprintCount, DseObjectiveParameter, DseParameterSearch, DseRefinementElement, DseResult}
+import edg.compiler._
+import edg_ide.dse._
 
 
 object PlotAxis {
@@ -32,7 +32,8 @@ object PlotAxis {
 
   // creates plot axes for an objective function
   def fromObjective(objective: DseObjective): Seq[PlotAxis] = objective match {
-    case objective: DseNumericObjective => Seq(new DseObjectiveAxis(objective))
+    case objective: DseFloatObjective => Seq(new DseObjectiveAxis(objective))
+    case objective: DseIntObjective => Seq(new DseObjectiveAxis(objective))
     case objective: DseObjectiveParameter if objective.exprType == classOf[FloatValue] =>
       Seq(new DseObjectiveParamAxis(objective, "", param => Some(param.asInstanceOf[FloatValue].value)))
     case objective: DseObjectiveParameter if objective.exprType == classOf[IntValue] =>

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -241,11 +241,13 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
       dsePanelShown = dseConfigSelected  // set it now, so we don't get multiple invocations of the update
       ApplicationManager.getApplication.invokeLater(() => {
         if (dseConfigSelected) {
-          mainSplitter.setSecondComponent(dseSplitter)
-          dseSplitter.setFirstComponent(bottomSplitter)
+          remove(mainSplitter)
+          dseSplitter.setFirstComponent(mainSplitter)
+          add(dseSplitter)
         } else {
+          remove(dseSplitter)
           dseSplitter.setFirstComponent(null)
-          mainSplitter.setSecondComponent(bottomSplitter)
+          add(mainSplitter)
         }
       })
     }

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -250,6 +250,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
           add(mainSplitter)
         }
       })
+      revalidate()
     }
   }, 333, 333, TimeUnit.MILLISECONDS) // seems flakey without initial delay
 

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -5,14 +5,13 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.ui.components.{JBScrollPane, JBTabbedPane}
 import com.intellij.ui.treeStructure.treetable.TreeTable
-import com.intellij.ui.{JBColor, JBIntSpinner, JBSplitter, TreeTableSpeedSearch}
+import com.intellij.ui.{JBSplitter, TreeTableSpeedSearch}
 import com.intellij.util.concurrency.AppExecutorUtil
 import edg.EdgirUtils.SimpleLibraryPath
 import edg.ElemModifier
 import edg.compiler.{Compiler, CompilerError, DesignMap, PythonInterfaceLibrary}
 import edg.wir.{DesignPath, Library}
 import edg_ide.EdgirUtils
-import edg_ide.build.BuildInfo
 import edg_ide.edgir_graph._
 import edg_ide.swing._
 import edg_ide.swing.blocks.JBlockDiagramVisualizer
@@ -27,12 +26,12 @@ import org.eclipse.elk.graph.{ElkGraphElement, ElkNode}
 
 import java.awt.datatransfer.DataFlavor
 import java.awt.event.{ComponentAdapter, ComponentEvent, MouseAdapter, MouseEvent}
-import java.awt.{BorderLayout, Color, Dimension, GridBagConstraints, GridBagLayout}
+import java.awt.{BorderLayout, GridBagConstraints, GridBagLayout}
 import java.io.{File, FileInputStream}
 import java.util.concurrent.{Callable, TimeUnit}
-import javax.swing.event.{ChangeEvent, ChangeListener, TreeSelectionEvent, TreeSelectionListener}
+import javax.swing.event.{TreeSelectionEvent, TreeSelectionListener}
 import javax.swing.tree.TreePath
-import javax.swing.{JLabel, JLayeredPane, JPanel, OverlayLayout, SwingConstants, TransferHandler}
+import javax.swing._
 import scala.collection.{SeqMap, mutable}
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.util.Using

--- a/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerService.scala
@@ -60,8 +60,8 @@ class BlockVisualizerService(project: Project) extends
     visualizerPanelOption.foreach(_.setDesignTop(design, compiler, refinements, errors, namePrefix))
   }
 
-  def clearDesign(): Unit = {
-    visualizerPanelOption.foreach(_.clearDesign())
+  def setDesignStale(): Unit = {
+    visualizerPanelOption.foreach(_.setDesignStale())
   }
 
   def getDesign: Option[schema.Design] = {

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -123,7 +123,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       () => {
         val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
         config.options.objectives = config.options.objectives :+ objective
-        DseService(project).onObjectiveConfigChanged(config)
+        DseService(project).onObjectiveConfigChanged(config, true)
       }
     }, "Add objective"))
   }

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -135,6 +135,8 @@ class DetailPanel(initPath: DesignPath, initCompiler: Compiler, project: Project
   private val tree = new TreeTable(new ElementDetailTreeModel(initPath, schema.Design(), edgrpc.Refinements(), initCompiler))
   tree.setShowColumns(true)
   private val treeScrollPane = new JBScrollPane(tree)
+  private val treeTreeRenderer = tree.getTree.getCellRenderer
+  private val treeTableRenderer = tree.getDefaultRenderer(classOf[Object])
 
   setLayout(new BorderLayout())
   add(treeScrollPane)
@@ -159,6 +161,16 @@ class DetailPanel(initPath: DesignPath, initCompiler: Compiler, project: Project
   //
   def setLoaded(path: DesignPath, root: schema.Design, refinements: edgrpc.Refinements, compiler: Compiler): Unit = {
     TreeTableUtils.updateModel(tree, new ElementDetailTreeModel(path, root, refinements, compiler))
+  }
+
+  def setStale(stale: Boolean): Unit = {
+    if (stale) {
+      tree.setTreeCellRenderer(new StaleTreeRenderer)
+      tree.setDefaultRenderer(classOf[Object], new StaleTableRenderer)
+    } else {
+      tree.setTreeCellRenderer(treeTreeRenderer)
+      tree.setDefaultRenderer(classOf[Object], treeTableRenderer)
+    }
   }
 
   // Configuration State

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -91,7 +91,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DsePathParameterSearch(directPath, Seq(value))
       DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        DseService(project).addConfig(rootClass, newConfig)
+        DseService(project).addSearchConfig(rootClass, newConfig, this)
       }).exceptError
     }, s"Search values for instance $path"))
 
@@ -100,7 +100,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DseClassParameterSearch(blockClass, postfix, Seq(value))
       (DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        DseService(project).addConfig(rootClass, newConfig)
+        DseService(project).addSearchConfig(rootClass, newConfig, this)
       }).exceptError, s"Search values of class ${blockClass.toSimpleString}:${ExprToString(postfix)}")
     }, s"Search values of class"))
 
@@ -109,7 +109,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       val value = compiler.getParamValue(path).exceptNone("no value")
       val baseConfig = DseClassParameterSearch(paramDefiningClass, postfix, Seq(value))
       (DseSearchConfigPopupMenu.createParamSearchEditPopup(baseConfig, project, { newConfig =>
-        DseService(project).addConfig(rootClass, newConfig)
+        DseService(project).addSearchConfig(rootClass, newConfig, this)
       }).exceptError, s"Search values of param-defining class ${paramDefiningClass.toSimpleString}:${ExprToString(postfix)}")
     }, s"Search values of param-defining class"))
 
@@ -121,7 +121,7 @@ class DetailParamPopupMenu(path: IndirectDesignPath, design: schema.Design, comp
       }
 
       () => {
-        val config = DseService(project).getOrCreateRunConfiguration(rootClass)
+        val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
         config.options.objectives = config.options.objectives :+ objective
         DseService(project).onObjectiveConfigChanged(config)
       }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -75,9 +75,12 @@ class DseObjectivePopupMenu(objective: DseObjective, project: Project) extends J
 
 
 class DseResultPopupMenu(result: DseResult, project: Project) extends JPopupMenu {
+  add(new JLabel(s"Point ${result.index}"))
   result.config.foreach { case (config, configValue) =>
-    add(new JLabel(s"Point ${result.index}"))
     add(new JLabel(s"${config.configToString} = ${config.valueToString(configValue)}"))
+  }
+  result.objectives.foreach { case (objective, objectiveValue) =>
+    add(new JLabel(s"${objective.objectiveToString} = ${DseConfigElement.valueToString(objectiveValue)}"))
   }
   addSeparator()
 

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -226,7 +226,7 @@ class DsePanel(project: Project) extends JPanel {
     override def keyReleased(keyEvent: KeyEvent): Unit = {}
     override def keyPressed(keyEvent: KeyEvent): Unit = {
       if (keyEvent.getKeyCode == KeyEvent.VK_DELETE) {
-        configTree.getTree.getSelectionPath.getLastPathComponent match {
+        Option(configTree.getTree.getSelectionPath).getOrElse(return).getLastPathComponent match {
           case node: DseConfigTreeNode.DseSearchConfigNode =>
             DseService(project).getRunConfiguration.foreach { dseConfig =>
               val originalSearchConfigs = dseConfig.options.searchConfigs

--- a/src/main/scala/edg_ide/ui/DseService.scala
+++ b/src/main/scala/edg_ide/ui/DseService.scala
@@ -25,17 +25,17 @@ class DseService(project: Project) extends
   private var initialState: Option[DseServiceState] = None
 
   // Called when the run configuration changes
-  def onSearchConfigChanged(config: DseRunConfiguration): Unit = {
+  def onSearchConfigChanged(config: DseRunConfiguration, scrollToLast: Boolean): Unit = {
     dsePanelOption.foreach { panel =>
       panel.onConfigChange(config)
-      panel.focusConfigSearch()
+      panel.focusConfigSearch(scrollToLast)
     }
   }
 
-  def onObjectiveConfigChanged(config: DseRunConfiguration): Unit = {
+  def onObjectiveConfigChanged(config: DseRunConfiguration, scrollToLast: Boolean): Unit = {
     dsePanelOption.foreach { panel =>
       panel.onConfigChange(config)
-      panel.focusConfigObjective()
+      panel.focusConfigObjective(scrollToLast)
     }
   }
 
@@ -81,8 +81,8 @@ class DseService(project: Project) extends
 
   def addSearchConfig(blockType: ref.LibraryPath, newConfig: DseConfigElement, owner: Component): Unit = {
     val config = getOrCreateRunConfiguration(blockType, owner)
-    config.options.searchConfigs = config.options.searchConfigs ++ Seq(newConfig)
-    onSearchConfigChanged(config)
+    config.options.searchConfigs = config.options.searchConfigs :+ newConfig
+    onSearchConfigChanged(config, true)
   }
 
   def setResults(results: Seq[DseResult], search: Seq[DseConfigElement], objectives: Seq[DseObjective],

--- a/src/main/scala/edg_ide/ui/DseService.scala
+++ b/src/main/scala/edg_ide/ui/DseService.scala
@@ -54,18 +54,15 @@ class DseService(project: Project) extends
           case config: DseRunConfiguration if config.options.designName == blockType.toFullString => config
         }
     val existingConfig = currentConfig.orElse {
-      runManager.getAllSettings.asScala.toSeq.map { configSettings =>
-        println(s"$configSettings    ${configSettings.getConfiguration}")
+      runManager.getAllSettings.asScala.map { configSettings =>
         (configSettings, configSettings.getConfiguration)
       }.collectFirst {
         case (configSettings, config: DseRunConfiguration) if config.options.designName == blockType.toFullString =>
           (configSettings, config)
-      } match {
-        case Some((configSettings, config)) =>
-          runManager.setSelectedConfiguration(configSettings)
-          PopupUtils.createPopupAtMouse(s"switched to existing DSE config ${config.getName}", owner)
-          Some(config)
-        case None => None
+      }.map { case (configSettings, config) =>
+        runManager.setSelectedConfiguration(configSettings)
+        PopupUtils.createPopupAtMouse(s"switched to existing DSE config ${config.getName}", owner)
+        config
       }
     }
     existingConfig.getOrElse { // if no existing config of the type, create a new one

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -5,6 +5,7 @@ import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.FormBuilder
+import edg_ide.build.BuildInfo
 
 import javax.swing.{JCheckBox, JPanel}
 
@@ -38,6 +39,10 @@ class EdgSettingsComponent {
     "IDE restart may be required to take effect.")
   showInternalBlocksHelp.setEnabled(false)
 
+  val versionLabel = new JBLabel(s"Version ${BuildInfo.version}, built at ${BuildInfo.builtAtString}, " +
+      s"scala ${BuildInfo.scalaVersion}, sbt ${BuildInfo.sbtVersion}")
+  versionLabel.setEnabled(false)
+
   val mainPanel = FormBuilder.createFormBuilder()
       .addLabeledComponent(new JBLabel("KiCad Footprint Directory"), kicadDirectoryText, false)
       .addComponent(kicadDirectoryHelp)
@@ -48,6 +53,7 @@ class EdgSettingsComponent {
       .addLabeledComponent(new JBLabel("Show Internal Blocks"), showInternalBlocks, false)
       .addComponent(showInternalBlocksHelp)
       .addComponentFillVertically(new JPanel(), 0)
+      .addComponent(versionLabel)
       .getPanel
 }
 

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -32,6 +32,12 @@ class EdgSettingsComponent {
     "IDE restart may be required to take effect.")
   showProvenStatusHelp.setEnabled(false)
 
+  val showInternalBlocks = new JCheckBox()
+  val showInternalBlocksHelp = new JBLabel("Show internal blocks like bridges and adapters in the design tree. " +
+    "These are implementation details in most cases but may be useful for model debugging. " +
+    "IDE restart may be required to take effect.")
+  showInternalBlocksHelp.setEnabled(false)
+
   val mainPanel = FormBuilder.createFormBuilder()
       .addLabeledComponent(new JBLabel("KiCad Footprint Directory"), kicadDirectoryText, false)
       .addComponent(kicadDirectoryHelp)
@@ -39,6 +45,8 @@ class EdgSettingsComponent {
       .addComponent(persistBlockCacheHelp)
       .addLabeledComponent(new JBLabel("Show Proven Status"), showProvenStatus, false)
       .addComponent(showProvenStatusHelp)
+      .addLabeledComponent(new JBLabel("Show Internal Blocks"), showInternalBlocks, false)
+      .addComponent(showInternalBlocksHelp)
       .addComponentFillVertically(new JPanel(), 0)
       .getPanel
 }
@@ -56,7 +64,8 @@ class EdgSettingsConfigurable extends Configurable {
     val settings = EdgSettingsState.getInstance()
     !settings.kicadDirectories.sameElements(component.kicadDirectoryText.getText.split(";")) ||
         settings.persistBlockCache != component.persistBlockCache.isSelected ||
-        settings.showProvenStatus != component.showProvenStatus.isSelected
+        settings.showProvenStatus != component.showProvenStatus.isSelected ||
+        settings.showInternalBlocks != component.showInternalBlocks.isSelected
   }
 
   override def apply(): Unit = {
@@ -64,6 +73,7 @@ class EdgSettingsConfigurable extends Configurable {
     settings.kicadDirectories = component.kicadDirectoryText.getText.split(";")
     settings.persistBlockCache = component.persistBlockCache.isSelected
     settings.showProvenStatus = component.showProvenStatus.isSelected
+    settings.showInternalBlocks = component.showInternalBlocks.isSelected
   }
 
   override def reset(): Unit = {
@@ -71,5 +81,6 @@ class EdgSettingsConfigurable extends Configurable {
     component.kicadDirectoryText.setText(settings.kicadDirectories.mkString(";"))
     component.persistBlockCache.setSelected(settings.persistBlockCache)
     component.showProvenStatus.setSelected(settings.showProvenStatus)
+    component.showInternalBlocks.setSelected(settings.showInternalBlocks)
   }
 }

--- a/src/main/scala/edg_ide/ui/PopupUtils.scala
+++ b/src/main/scala/edg_ide/ui/PopupUtils.scala
@@ -63,10 +63,14 @@ object PopupUtils {
   }
 
   // creates an error popup without showing it
-  private def createErrorPopupRaw(message: String): (JBPopup, Int) = {
+  private def createErrorPopupRaw(message: String, isWarning: Boolean): (JBPopup, Int) = {
     var hintHeight: Int = 0
+    var validationInfo = new ValidationInfo(message, null)  // TODO support component?
+    if (isWarning) {
+      validationInfo = validationInfo.asWarning()
+    }
     val popupBuilder = ComponentValidator.createPopupBuilder(
-      new ValidationInfo(message, null),  // TODO support component?
+      validationInfo,
       (editorPane: JEditorPane) => {
         hintHeight = editorPane.getPreferredSize.height
       }
@@ -79,21 +83,28 @@ object PopupUtils {
 
   // creates and shows an error popup at some point in screen coordinates
   // point will be the top left of the popup
+  def createPopupAtMouse(message: String, owner: java.awt.Component): Unit = {
+    val (popup, height) = createErrorPopupRaw(message, true)
+    val clickLocation = MouseInfo.getPointerInfo.getLocation
+    val adjustedLocation = new Point(clickLocation.x, clickLocation.y - JBUIScale.scale(6) + height)
+    popup.showInScreenCoordinates(owner, adjustedLocation)
+  }
+
   def createErrorPopupAtMouse(message: String, owner: java.awt.Component): Unit = {
-    val (popup, height) = createErrorPopupRaw(message)
+    val (popup, height) = createErrorPopupRaw(message, false)
     val clickLocation = MouseInfo.getPointerInfo.getLocation
     val adjustedLocation = new Point(clickLocation.x, clickLocation.y - JBUIScale.scale(6) + height)
     popup.showInScreenCoordinates(owner, adjustedLocation)
   }
 
   def createErrorPopup(message: String, e: MouseEvent): Unit = {
-    val (popup, height) = createErrorPopupRaw(message)
+    val (popup, height) = createErrorPopupRaw(message, false)
     popup.showInScreenCoordinates(e.getComponent,
       new Point(e.getXOnScreen, e.getYOnScreen - JBUIScale.scale(6) - height))
   }
 
   def createErrorPopup(message: String, editor: Editor): Unit = {
-    val (popup, height) = createErrorPopupRaw(message)
+    val (popup, height) = createErrorPopupRaw(message, false)
     popup.showInBestPositionFor(editor)
   }
 }

--- a/src/main/scala/edg_ide/ui/StaleRenderer.scala
+++ b/src/main/scala/edg_ide/ui/StaleRenderer.scala
@@ -1,0 +1,30 @@
+package edg_ide.ui
+
+import com.intellij.ui.JBColor
+
+import java.awt.Component
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.tree.DefaultTreeCellRenderer
+import javax.swing.{JTable, JTree}
+
+
+class StaleTreeRenderer extends DefaultTreeCellRenderer {
+  override def getTreeCellRendererComponent(tree: JTree, value: Any, sel: Boolean, expanded: Boolean, leaf: Boolean,
+                                            row: Int, hasFocus: Boolean): Component = {
+    val component = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus)
+    component.setForeground(JBColor.GRAY)
+    setIcon(null)
+    component
+  }
+}
+
+
+
+class StaleTableRenderer extends DefaultTableCellRenderer {
+  override def getTableCellRendererComponent(table: JTable, value: Any, isSelected: Boolean, hasFocus: Boolean,
+                                             row: Int, column: Int): Component = {
+    val component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+    component.setForeground(JBColor.GRAY)
+    component
+  }
+}

--- a/src/main/scala/edg_ide/ui/StaleRenderer.scala
+++ b/src/main/scala/edg_ide/ui/StaleRenderer.scala
@@ -19,7 +19,6 @@ class StaleTreeRenderer extends DefaultTreeCellRenderer {
 }
 
 
-
 class StaleTableRenderer extends DefaultTableCellRenderer {
   override def getTableCellRendererComponent(table: JTable, value: Any, isSelected: Boolean, hasFocus: Boolean,
                                              row: Int, column: Int): Component = {

--- a/src/main/scala/edg_ide/ui/dse/DseParallelPlotPanel.scala
+++ b/src/main/scala/edg_ide/ui/dse/DseParallelPlotPanel.scala
@@ -4,7 +4,7 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.ComboBox
 import edg_ide.dse._
-import edg_ide.swing.SwingHtmlUtil
+import edg_ide.swing.{ColorUtil, SwingHtmlUtil}
 import edg_ide.swing.dse._
 import edg_ide.ui.Gbc
 
@@ -80,14 +80,14 @@ class DseParallelPlotPanel() extends DseBasePlot {
     val parallelPoints = flatResults.toIndexedSeq.zipWithIndex.map { case (result, dataIndex) =>
       val (idealErrors, otherErrors) = DseResultModel.partitionByIdeal(result.errors)
       val color = (idealErrors.nonEmpty, otherErrors.nonEmpty) match {
-        case (_, true) => Some(DseResultModel.kColorOtherError)
-        case (true, false) => Some(DseResultModel.kColorIdealError)
+        case (_, true) => Some(ColorUtil.blendColor(getBackground, DseResultModel.kColorOtherError, 0.66))
+        case (true, false) => Some(ColorUtil.blendColor(getBackground, DseResultModel.kColorIdealError, 0.66))
         case (false, false) => None
       }
       val tooltipText = DseConfigElement.configMapToString(result.config)
       val axisValues = axisSelectors.indices.map { axisIndex =>
         pointsByAxis(axisIndex)(dataIndex)
-      }.toIndexedSeq
+      }
 
       new parallelPlot.Data(result, axisValues, color,
         Some(SwingHtmlUtil.wrapInHtml(tooltipText, this.getFont)))

--- a/src/main/scala/edg_ide/ui/dse/DseScatterPlotPanel.scala
+++ b/src/main/scala/edg_ide/ui/dse/DseScatterPlotPanel.scala
@@ -43,7 +43,7 @@ class DseScatterPlotPanel() extends DseBasePlot {
 
   setLayout(new GridBagLayout)
 
-  private val scatterPlot = new JScatterPlot[DseResult]() {
+  private val scatterPlot = new JDsePlot[DseResult]() {
     override def onClick(e: MouseEvent, data: Seq[Data]): Unit = {
       DseScatterPlotPanel.this.onClick(e, data.map(_.value))
     }

--- a/src/main/scala/edg_ide/ui/dse/DseScatterPlotPanel.scala
+++ b/src/main/scala/edg_ide/ui/dse/DseScatterPlotPanel.scala
@@ -43,7 +43,7 @@ class DseScatterPlotPanel() extends DseBasePlot {
 
   setLayout(new GridBagLayout)
 
-  private val scatterPlot = new JDsePlot[DseResult]() {
+  private val scatterPlot = new JScatterPlot[DseResult]() {
     override def onClick(e: MouseEvent, data: Seq[Data]): Unit = {
       DseScatterPlotPanel.this.onClick(e, data.map(_.value))
     }

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -118,12 +118,12 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
       val blockPyClass = DesignAnalysisUtils.pyClassOf(refinementClass, project).get
       () => {
         ReadAction.nonBlocking((() => {
-          val subClasses = PyClassInheritorsSearch.search(blockPyClass, true).findAll().asScala
-          subClasses.filter { subclass =>  // filter out abstract blocks
-            !DesignAnalysisUtils.isPyClassAbstract(subclass)
-          } .map { subclass =>
-            DesignAnalysisUtils.typeOf(subclass)
-          }
+          DesignAnalysisUtils.findOrderedSubclassesOf(blockPyClass)
+              .filter { subclass =>  // filter out abstract blocks
+                !DesignAnalysisUtils.isPyClassAbstract(subclass)
+              } .map { subclass =>
+                DesignAnalysisUtils.typeOf(subclass)
+              }
         }): Callable[Iterable[ref.LibraryPath]]).finishOnUiThread(ModalityState.defaultModalityState(), subclasses => {
           if (subclasses.isEmpty) {
             PopupUtils.createErrorPopupAtMouse(s"${blockPyClass.getName} has no non-abstract subclasses", this)

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -149,11 +149,18 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
       config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintCount(path))
       DseService(project).onObjectiveConfigChanged(config, true)
     }, "Add objective component count"))
+    if (path == DesignPath()) {  // price only supported at top level for now
+      add(ContextMenuUtils.MenuItem(() => {
+        val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
+        config.options.objectives = config.options.objectives ++ Seq(DseObjectivePrice())
+        DseService(project).onObjectiveConfigChanged(config, true)
+      }, "Add objective price"))
+    }
     add(ContextMenuUtils.MenuItem(() => {
       val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
-      config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintPrice(path))
+      config.options.objectives = config.options.objectives ++ Seq(DseObjectiveUnprovenCount(path))
       DseService(project).onObjectiveConfigChanged(config, true)
-    }, "Add objective price"))
+    }, "Add unproven count"))
   }
 }
 

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -109,11 +109,7 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
     addSeparator()
 
     val rootClass = interface.getDesign.getContents.getSelfClass
-    val (refinementClass, refinementLabel) = block.prerefineClass match {
-      case Some(prerefineClass) if prerefineClass != block.getSelfClass =>
-        (prerefineClass, f"Search refinements of base ${prerefineClass.toSimpleString}")
-      case _ => (block.getSelfClass, f"Search refinements of ${block.getSelfClass.toSimpleString}")
-    }
+    val refinementClass = block.prerefineClass.getOrElse(block.getSelfClass)
     add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
       val blockPyClass = DesignAnalysisUtils.pyClassOf(refinementClass, project).get
       () => {
@@ -134,25 +130,25 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
           }
         }).inSmartMode(project).submit(AppExecutorUtil.getAppExecutorService)
       }
-    }, refinementLabel))
+    }, f"Search subclasses of ${refinementClass.toSimpleString}"))
     add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
       requireExcept(block.params.toSeqMap.contains("matching_parts"), "block must have matching_parts")
       () => {
         val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
         config.options.searchConfigs = config.options.searchConfigs :+ DseDerivedPartSearch(path)
         DseService(project).onSearchConfigChanged(config, true)
-    }}, "Search matching parts"))
+    }}, s"Search matching parts"))
 
     add(ContextMenuUtils.MenuItem(() => {
       val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
       config.options.objectives = config.options.objectives :+ DseObjectiveFootprintArea(path)
       DseService(project).onObjectiveConfigChanged(config, true)
-    }, "Add objective contained footprint area"))
+    }, s"Add objective area"))
     add(ContextMenuUtils.MenuItem(() => {
       val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
       config.options.objectives = config.options.objectives :+ DseObjectiveFootprintCount(path)
       DseService(project).onObjectiveConfigChanged(config, true)
-    }, "Add objective contained footprint count"))
+    }, s"Add objective component count"))
   }
 }
 

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -128,7 +128,7 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
           if (subclasses.isEmpty) {
             PopupUtils.createErrorPopupAtMouse(s"${blockPyClass.getName} has no non-abstract subclasses", this)
           } else {
-            val config = DseService(project).getOrCreateRunConfiguration(rootClass)
+            val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
             config.options.searchConfigs = config.options.searchConfigs ++ Seq(
               DseSubclassSearch(path, subclasses.toSeq)
             )
@@ -140,18 +140,18 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
     add(ContextMenuUtils.MenuItemFromErrorable(exceptable {
       requireExcept(block.params.toSeqMap.contains("matching_parts"), "block must have matching_parts")
       () => {
-        val config = DseService(project).getOrCreateRunConfiguration(rootClass)
+        val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
         config.options.searchConfigs = config.options.searchConfigs ++ Seq(DseDerivedPartSearch(path))
         DseService(project).onSearchConfigChanged(config)
     }}, "Search matching parts"))
 
     add(ContextMenuUtils.MenuItem(() => {
-      val config = DseService(project).getOrCreateRunConfiguration(rootClass)
+      val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
       config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintArea(path))
       DseService(project).onObjectiveConfigChanged(config)
     }, "Add objective contained footprint area"))
     add(ContextMenuUtils.MenuItem(() => {
-      val config = DseService(project).getOrCreateRunConfiguration(rootClass)
+      val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
       config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintCount(path))
       DseService(project).onObjectiveConfigChanged(config)
     }, "Add objective contained footprint count"))

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -129,10 +129,8 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
             PopupUtils.createErrorPopupAtMouse(s"${blockPyClass.getName} has no non-abstract subclasses", this)
           } else {
             val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
-            config.options.searchConfigs = config.options.searchConfigs ++ Seq(
-              DseSubclassSearch(path, subclasses.toSeq)
-            )
-            DseService(project).onSearchConfigChanged(config)
+            config.options.searchConfigs = config.options.searchConfigs :+ DseSubclassSearch(path, subclasses.toSeq)
+            DseService(project).onSearchConfigChanged(config, true)
           }
         }).inSmartMode(project).submit(AppExecutorUtil.getAppExecutorService)
       }
@@ -141,19 +139,19 @@ class DesignBlockPopupMenu(path: DesignPath, interface: ToolInterface)
       requireExcept(block.params.toSeqMap.contains("matching_parts"), "block must have matching_parts")
       () => {
         val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
-        config.options.searchConfigs = config.options.searchConfigs ++ Seq(DseDerivedPartSearch(path))
-        DseService(project).onSearchConfigChanged(config)
+        config.options.searchConfigs = config.options.searchConfigs :+ DseDerivedPartSearch(path)
+        DseService(project).onSearchConfigChanged(config, true)
     }}, "Search matching parts"))
 
     add(ContextMenuUtils.MenuItem(() => {
       val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
-      config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintArea(path))
-      DseService(project).onObjectiveConfigChanged(config)
+      config.options.objectives = config.options.objectives :+ DseObjectiveFootprintArea(path)
+      DseService(project).onObjectiveConfigChanged(config, true)
     }, "Add objective contained footprint area"))
     add(ContextMenuUtils.MenuItem(() => {
       val config = DseService(project).getOrCreateRunConfiguration(rootClass, this)
-      config.options.objectives = config.options.objectives ++ Seq(DseObjectiveFootprintCount(path))
-      DseService(project).onObjectiveConfigChanged(config)
+      config.options.objectives = config.options.objectives :+ DseObjectiveFootprintCount(path)
+      DseService(project).onObjectiveConfigChanged(config, true)
     }, "Add objective contained footprint count"))
   }
 }

--- a/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
+++ b/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
@@ -334,10 +334,12 @@ object DesignAnalysisUtils {
   }
 
   /** Like PyClassInheritorsSearch.search, but returns subclasses depth-first order (roughly grouping similar results).
+    * Each level is sorted alphabetically by name.
     * If a subclass occurs multiple times, only the first is kept.
     */
   def findOrderedSubclassesOf(superclass: PyClass): Seq[PyClass] = {
     val directSubclasses = PyClassInheritorsSearch.search(superclass, false).findAll().asScala.toSeq
+        .sortBy(_.getName)
     directSubclasses.flatMap { directSubclass =>
       directSubclass +: findOrderedSubclassesOf(directSubclass)
     }.distinct

--- a/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
+++ b/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
@@ -6,6 +6,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.SlowOperations
 import com.jetbrains.python.psi.types.TypeEvalContext
 import com.jetbrains.python.psi._
+import com.jetbrains.python.psi.search.PyClassInheritorsSearch
 import edgir.ref.ref
 import edgir.schema.schema
 import edg.wir.DesignPath
@@ -15,7 +16,7 @@ import edg_ide.EdgirUtils
 import edg_ide.psi_edits.InsertConnectAction
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption, ExceptSeq}
 
-import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, ListHasAsScala}
 import scala.collection.mutable
 
 
@@ -330,5 +331,15 @@ object DesignAnalysisUtils {
     } else {
       assigns
     }
+  }
+
+  /** Like PyClassInheritorsSearch.search, but returns subclasses depth-first order (roughly grouping similar results).
+    * If a subclass occurs multiple times, only the first is kept.
+    */
+  def findOrderedSubclassesOf(superclass: PyClass): Seq[PyClass] = {
+    val directSubclasses = PyClassInheritorsSearch.search(superclass, false).findAll().asScala.toSeq
+    directSubclasses.flatMap { directSubclass =>
+      directSubclass +: findOrderedSubclassesOf(directSubclass)
+    }.distinct
   }
 }

--- a/src/test/scala/edg_ide/proven/tests/ProvenDataReaderTest.scala
+++ b/src/test/scala/edg_ide/proven/tests/ProvenDataReaderTest.scala
@@ -20,18 +20,18 @@ class ProvenDataReaderTest extends AnyFlatSpec with Matchers {
     stmRecord.data.map { case (design, records) => (design._1.getName, design._2) -> records.length } shouldEqual
         SeqMap(("TofArrayTest.edg", "c5a263037c00c5585586453d10de8963fa39d0e7") -> 1,
           ("BldcDriverBoard.edg", "de2f2692524fa4f20c05d237879fca5222511790") -> 1)
-    stmRecord.getLatestStatus shouldEqual ProvenStatus.Working
+    stmRecord.latestStatus shouldEqual ProvenStatus.Working
 
     val esp32c = data.getRecords(ElemBuilder.LibraryPath("electronics_lib.Microcontroller_Esp32c3.Esp32c3_Wroom02"))
     esp32c.isEmpty shouldEqual false
-    esp32c.getLatestStatus shouldEqual ProvenStatus.Fixed
+    esp32c.latestStatus shouldEqual ProvenStatus.Fixed
 
     val caps = data.getRecords(ElemBuilder.LibraryPath("electronics_lib.JlcCapacitor.JlcCapacitor"))
     caps.isEmpty shouldEqual false
-    caps.getLatestStatus shouldEqual ProvenStatus.Working
+    caps.latestStatus shouldEqual ProvenStatus.Working
 
     val nonexistent = data.getRecords(ElemBuilder.LibraryPath("nonexistent"))
     nonexistent.isEmpty shouldEqual true
-    nonexistent.getLatestStatus shouldEqual ProvenStatus.Untested
+    nonexistent.latestStatus shouldEqual ProvenStatus.Untested
   }
 }


### PR DESCRIPTION
... and boy are there a lot of them!

_DSE is an experimental feature and is not enabled by default_

General:
- Hide internal (bridge, adapter, not-connected) blocks in the design tree by default, with an optional toggle in settings
- When recompiling, the existing design is marked as stale, indicated by the design tree, details tree, and errors tree being greyed-out
  - This is done by overwriting the tree and table renderer with a stale renderer that changes the colors to grey. The default renderers are saved and restored when the design is updated (no longer stale)
- Allow limited interrupts (between stages only) from the stop button
- Proven data: show numeric summary, remove excess newlines
- Proven column in design tree: set maximum width instead of just preferred width
- Fix fallback case in SeqTreeTableModel.isLeaf, should match everything not just None
- Infrastructure for non-error (warning - orange) popups
- Remove version string from top, make status label part of a layered pane that displays over the block diagrams
- Move version string to settings panel
- Detail panel: don't display types unnecessarily (less visual clutter)

DSE:
- Results tree view: groups now separated by ideal-only errors
- DSE search can be interrupted using the stop button
- Refactor plot constants into JDsePlot object (from JScatterPlot)
- Support infinity (positive and negative) points by pegging them to the top/bottom/left/right of screen, and not affecting initial ranging
- Parallel coordinates plots
  - Better layering: normal data, selected data, mouseover highlight, mouseover data
  - Dim out normal data if there is an existing selection
  - Clicking filters existing selection, if there is no overlap it deselects all (and allows starting a new selection)
- Ordinal config axes: sort by user-defined search space, then anything else not in the user-defined space (by alpha sort)
- Main window: make main splitter between block diagram visualizer and DSE panel, so adjusting the split is (hopefully) more intuitive
- Changing DSE config
  - Shows a popup if switching / creating runner configs
  - Autoscroll to last in the config tree when adding a new config
  - Support delete key in config tree
- Add unproven instances count
- Adding subclass-refinements config: in depth-first subclass tree order, to kinda group similar subclasses together
- Unify objective-type axis creation with a base IntObjective and FloatObjective type