### PR TITLE
Clean up run configuration

### DIFF
--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -312,16 +312,6 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
           ""
         }
 
-        if (options.pdfFile.nonEmpty) {
-          runFailableStage("generate PDF", indicator) {
-            PDFGeneratorUtil.generate(compiled.getContents, mappers=Seq(new ElkEdgirGraphUtils.TitleMapper(compiler)), options.pdfFile)
-            f"wrote ${options.pdfFile}"
-          }
-        } else {
-          console.print(s"Skip generating PDF, no PDF file specified in run options\n",
-            ConsoleViewContentType.ERROR_OUTPUT)
-        }
-
         if (options.netlistFile.nonEmpty) {
           runFailableStage("generate netlist", indicator) {
             val netlist = pythonInterface.get.runBackend(
@@ -338,7 +328,7 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
           }
         } else {
           console.print(s"Skip generating netlist, no netlist file specified in run options\n",
-            ConsoleViewContentType.ERROR_OUTPUT)
+            ConsoleViewContentType.LOG_INFO_OUTPUT)
         }
 
         if (options.bomFile.nonEmpty) {
@@ -357,7 +347,14 @@ class CompileProcessHandler(project: Project, options: DesignTopRunConfiguration
           }
         } else {
           console.print(s"Skip generating BOM, no BOM file specified in run options\n",
-            ConsoleViewContentType.ERROR_OUTPUT)
+            ConsoleViewContentType.LOG_INFO_OUTPUT)
+        }
+
+        if (options.pdfFile.nonEmpty) {
+          runFailableStage("generate PDF", indicator) {
+            PDFGeneratorUtil.generate(compiled.getContents, mappers = Seq(new ElkEdgirGraphUtils.TitleMapper(compiler)), options.pdfFile)
+            f"wrote ${options.pdfFile}"
+          }
         }
       }
       exitCode = pythonInterface.get.shutdown()

--- a/src/main/scala/edg_ide/runner/DesignTopRunConfigurationProducer.scala
+++ b/src/main/scala/edg_ide/runner/DesignTopRunConfigurationProducer.scala
@@ -30,10 +30,9 @@ class DesignTopRunConfigurationProducer extends LazyRunConfigurationProducer[Des
           val containingDirectory = new File(psiPyClass.getContainingFile.getContainingDirectory.getVirtualFile.getPath)
           val netlistFile = new File(containingDirectory, psiPyClass.getName + ".net")
           configuration.options.netlistFile = netlistFile.getAbsolutePath
-          val pdfFile = new File(containingDirectory, psiPyClass.getName + ".pdf")
-          configuration.options.pdfFile = pdfFile.getAbsolutePath
           val bomFile = new File(containingDirectory, psiPyClass.getName + ".csv")
           configuration.options.bomFile = bomFile.getAbsolutePath
+          configuration.options.pdfFile = ""
           true
         } else {
           false

--- a/src/main/scala/edg_ide/runner/DesignTopRunConfigurationType.scala
+++ b/src/main/scala/edg_ide/runner/DesignTopRunConfigurationType.scala
@@ -62,9 +62,9 @@ object RefdesMode extends Enumeration {
 class DesignTopRunConfigurationOptions extends RunConfigurationOptions {
   var designName: String = ""
   var netlistFile: String = ""
-  var pdfFile: String = ""
-  var bomFile: String = ""
   var toggle: RefdesMode.selections = RefdesMode.refdes
+  var bomFile: String = ""
+  var pdfFile: String = ""
 }
 
 class DesignTopRunConfiguration(project: Project, factory: ConfigurationFactory, name: String)
@@ -94,57 +94,54 @@ class DesignTopRunConfiguration(project: Project, factory: ConfigurationFactory,
 
   val kFieldDesignName = "DESIGN_NAME"
   val kFieldNetlistName = "NETLIST_NAME"
+  val kFieldRefdesMode = "REFDESMODE_NAME"
   val kPdfFileName = "PDF_NAME"
   val kBomFileName = "BOM_NAME"
-  val kFieldRefdesMode = "REFDESMODE_NAME"
 
   // Allows persistence of run configuration
   override def readExternal(element: Element): Unit = {
     super.readExternal(element)
     options.designName = JDOMExternalizerUtil.readField(element, kFieldDesignName, "")
     options.netlistFile = JDOMExternalizerUtil.readField(element, kFieldNetlistName, "")
-    options.pdfFile = JDOMExternalizerUtil.readField(element, kPdfFileName, "")
-    options.bomFile = JDOMExternalizerUtil.readField(element, kBomFileName, "")
     RefdesMode.toEnum(JDOMExternalizerUtil.readField(element, kFieldRefdesMode)).foreach(options.toggle = _)
+    options.bomFile = JDOMExternalizerUtil.readField(element, kBomFileName, "")
+    options.pdfFile = JDOMExternalizerUtil.readField(element, kPdfFileName, "")
   }
 
   override def writeExternal(element: Element): Unit = {
     super.writeExternal(element)
     JDOMExternalizerUtil.writeField(element, kFieldDesignName, options.designName)
     JDOMExternalizerUtil.writeField(element, kFieldNetlistName, options.netlistFile)
-    JDOMExternalizerUtil.writeField(element, kPdfFileName, options.pdfFile)
-    JDOMExternalizerUtil.writeField(element, kBomFileName, options.bomFile)
     JDOMExternalizerUtil.writeField(element, kFieldRefdesMode, options.toggle.toString)
+    JDOMExternalizerUtil.writeField(element, kBomFileName, options.bomFile)
+    JDOMExternalizerUtil.writeField(element, kPdfFileName, options.pdfFile)
   }
 }
 
 class DesignTopSettingsEditor(project: Project) extends SettingsEditor[DesignTopRunConfiguration] {
   protected val designName = new JTextField()
   protected val netlistFile = new JTextField()  // no browse button b/c FileChooser can't create new files
-  protected val pdfFile = new JTextField()
-  protected val bomFile = new JTextField()
   protected val toggleRefdes = new JBRadioButton()
   protected val togglePathname = new JBRadioButton()
   protected val toggleButtons = new ButtonGroup()
   toggleButtons.add(toggleRefdes)
   toggleButtons.add(togglePathname)
+  protected val bomFile = new JTextField()
+  protected val pdfFile = new JTextField()
 
   protected val panel = FormBuilder.createFormBuilder()
       .addLabeledComponent(new JBLabel("Design top name"), designName, false)
+      .addLabeledComponent(new JBLabel("Netlist output file"), netlistFile, false)
       .addLabeledComponent(new JBLabel("Select Netlist Refdes value"), toggleRefdes)
       .addLabeledComponent(new JBLabel("Select Netlist Path Name"), togglePathname)
-      .addLabeledComponent(new JBLabel("Netlist output file"), netlistFile, false)
-      .addLabeledComponent(new JBLabel("PDF output file"), pdfFile, false)
       .addLabeledComponent(new JBLabel("BOM output file"), bomFile, false)
+      .addLabeledComponent(new JBLabel("PDF output file"), pdfFile, false)
       .addComponentFillVertically(new JPanel(), 0)
       .getPanel
 
   override def resetEditorFrom(s: DesignTopRunConfiguration): Unit = {
     designName.setText(s.options.designName)
     netlistFile.setText(s.options.netlistFile)
-    pdfFile.setText(s.options.pdfFile)
-    bomFile.setText(s.options.bomFile)
-
     s.options.toggle match {
       case RefdesMode.refdes =>
         toggleRefdes.setSelected(true)
@@ -153,20 +150,22 @@ class DesignTopSettingsEditor(project: Project) extends SettingsEditor[DesignTop
         toggleRefdes.setSelected(false)
         togglePathname.setSelected(true)
     }
+    bomFile.setText(s.options.bomFile)
+    pdfFile.setText(s.options.pdfFile)
   }
 
   override def applyEditorTo(s: DesignTopRunConfiguration): Unit = {
     s.options.designName = designName.getText
     s.options.netlistFile = netlistFile.getText
-    s.options.pdfFile = pdfFile.getText
-    s.options.bomFile = bomFile.getText
-    if (toggleRefdes.isSelected){
+    if (toggleRefdes.isSelected) {
       s.options.toggle = RefdesMode.refdes
     } else if (togglePathname.isSelected) {
       s.options.toggle = RefdesMode.pathName
     } else {
       // Ignore invalid user selection
     }
+    s.options.bomFile = bomFile.getText
+    s.options.pdfFile = pdfFile.getText
   }
 
   override def createEditor(): JComponent = panel


### PR DESCRIPTION
- Don't PDF by default, since it sometimes errors out
  - No warning on empty PDF, since it's no longer enabled by default
- Change skip warnings to normal log output color (instead of error color)
- Sort options logically