### PR TITLE
More UI cleaning

### DIFF
--- a/src/main/scala/edg_ide/psi_edits/InsertAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertAction.scala
@@ -13,7 +13,6 @@ import edg_ide.ui.{BlockVisualizerService, PopupUtils}
 import edg_ide.util.ExceptionNotifyImplicits._
 import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
 
-import java.util
 import scala.jdk.CollectionConverters.{ListHasAsScala, SeqHasAsJava}
 import scala.reflect.ClassTag
 

--- a/src/main/scala/edg_ide/psi_edits/InsertAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertAction.scala
@@ -1,18 +1,20 @@
 package edg_ide.psi_edits
 
 import com.intellij.lang.LanguageNamesValidation
+import com.intellij.openapi.editor.CaretState
 import com.intellij.openapi.fileEditor.{FileEditorManager, OpenFileDescriptor, TextEditor}
 import com.intellij.openapi.project.Project
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.{PsiElement, PsiFile}
 import com.jetbrains.python.PythonLanguage
 import com.jetbrains.python.psi.{PyClass, PyFunction, PyStatementList}
-
 import edg.util.Errorable
 import edg_ide.ui.{BlockVisualizerService, PopupUtils}
 import edg_ide.util.ExceptionNotifyImplicits._
 import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
-import scala.jdk.CollectionConverters.ListHasAsScala
+
+import java.util
+import scala.jdk.CollectionConverters.{ListHasAsScala, SeqHasAsJava}
 import scala.reflect.ClassTag
 
 
@@ -84,6 +86,26 @@ object InsertAction {
     new OpenFileDescriptor(element.getProject, element.getContainingFile.getVirtualFile,
       element.getTextRange.getEndOffset)
         .navigate(true)
+  }
+
+  def selectAndNavigate(elements: Seq[PsiElement]): Unit = {
+    // TODO a proof of concept, should be cleaned up and use live templates instead of a caret selection
+    if (elements.isEmpty) {
+      return
+    }
+    val exampleElement = elements.head
+    val project = exampleElement.getProject
+    val fileEditor = FileEditorManager.getInstance(project).getSelectedEditor(exampleElement.getContainingFile.getVirtualFile)
+    val editor = fileEditor match {
+      case editor: TextEditor => editor.getEditor
+      case _ => return
+    }
+    val carets = elements.map { element =>
+      val startPos = editor.offsetToLogicalPosition(element.getTextRange.getStartOffset)
+      val endPos = editor.offsetToLogicalPosition(element.getTextRange.getEndOffset)
+      new CaretState(endPos, startPos, endPos)
+    }.toList
+    editor.getCaretModel.setCaretsAndSelections(carets.asJava)
   }
 
   def findInsertionPoints(container: PyClass, validFunctions: Seq[String]): Errorable[Seq[PyFunction]] = exceptable {

--- a/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertRefinementAction.scala
@@ -36,7 +36,7 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
   private def insertRefinementKwarg(into: PyArgumentList, kwargName: String,
                                     refinements: Seq[(Seq[PyExpression], PyExpression)]): Seq[PyElement] = {
     val refinementsText = refinements.map { case (keyElts, value) =>
-      s"  (${keyElts.map(_.getText).mkString(", ")}, ${value.getText}),"
+      s"  (${keyElts.map(_.getText).mkString(", ")}, ${value.getText})"
     }
     val kwargExpr = psiElementGenerator.createKeywordArgument(languageLevel,
       kwargName,
@@ -79,12 +79,12 @@ class InsertRefinementAction(project: Project, insertIntoClass: PyClass) {
             }
             case None => () => {
               val insertTuple = psiElementGenerator.createExpressionFromText(languageLevel,
-                s"(${keyElts.map(_.getText).mkString(", ")}, ${value.getText}),") // note, trailing comma
+                s"(${keyElts.map(_.getText).mkString(", ")}, ${value.getText})")
               // for some reason, PyElementGenerator.getInstance(project).createNewLine inserts two spaces
-              val inserted = valueList.add(insertTuple).asInstanceOf[PyTupleExpression]
+              val inserted = valueList.add(insertTuple).asInstanceOf[PyExpression]
               // can't do valueList.addBefore, since that does a check for PyExpr, which whitespace is not
               inserted.addBefore(newline, inserted.getFirstChild)
-              Seq(inserted.getElements.last)  // for whatever reason the tuple throws an error when navigating to
+              Seq(inserted)
             }
           }
         }

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -91,8 +91,9 @@ class DseResultPopupMenu(result: DseResult, project: Project) extends JPopupMenu
     val insertAction = new InsertRefinementAction(project, topClass)
       .createInsertRefinements(result.searchRefinements).exceptError
     () => { // TODO standardized continuation?
-      val inserted = insertAction().head
-      InsertAction.navigateToEnd(inserted)
+      val inserted = insertAction()
+      InsertAction.navigateToEnd(inserted.head)
+      InsertAction.selectAndNavigate(inserted)
     }
   }, s"Insert refinements"))
 }


### PR DESCRIPTION
- When inserting refinements, don't insert the trailing comma (this causes bugs)
- When inserting refinements from DSE only, selects the inserted refinements (prototype interaction)
- DSE results table displayed with ideal / errors last