### PR TITLE
Fix crash for some error messages; create option to show IDE internal errors

### DIFF
--- a/src/main/java/edg_ide/ui/EdgSettingsState.java
+++ b/src/main/java/edg_ide/ui/EdgSettingsState.java
@@ -18,6 +18,7 @@ public class EdgSettingsState implements PersistentStateComponent<EdgSettingsSta
     public boolean persistBlockCache = false;
     public boolean showProvenStatus = false;
     public boolean showInternalBlocks = false;
+    public boolean showIdeErrors = false;
 
 
     public static EdgSettingsState getInstance() {

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -17,7 +17,7 @@ import edg.compiler._
 import edg.util.{Errorable, StreamUtils, timeExec}
 import edg.wir.DesignPath
 import edg_ide.edgir_graph.{ElkEdgirGraphUtils, HierarchyGraphElk}
-import edg_ide.ui.{BlockVisualizerService, EdgCompilerService}
+import edg_ide.ui.{BlockVisualizerService, EdgCompilerService, EdgSettingsState}
 import edg_ide.util.ExceptionNotifyImplicits.ExceptNotify
 import edg_ide.util.exceptable
 import edgir.elem.elem
@@ -202,14 +202,13 @@ trait HasConsoleStages {
       }
     } catch {
       case e: Exception if !e.isInstanceOf[InterruptedException] =>
+        if (EdgSettingsState.getInstance().showIdeErrors) {
+          val sw = new StringWriter
+          val pw = new PrintWriter(sw)
+          e.printStackTrace(pw)
+          console.print(sw.toString, ConsoleViewContentType.ERROR_OUTPUT)
+        }
         console.print(s"Failed: $name: $e\n", ConsoleViewContentType.ERROR_OUTPUT)
-        // By default, the stack trace isn't printed, since most of the internal details
-        // (stack trace elements) aren't relevant for end users
-        // TODO this should be plumbed to a toggle
-        // val sw = new StringWriter
-        // val pw = new PrintWriter(sw)
-        // e.printStackTrace(pw)
-        // console.print(sw.toString, ConsoleViewContentType.ERROR_OUTPUT)
         default
     }
   }

--- a/src/main/scala/edg_ide/swing/ExprVarToValue.scala
+++ b/src/main/scala/edg_ide/swing/ExprVarToValue.scala
@@ -10,9 +10,9 @@ object ExprVarToValue {
 
 class ExprVarToValue(compiler: Compiler, designPath: DesignPath) extends ExprToString() {
   override def mapRef(path: ref.LocalPath): String = {
-    val value = compiler.getParamValue((designPath ++ path).asIndirect)
+    val value = compiler.getParamValue(designPath.asIndirect ++ path)
         .map(ParamToUnitsStringUtil.toString)
         .getOrElse("unknown")
-    s"${(designPath ++ path).asIndirect} = ${value}"
+    s"${designPath.asIndirect ++ path} = $value"
   }
 }

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -39,6 +39,11 @@ class EdgSettingsComponent {
     "IDE restart may be required to take effect.")
   showInternalBlocksHelp.setEnabled(false)
 
+  val showIdeErrors = new JCheckBox()
+  val showIdeErrorsHelp = new JBLabel("Show detailed IDE internal errors. " +
+    "This is generally only useful for developing the IDE itself and may add excessive clutter for HDL work.")
+  showIdeErrorsHelp.setEnabled(false)
+
   val versionLabel = new JBLabel(s"Version ${BuildInfo.version}, built at ${BuildInfo.builtAtString}, " +
       s"scala ${BuildInfo.scalaVersion}, sbt ${BuildInfo.sbtVersion}")
   versionLabel.setEnabled(false)
@@ -52,6 +57,8 @@ class EdgSettingsComponent {
       .addComponent(showProvenStatusHelp)
       .addLabeledComponent(new JBLabel("Show Internal Blocks"), showInternalBlocks, false)
       .addComponent(showInternalBlocksHelp)
+      .addLabeledComponent(new JBLabel("Show IDE Errors"), showIdeErrors, false)
+      .addComponent(showIdeErrorsHelp)
       .addComponentFillVertically(new JPanel(), 0)
       .addComponent(versionLabel)
       .getPanel
@@ -71,7 +78,8 @@ class EdgSettingsConfigurable extends Configurable {
     !settings.kicadDirectories.sameElements(component.kicadDirectoryText.getText.split(";")) ||
         settings.persistBlockCache != component.persistBlockCache.isSelected ||
         settings.showProvenStatus != component.showProvenStatus.isSelected ||
-        settings.showInternalBlocks != component.showInternalBlocks.isSelected
+        settings.showInternalBlocks != component.showInternalBlocks.isSelected ||
+        settings.showIdeErrors != component.showIdeErrors.isSelected
   }
 
   override def apply(): Unit = {
@@ -80,6 +88,7 @@ class EdgSettingsConfigurable extends Configurable {
     settings.persistBlockCache = component.persistBlockCache.isSelected
     settings.showProvenStatus = component.showProvenStatus.isSelected
     settings.showInternalBlocks = component.showInternalBlocks.isSelected
+    settings.showIdeErrors = component.showIdeErrors.isSelected
   }
 
   override def reset(): Unit = {
@@ -88,5 +97,6 @@ class EdgSettingsConfigurable extends Configurable {
     component.persistBlockCache.setSelected(settings.persistBlockCache)
     component.showProvenStatus.setSelected(settings.showProvenStatus)
     component.showInternalBlocks.setSelected(settings.showInternalBlocks)
+    component.showIdeErrors.setSelected(settings.showIdeErrors)
   }
 }

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -40,7 +40,7 @@ class EdgSettingsComponent {
   showInternalBlocksHelp.setEnabled(false)
 
   val showIdeErrors = new JCheckBox()
-  val showIdeErrorsHelp = new JBLabel("Show detailed IDE internal errors. " +
+  val showIdeErrorsHelp = new JBLabel("Show detailed IDE internal errors in the run console. " +
     "This is generally only useful for developing the IDE itself and may add excessive clutter for HDL work.")
   showIdeErrorsHelp.setEnabled(false)
 


### PR DESCRIPTION
Some errors previously would crash the error panel since it had an indirect path component like IS_CONNECTED, this fixes that by doing the indirect conversion before path addition.

Additionally, creates an option (in the plugin settings panel) to show detailed IDE errors (stack traces) in the run process log.

And rolls the HDL submodule to include the latest KiCad schematic import upgrades and UI improvements.