### PR TITLE
Simplify graphical edit actions

### DIFF
--- a/src/main/scala/edg_ide/psi_edits/InsertBlockAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertBlockAction.scala
@@ -15,7 +15,8 @@ import java.util.concurrent.Callable
 
 
 object InsertBlockAction {
-  val VALID_FUNCTION_NAMES = Seq("__init__", "contents")  // TODO support generators
+  // sorted by preference
+  val VALID_FUNCTION_NAMES = Seq("contents", "__init__")  // TODO support generators
   val VALID_SUPERCLASS = "edg_core.HierarchyBlock.Block"
 
   /** Creates an action to insert a block of type libClass after some PSI element after.

--- a/src/main/scala/edg_ide/psi_edits/InsertConnectAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertConnectAction.scala
@@ -137,7 +137,10 @@ object InsertConnectAction {
                               allPortPairs: Seq[(String, String)], portPairs: Seq[(String, String)],
                               actionName: String, project: Project,
                               continuation: (String, PsiElement) => Unit): Errorable[() => Unit] = exceptable {
-    val containingPsiCall = within match {
+    val containingPsiCall = (within match {  // first extract the statement if needed
+      case within: PyExpressionStatement => within.getExpression
+      case within => within
+    }) match {
       case within: PyCallExpression => within
       case within => PsiTreeUtil.getParentOfType(within, classOf[PyCallExpression])
           .exceptNull(s"not in an call in ${within.getContainingFile.getName}")

--- a/src/main/scala/edg_ide/psi_edits/InsertFootprintAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertFootprintAction.scala
@@ -53,7 +53,7 @@ object InsertFootprintAction {
                                 continuation: PsiElement => Unit): Errorable[() => Unit] = exceptable {
     // Check for general sanity
     val after = InsertAction.getCaretAtFileOfType(
-      container.getContainingFile, classOf[PyStatementList], project, requireClass = false).exceptError
+      container.getContainingFile, classOf[PyStatementList], project).exceptError
     val containingPsiFunction = PsiTreeUtil.getParentOfType(after, classOf[PyFunction])
         .exceptNull(s"not in a function in ${after.getContainingFile.getName}")
     val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFunction, classOf[PyClass])

--- a/src/main/scala/edg_ide/psi_edits/InsertPinningAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertPinningAction.scala
@@ -59,7 +59,7 @@ object InsertPinningAction {
     // TODO Dedup w/ InsertFootprintAction?
     val blockClass = DesignAnalysisUtils.pyClassOf(block.getSelfClass, project).exceptError
     val after = InsertAction.getCaretAtFileOfType(
-      blockClass.getContainingFile, classOf[PyStatementList], project, requireClass = false).exceptError
+      blockClass.getContainingFile, classOf[PyStatementList], project).exceptError
     val containingPsiFunction = PsiTreeUtil.getParentOfType(after, classOf[PyFunction])
         .exceptNull(s"not in a function in ${after.getContainingFile.getName}")
     val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFunction, classOf[PyClass])

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -50,7 +50,7 @@ class BlockRootPopupMenu(project: Project) extends JPopupMenu {
     InsertAction.getCaretAtFileOfType(contextPyClass.exceptError.getContainingFile,
       classOf[PsiFile], project).exceptError
   }
-  val defineClassAtEndAction: Errorable[() => Unit] = exceptable {
+  val defineClassAction: Errorable[() => Unit] = exceptable {
     val blockClass = DesignAnalysisUtils.pyClassOf("edg_core.HierarchyBlock.Block", project)
         .exceptError
     DefineBlockAction.createDefineBlockFlow(
@@ -60,13 +60,13 @@ class BlockRootPopupMenu(project: Project) extends JPopupMenu {
       project, createBlockContinuation).exceptError
   }
   private val defineFileLine = exceptable {
-    defineClassAtEndAction.exceptError
+    defineClassAction.exceptError
     PsiUtils.fileNextLineOf(defineClassAfter.exceptError, project).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
 
-  private val createClassAtEndItem = ContextMenuUtils.MenuItemFromErrorable(
-    defineClassAtEndAction, s"Define new subclass at $contextPyName caret$defineFileLine")
-  add(createClassAtEndItem)
+  private val defineClassItem = ContextMenuUtils.MenuItemFromErrorable(
+    defineClassAction, s"Define new subclass$defineFileLine")
+  add(defineClassItem)
 }
 
 
@@ -100,36 +100,30 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
     }
   }
 
-  val caretInsertAction: Errorable[() => Unit] = exceptable {
-    InsertBlockAction.createInsertBlockFlow(caretPsiElement.exceptError, blockPyClass.exceptError,
-        s"Insert $blockTypeName at $contextPyName caret",
-        project, insertContinuation).exceptError
-  }
-  private val caretFileLine = exceptable {
-    caretInsertAction.exceptError
-    PsiUtils.fileNextLineOf(caretPsiElement.exceptError, project).exceptError
+  // TODO avoid eagerly evaluating all possibilities, if the first ones succeed
+  val insertLocations = Seq(  // all potential insert locations sorted by desirability
+    caretPsiElement.toOption.map(Seq(_)),
+    exceptable {
+      InsertAction.findInsertionElements(contextPyClass.exceptError, InsertBlockAction.VALID_FUNCTION_NAMES)
+    }.toOption
+  ).flatten.flatten
+
+  val insertAction: Errorable[(PsiElement, () => Unit)] = Errorable(insertLocations.flatMap { insertPsiElement =>
+    exceptable {
+      val insertBlockFlow = InsertBlockAction.createInsertBlockFlow(insertPsiElement, blockPyClass.exceptError,
+        s"Insert $blockTypeName", project, insertContinuation)
+      (insertPsiElement, insertBlockFlow.exceptError)
+    }.toOption
+  }.headOption, "no valid locations")
+
+  private val insertFileLine = exceptable {
+    PsiUtils.fileNextLineOf(insertAction.exceptError._1, project).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
 
-  private val caretInsertItem = ContextMenuUtils.MenuItemFromErrorable(
-    caretInsertAction, s"Insert at $contextPyName caret$caretFileLine")
-  add(caretInsertItem)
+  private val insertItem = ContextMenuUtils.MenuItemFromErrorable(
+    insertAction.map(_._2), s"Insert into $contextPyName$insertFileLine")
+  add(insertItem)
 
-  private val insertionPairs = exceptable {
-    InsertAction.findInsertionPoints(contextPyClass.exceptError, InsertBlockAction.VALID_FUNCTION_NAMES).exceptError
-        .map { fn =>
-          val fileLine = PsiUtils.fileNextLineOf(fn.getStatementList.getLastChild, project)
-              .mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
-          val label = s"Insert at ${contextPyName}.${fn.getName}$fileLine"
-          val action = InsertBlockAction.createInsertBlockFlow(fn.getStatementList.getStatements.last, blockPyClass.exceptError,
-            s"Insert $blockTypeName at $contextPyName.${fn.getName}",
-            project, insertContinuation)
-          (label, action)
-        } .collect {
-          case (fn, Errorable.Success(action)) => (fn, action)
-        }.exceptEmpty("no insertion points")
-  }
-  ContextMenuUtils.MenuItemsFromErrorableSeq(insertionPairs, s"Insert into $contextPyName")
-      .foreach(add)
   addSeparator()
 
   // Refinements action
@@ -195,7 +189,7 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
     InsertAction.getCaretAtFileOfType(contextPyClass.exceptError.getContainingFile,
       classOf[PsiFile], project).exceptError
   }
-  val defineClassAtEndAction: Errorable[() => Unit] = exceptable {
+  val defineClassAction: Errorable[() => Unit] = exceptable {
     DefineBlockAction.createDefineBlockFlow(
       defineClassAfter.exceptError,
       blockPyClass.exceptError,
@@ -203,13 +197,13 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
       project, createBlockContinuation).exceptError
   }
   private val defineFileLine = exceptable {
-    defineClassAtEndAction.exceptError
+    defineClassAction.exceptError
     PsiUtils.fileNextLineOf(defineClassAfter.exceptError, project).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
 
-  private val createClassAtEndItem = ContextMenuUtils.MenuItemFromErrorable(
-    defineClassAtEndAction, s"Define new subclass at $contextPyName caret$defineFileLine")
-  add(createClassAtEndItem)
+  private val createClassItem = ContextMenuUtils.MenuItemFromErrorable(
+    defineClassAction, s"Define new subclass$defineFileLine")
+  add(createClassItem)
   addSeparator()
 
   // Navigation actions
@@ -258,38 +252,30 @@ class LibraryPortPopupMenu(portType: ref.LibraryPath, project: Project) extends 
     }
   }
 
-  val caretInsertAction: Errorable[() => Unit] = exceptable {
-    requireExcept(contextPath != DesignPath(), "can't insert port at design top")
-    InsertPortAction.createInsertPortFlow(caretPsiElement.exceptError, portPyClass.exceptError,
-      s"Insert $portTypeName at $contextPyName caret",
-      project, insertContinuation).exceptError
-  }
-  private val caretFileLine = exceptable {
-    caretInsertAction.exceptError
-    PsiUtils.fileNextLineOf(caretPsiElement.exceptError, project).exceptError
+  val insertLocations = Seq(
+    caretPsiElement.toOption.map(Seq(_)),
+    exceptable {
+      InsertAction.findInsertionElements(contextPyClass.exceptError, InsertPortAction.VALID_FUNCTION_NAME)
+    }.toOption
+  ).flatten.flatten
+
+  val insertAction: Errorable[(PsiElement, () => Unit)] = Errorable(insertLocations.flatMap { insertPsiElement =>
+    exceptable {
+      requireExcept(contextPath != DesignPath(), "can't insert port at design top")  // TODO propagate error message
+      val insertPortFlow = InsertPortAction.createInsertPortFlow(insertPsiElement, portPyClass.exceptError,
+        s"Insert $portTypeName at $contextPyName caret", project, insertContinuation)
+      (insertPsiElement, insertPortFlow.exceptError)
+    }.toOption
+  }.headOption, "no valid locations")
+
+  private val insertFileLine = exceptable {
+    PsiUtils.fileNextLineOf(insertAction.exceptError._1, project).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
 
-  private val caretInsertItem = ContextMenuUtils.MenuItemFromErrorable(
-    caretInsertAction, s"Insert at $contextPyName caret$caretFileLine")
-  add(caretInsertItem)
+  private val insertItem = ContextMenuUtils.MenuItemFromErrorable(
+    insertAction.map(_._2), s"Insert into $contextPyName$insertFileLine")
+  add(insertItem)
 
-  private val insertionPairs = exceptable {
-    requireExcept(contextPath != DesignPath(), "can't insert port at design top")
-    InsertAction.findInsertionPoints(contextPyClass.exceptError, Seq(InsertPortAction.VALID_FUNCTION_NAME)).exceptError
-        .map { fn =>
-          val fileLine = PsiUtils.fileNextLineOf(fn.getStatementList.getLastChild, project)
-              .mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
-          val label = s"Insert at ${contextPyName}.${fn.getName}$fileLine"
-          val action = InsertPortAction.createInsertPortFlow(fn.getStatementList.getStatements.last, portPyClass.exceptError,
-            s"Insert $portTypeName at $contextPyName.${fn.getName}",
-            project, insertContinuation)
-          (label, action)
-        } .collect {
-      case (fn, Errorable.Success(action)) => (fn, action)
-    }.exceptEmpty("no insertion points")
-  }
-  ContextMenuUtils.MenuItemsFromErrorableSeq(insertionPairs, s"Insert into $contextPyName")
-      .foreach(add)
   addSeparator()
 
   // Navigation actions
@@ -496,7 +482,7 @@ class LibraryPanel(project: Project) extends JPanel {
           if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) {
             // double click quick insert at caret
             exceptionPopup(e) {
-              (new LibraryBlockPopupMenu(selected.path, project).caretInsertAction.exceptError) ()
+              (new LibraryBlockPopupMenu(selected.path, project).insertAction.exceptError._2) ()
             }
           } else if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) {
             // right click context menu
@@ -507,7 +493,7 @@ class LibraryPanel(project: Project) extends JPanel {
           if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) {
             // double click quick insert at caret
             exceptionPopup(e) {
-              (new LibraryPortPopupMenu(selected.path, project).caretInsertAction.exceptError) ()
+              (new LibraryPortPopupMenu(selected.path, project).insertAction.exceptError._2) ()
             }
           } else if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) {
             // right click context menu

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -255,7 +255,7 @@ class LibraryPortPopupMenu(portType: ref.LibraryPath, project: Project) extends 
   val insertLocations = Seq(
     caretPsiElement.toOption.map(Seq(_)),
     exceptable {
-      InsertAction.findInsertionElements(contextPyClass.exceptError, InsertPortAction.VALID_FUNCTION_NAME)
+      InsertAction.findInsertionElements(contextPyClass.exceptError, Seq(InsertPortAction.VALID_FUNCTION_NAME))
     }.toOption
   ).flatten.flatten
 

--- a/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
@@ -220,8 +220,7 @@ class ConnectPopup(interface: ToolInterface, action: ConnectToolAction,
   private val contextPyName = contextPyClass.mapToString(_.getName)
   private val caretPsiElement = exceptable {
     InsertAction.getCaretAtFileOfType(
-      contextPyClass.exceptError.getContainingFile, classOf[PyStatementList],
-      interface.getProject, requireClass = false).exceptError
+      contextPyClass.exceptError.getContainingFile, classOf[PyStatementList], interface.getProject).exceptError
   }
 
   val appendConnectAction: Errorable[() => Unit] = exceptable {
@@ -237,7 +236,7 @@ class ConnectPopup(interface: ToolInterface, action: ConnectToolAction,
     PsiUtils.fileLineOf(caretPsiElement.exceptError, interface.getProject).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
   private val appendConnectItem = ContextMenuUtils.MenuItemFromErrorable(
-    appendConnectAction, s"Append connect at $contextPyName caret$appendConnectCaretFileLine")
+    appendConnectAction, s"Append connect$appendConnectCaretFileLine")
   add(appendConnectItem)
 
   private val initialPortPair = pathToPairs(action.getInitialPort)
@@ -275,7 +274,7 @@ class ConnectPopup(interface: ToolInterface, action: ConnectToolAction,
     PsiUtils.fileNextLineOf(caretPsiElement.exceptError, interface.getProject).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
   private val insertConnectItem = ContextMenuUtils.MenuItemFromErrorable(
-    insertConnectAction, s"Insert connect at $contextPyName caret$insertConnectCaretFileLine")
+    insertConnectAction, s"Insert connect$insertConnectCaretFileLine")
   add(insertConnectItem)
 
   private val insertionPairs = exceptable {

--- a/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
@@ -236,7 +236,7 @@ class ConnectPopup(interface: ToolInterface, action: ConnectToolAction,
     PsiUtils.fileLineOf(caretPsiElement.exceptError, interface.getProject).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
   private val appendConnectItem = ContextMenuUtils.MenuItemFromErrorable(
-    appendConnectAction, s"Append connect$appendConnectCaretFileLine")
+    appendConnectAction, s"Append connect into $contextPyName$appendConnectCaretFileLine")
   add(appendConnectItem)
 
   private val initialPortPair = pathToPairs(action.getInitialPort)
@@ -274,7 +274,7 @@ class ConnectPopup(interface: ToolInterface, action: ConnectToolAction,
     PsiUtils.fileNextLineOf(caretPsiElement.exceptError, interface.getProject).exceptError
   }.mapToStringOrElse(fileLine => s" ($fileLine)", err => "")
   private val insertConnectItem = ContextMenuUtils.MenuItemFromErrorable(
-    insertConnectAction, s"Insert connect$insertConnectCaretFileLine")
+    insertConnectAction, s"Insert connect into $contextPyName$insertConnectCaretFileLine")
   add(insertConnectItem)
 
   private val insertionPairs = exceptable {


### PR DESCRIPTION
- Removes the "insert into ..." alternatives in the right click menu since those were never used
- Instead rolls those alternatives into the main (including double click) option - it will pick the first viable option: caret, then named functions
- Additionally relaxes the caret positioning requirement, it will infer the end of the current PyStatement (or similar) as the insertion point if the caret is in the middle of a statement
- Only for block and ports
- Graphical edits need more work, this is a stopgap solution