### PR TITLE
Fix exceptions on shutdown

### DIFF
--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -237,8 +237,8 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
   AppExecutorUtil.getAppScheduledExecutorService.scheduleWithFixedDelay(() => {
     // can't use DseService(project) here since this keeps getting called after the panel closes
     // and creates an error
-    // TODO: properly stop the recurring event when this panel is closed?
-    val dseConfigSelected = Option(RunManager.getInstance(project).getSelectedConfiguration)
+    // the outer Option(...) wrapper prevents an error on shutdown after RunManager has been disposed
+    val dseConfigSelected = Option(RunManager.getInstanceIfCreated(project)).map(_.getSelectedConfiguration)
         .map(_.getConfiguration)
         .collect { case config: DseRunConfiguration => config }
         .isDefined

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -104,10 +104,12 @@ class DsePanel(project: Project) extends JPanel {
 
   // Regularly check the selected run config so the panel contents are kept in sync
   AppExecutorUtil.getAppScheduledExecutorService.scheduleWithFixedDelay(() => {
-    val newConfig = DseService(project).getRunConfiguration
-    if (newConfig != displayedConfig) {
-      displayedConfig = newConfig
-      onConfigUpdate()
+    DseService.option(project).map { dseService =>  // option avoids an exception on shutdown, after it's been disposed
+      val newConfig = dseService.getRunConfiguration
+      if (newConfig != displayedConfig) {
+        displayedConfig = newConfig
+        onConfigUpdate()
+      }
     }
   }, 333, 333, TimeUnit.MILLISECONDS)  // seems flakey without initial delay
 

--- a/src/main/scala/edg_ide/ui/DseService.scala
+++ b/src/main/scala/edg_ide/ui/DseService.scala
@@ -17,6 +17,10 @@ object DseService {
   def apply(project: Project): DseService = {
     project.getService(classOf[DseServiceWrapper]).asInstanceOf[DseService]
   }
+
+  def option(project: Project): Option[DseService] = {
+    Option(project.getServiceIfCreated(classOf[DseServiceWrapper])).map(_.asInstanceOf[DseService])
+  }
 }
 
 class DseService(project: Project) extends


### PR DESCRIPTION
As the title suggests, this fixes exceptions on IDE shutdown. The errors were caused by timers accessing trying to access services that have been disposed, this gates those service accesses within timers to only run if the service exists.