### PR TITLE
Ignore non_library parts in findOrderedSubclassesOf

### DIFF
--- a/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
+++ b/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
@@ -358,12 +358,12 @@ object DesignAnalysisUtils {
         .flatMap { case expr: PyReferenceExpression => referenceToClass(expr) }
 
     val (defaults, others) = directSubclasses.flatMap { directSubclass =>
-        val directIfLibrary = if (Option(directSubclass.getDecoratorList).toSeq.flatMap(_.getDecorators.toSeq)
-            .exists(_.getName == "non_library")) {  // don't include non_library subclasses
-          Seq()
-        } else {
-          Seq(directSubclass)
-        }
+      val directIfLibrary = if (Option(directSubclass.getDecoratorList).toSeq.flatMap(_.getDecorators.toSeq)
+          .exists(_.getName == "non_library")) { // don't include non_library subclasses
+        Seq()
+      } else {
+        Seq(directSubclass)
+      }
       directIfLibrary ++ findOrderedSubclassesOf(directSubclass)
     }.distinct.partition(elt => defaultRefinements.contains(elt))
     defaults ++ others


### PR DESCRIPTION
Also rolls the HDL repo, which has changed a lot (though not much on the core compiler side)