### PR TITLE
Mixins

### DIFF
--- a/src/main/scala/edg_ide/EdgirUtils.scala
+++ b/src/main/scala/edg_ide/EdgirUtils.scala
@@ -18,10 +18,10 @@ object EdgirUtils {
   val FootprintBlockType: ref.LibraryPath =
     ElemBuilder.LibraryPath("electronics_model.CircuitBlock.CircuitBlock")
 
-  // TODO refactor into common utils elsewher
+  // TODO refactor into common utils elsewhere
   def typeOfBlockLike(blockLike: elem.BlockLike): Option[ref.LibraryPath] = blockLike.`type` match {
     case elem.BlockLike.Type.Hierarchy(block) => Some(block.getSelfClass)
-    case elem.BlockLike.Type.LibElem(lib) => Some(lib)
+    case elem.BlockLike.Type.LibElem(lib) => Some(lib.getBase)
     case _ => None
   }
 

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -19,7 +19,9 @@ case class BlockWrapper(path: DesignPath, blockLike: elem.BlockLike) extends Nod
     case elem.BlockLike.Type.Hierarchy(block) =>
       block.getSelfClass.toSimpleString
     case elem.BlockLike.Type.LibElem(lib) =>
-      s"lib: ${lib.toSimpleString}"
+      require(lib.mixins.isEmpty) // TODO support mixins
+      val allTypes = Seq(lib.getBase) ++ lib.mixins
+      s"lib: ${allTypes.map(_.toSimpleString).mkString("+")}"
     case other => other.getClass.getName
   }
 }

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -19,7 +19,6 @@ case class BlockWrapper(path: DesignPath, blockLike: elem.BlockLike) extends Nod
     case elem.BlockLike.Type.Hierarchy(block) =>
       block.getSelfClass.toSimpleString
     case elem.BlockLike.Type.LibElem(lib) =>
-      require(lib.mixins.isEmpty) // TODO support mixins
       val allTypes = Seq(lib.getBase) ++ lib.mixins
       s"lib: ${allTypes.map(_.toSimpleString).mkString("+")}"
     case other => other.getClass.getName

--- a/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
+++ b/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
@@ -181,7 +181,7 @@ class ElementDetailNodes(
     block.`type` match {
       case elem.BlockLike.Type.Hierarchy(block) => new BlockNode(path, block)
       case elem.BlockLike.Type.LibElem(block) =>
-        new UnelaboratedNode(path, s"unelaborated ${block.toSimpleString}")
+        new UnelaboratedNode(path, s"unelaborated ${block.getBase.toSimpleString}")
       case _ =>
         new UnelaboratedNode(path, "unknown")
     }

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -12,7 +12,7 @@ import edg_ide.dse.{DseClassParameterSearch, DseFeature, DseObjectiveParameter, 
 import edg_ide.psi_edits.{InsertAction, InsertRefinementAction}
 import edg_ide.swing.{ElementDetailTreeModel, TreeTableUtils}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptOption, ExceptSeq}
-import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
+import edg_ide.util.{DesignAnalysisUtils, LibraryUtils, exceptable, requireExcept}
 import edg_ide.{EdgirUtils, swing}
 import edgir.schema.schema
 import edgrpc.hdl.{hdl => edgrpc}
@@ -72,9 +72,9 @@ class DetailParamPopupMenu(
     val (blockPath, block) = EdgirUtils.resolveDeepestBlock(directPath, design)
     val postfix = directPath.postfixFromOption(blockPath).get
     val paramName = postfix.steps.onlyExcept("not a block param").getName
-    val paramDefiningClass = compiler.library
-      .blockParamGetDefiningSuperclass(block.getSelfClass, paramName)
-      .exceptNone("no param-defining class")
+    val paramDefiningClass =
+      LibraryUtils.blockParamGetDefiningSuperclass(compiler.library, block.getSelfClass, paramName)
+        .exceptNone("no param-defining class")
     (paramDefiningClass, postfix)
   }
 

--- a/src/main/scala/edg_ide/util/LibraryUtils.scala
+++ b/src/main/scala/edg_ide/util/LibraryUtils.scala
@@ -1,0 +1,30 @@
+package edg_ide.util
+
+import edg.EdgirUtils.SimpleLibraryPath
+import edg.wir.Library
+import edg.wir.ProtoUtil.ParamProtoToSeqMap
+import edgir.ref.ref
+
+object LibraryUtils {
+  // returns the top-most superclass that defines some parameter name
+  // returns None if thisClass does not define the parameter, and errors out if there are multiple top-most superclasses
+  def blockParamGetDefiningSuperclass(
+      library: Library,
+      thisClass: ref.LibraryPath,
+      paramName: String
+  ): Option[ref.LibraryPath] = {
+    val thisBlock = library.getBlock(thisClass, ignoreRefinements = true).get
+    if (thisBlock.params.get(paramName).isEmpty) {
+      return None
+    }
+    val definingSuperclasses = thisBlock.superclasses.flatMap { superclass =>
+      blockParamGetDefiningSuperclass(library, superclass, paramName)
+    }.distinct
+    definingSuperclasses match {
+      case Seq() => Some(thisClass)
+      case Seq(baseClass) => Some(baseClass)
+      case _ =>
+        throw new IllegalArgumentException(s"multiple superclasses of ${thisClass.toSimpleString} defines $paramName")
+    }
+  }
+}


### PR DESCRIPTION
Update IDE for mixins PR in HDL, and roll the HDL submodule.

`blockParamGetDefiningSuperclass` is moved into the IDE as it is now only used here and the base library class no longer has analysis functionality.