### PR TITLE
Deprioritize internal blocks on library tree

### DIFF
--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -659,11 +659,16 @@ class LibraryPanel(project: Project) extends JPanel {
         case node: EdgirLibraryNode#PortNode =>
           searchTerms.forall(searchTerm => node.path.toSimpleString.toLowerCase().contains(searchTerm))
         case other => false
+      }.filter { path =>
+        !path.getPath.exists {
+          case node: EdgirLibraryNode#BlockNode
+            if node.path == EdgirLibraryTreeTableModel.kInternalBlockPath => true // don't expand InternalBlock
+          case _ => false
+        }
       }
       filteredPaths.foreach { filteredPath =>
         recursiveExpandPath(filteredPath)
       }
-
     }
   }
   libraryTreeSearch.getDocument.addDocumentListener(new DocumentListener() {


### PR DESCRIPTION
... both by sorting to the bottom, and not expanding in filter-search