### PR TITLE
Insertion live template for connections

### DIFF
--- a/src/main/scala/edg_ide/psi_edits/InsertAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertAction.scala
@@ -44,6 +44,7 @@ object InsertAction {
 
     // given the leaf element at the caret, returns the rootmost element right before the caret
     def prevElementOf(element: PsiElement): PsiElement = {
+      requireExcept(element.getTextRange != null, "element with null range") // if traversing beyond file level
       if (element.getTextRange.getStartOffset == caretOffset) { // caret at beginning of element, so take the previous
         val prev = PsiTreeUtil.prevLeaf(element)
         prevElementOf(prev.exceptNull("no element before caret"))

--- a/src/main/scala/edg_ide/psi_edits/InsertBlockAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertBlockAction.scala
@@ -1,16 +1,15 @@
 package edg_ide.psi_edits
 
-import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.application.{ModalityState, ReadAction}
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.{PsiElement, PsiWhiteSpace}
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.jetbrains.python.psi._
 import edg.util.Errorable
-import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption, ExceptSeq}
-import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptSeq}
+import edg_ide.util.{DesignAnalysisUtils, exceptable}
 
 import java.util.concurrent.Callable
 
@@ -111,149 +110,4 @@ object InsertBlockAction {
     () => insertBlockFlow
   }
 
-  /** Creates an action to start a live template to insert a block.
-    */
-  def createTemplateBlock(
-      contextClass: PyClass,
-      libClass: PyClass,
-      actionName: String,
-      project: Project,
-      continuation: (String, PsiElement) => Unit
-  ): Errorable[() => Unit] = exceptable {
-    val languageLevel = LanguageLevel.forElement(libClass)
-    val psiElementGenerator = PyElementGenerator.getInstance(project)
-
-    // given some caret position, returns the best insertion position
-    def getInsertionElt(caretEltOpt: Option[PsiElement]): PsiElement = {
-      exceptable { // TODO better propagation of error messages
-        val caretElt = caretEltOpt.exceptNone("no elt at caret")
-        val caretStatement = InsertAction.snapInsertionEltOfType[PyStatement](caretElt).get
-        val containingPsiFn = PsiTreeUtil
-          .getParentOfType(caretStatement, classOf[PyFunction])
-          .exceptNull(s"caret not in a function")
-        val containingPsiClass = PsiTreeUtil
-          .getParentOfType(containingPsiFn, classOf[PyClass])
-          .exceptNull(s"caret not in a class")
-        requireExcept(containingPsiClass == contextClass, s"caret not in class of type ${libClass.getName}")
-        caretStatement
-      }.toOption.orElse {
-        val candidates =
-          InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES)
-        candidates.headOption
-      }.get // TODO insert contents() if needed
-    }
-
-    val movableLiveTemplate = new MovableLiveTemplate(actionName) {
-      override def startTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
-        val insertAfter = getInsertionElt(caretEltOpt)
-        val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
-        val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
-        val selfName = containingPsiFn.getParameterList.getParameters.toSeq
-          .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
-          .head
-          .getName
-
-        val newAssignTemplate = psiElementGenerator.createFromText(
-          languageLevel,
-          classOf[PyAssignmentStatement],
-          s"$selfName.name = $selfName.Block(${libClass.getName}())"
-        )
-        val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
-
-        val newAssign =
-          containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
-        val newArgList = newAssign.getAssignedValue
-          .asInstanceOf[PyCallExpression]
-          .getArgument(0, classOf[PyCallExpression])
-          .getArgumentList
-
-        val initParams =
-          DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
-        val allParams = initParams._1 ++ initParams._2
-
-        val nameTemplateVar = new InsertionLiveTemplate.Reference(
-          "name",
-          newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
-          InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
-          defaultValue = Some("")
-        )
-
-        val argTemplateVars = allParams.map { initParam =>
-          val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
-            case Some(typed) => f": $typed"
-            case None => ""
-          })
-
-          if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
-            newArgList.addArgument(psiElementGenerator.createEllipsis())
-            new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
-          } else { // optional argument
-            // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
-            newArgList.addArgument(
-              psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
-            )
-            new InsertionLiveTemplate.Variable(
-              f"$paramName (optional)",
-              newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
-              defaultValue = Some("")
-            )
-          }
-        }
-
-        new InsertionLiveTemplate(newAssign, IndexedSeq(nameTemplateVar) ++ argTemplateVars)
-      }
-    }
-
-    movableLiveTemplate.addTemplateStateListener(new TemplateFinishedListener {
-      override def templateFinished(state: TemplateState, brokenOff: Boolean): Unit = {
-        val expr = state.getExpressionContextForSegment(0)
-        if (expr.getTemplateEndOffset <= expr.getTemplateStartOffset) {
-          return // ignored if template was deleted, including through moving the template
-        }
-
-        val insertedName = state.getVariableValue("name").getText
-        if (insertedName.isEmpty && brokenOff) { // canceled by esc while name is empty
-          writeCommandAction(project)
-            .withName(s"cancel $actionName")
-            .compute(() => {
-              TemplateUtils.deleteTemplate(state)
-            })
-        } else {
-          var templateElem = state.getExpressionContextForSegment(0).getPsiElementAtStartOffset
-          while (templateElem.isInstanceOf[PsiWhiteSpace]) { // ignore inserted whitespace before the statement
-            templateElem = templateElem.getNextSibling
-          }
-          try {
-            val args = templateElem
-              .asInstanceOf[PyAssignmentStatement]
-              .getAssignedValue
-              .asInstanceOf[PyCallExpression] // the self.Block(...) call
-              .getArgument(0, classOf[PyCallExpression]) // the object instantiation
-              .getArgumentList // args to the object instantiation
-            val deleteArgs = args.getArguments.flatMap { // remove empty kwargs
-              case arg: PyKeywordArgument => if (arg.getValueExpression == null) Some(arg) else None
-              case _ => None // ignored
-            }
-            writeCommandAction(project)
-              .withName(s"clean $actionName")
-              .compute(() => {
-                deleteArgs.foreach(_.delete())
-              })
-          } finally {
-            continuation(insertedName, templateElem)
-          }
-        }
-      }
-    })
-
-    val caretElt = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
-    def insertBlockFlow: Unit = {
-      writeCommandAction(project)
-        .withName(s"$actionName")
-        .compute(() => {
-          movableLiveTemplate.run(caretElt)
-        })
-    }
-    () => insertBlockFlow
-  }
 }

--- a/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
@@ -247,9 +247,10 @@ class InsertionLiveTemplate(elt: PsiElement, variables: IndexedSeq[InsertionLive
     // if the editor just started, it isn't marked as showing and the tooltip creation crashes
     // TODO the positioning is still off, but at least it doesn't crash
     UIUtil.markAsShowing(editor.getContentComponent, true)
+    val firstVariableName = variables.headOption.map(_.name).getOrElse("")
     val tooltipString = initialTooltip match {
-      case Some(initialTooltip) => f"${variables.head.name} | $initialTooltip"
-      case None => f"${variables.head.name}"
+      case Some(initialTooltip) => f"$firstVariableName | $initialTooltip"
+      case None => firstVariableName
     }
     val tooltip = createTemplateTooltip(tooltipString, editor)
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -36,6 +36,7 @@ object LiveTemplateConnect {
           .exceptNull(s"caret not in a class")
         requireExcept(containingPsiClass == contextClass, s"caret not in class of type ${contextClass.getName}")
         caretStatement
+        ???
       }
     }
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -37,8 +37,8 @@ object LiveTemplateConnect {
     case PortConnects.BlockPort(blockName, portName) => Some(blockName.takeWhile(_ != '['))
     case PortConnects.BoundaryPort(portName, _) => Some(portName)
     case PortConnects.BlockVectorUnit(blockName, portName) => Some(blockName.takeWhile(_ != '['))
-    case PortConnects.BlockVectorSlicePort(blockName, portName, _) => Some(portName)
-    case PortConnects.BlockVectorSliceVector(blockName, portName, _) => Some(portName)
+    case PortConnects.BlockVectorSlicePort(blockName, portName, _) => Some(blockName.takeWhile(_ != '['))
+    case PortConnects.BlockVectorSliceVector(blockName, portName, _) => Some(blockName.takeWhile(_ != '['))
     case PortConnects.BlockVectorSlice(blockName, portName, _) => Some(blockName.takeWhile(_ != '['))
     case PortConnects.BoundaryPortVectorUnit(portName) => Some(portName)
   }

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -11,6 +11,8 @@ import edg_ide.util.ExceptionNotifyImplicits.ExceptSeq
 import edg_ide.util.{DesignAnalysisUtils, PortConnects, exceptable}
 
 object LiveTemplateConnect {
+  protected val kTemplateVariableName = "name (optional)"
+
   // generate the reference Python HDL code for a PortConnect
   protected def connectedToRefCode(selfName: String, connect: PortConnects.Base): String = connect match {
     case PortConnects.BlockPort(blockName, portName) => s"$selfName.$blockName.$portName"
@@ -100,7 +102,7 @@ object LiveTemplateConnect {
         }
 
         val nameTemplateVar = new InsertionLiveTemplate.Reference(
-          "name (optional)",
+          kTemplateVariableName,
           newConnect.getTargets.head.asInstanceOf[PyTargetExpression],
           defaultValue = Some("")
         )
@@ -116,7 +118,7 @@ object LiveTemplateConnect {
           return // ignored if template was deleted, including through moving the template
         }
 
-        val insertedName = state.getVariableValue("name (optional)").getText
+        val insertedName = state.getVariableValue(kTemplateVariableName).getText
         val insertedNameOpt = if (insertedName.isEmpty) None else Some(insertedName)
         if (insertedNameOpt.isEmpty && brokenOff) { // canceled by esc while name is empty
           writeCommandAction(project)

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -5,10 +5,20 @@ import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import com.jetbrains.python.psi.{PyClass, PyFunction, PyStatement}
+import com.jetbrains.python.psi.{
+  LanguageLevel,
+  PyAssignmentStatement,
+  PyCallExpression,
+  PyClass,
+  PyElementGenerator,
+  PyFunction,
+  PyStatement,
+  PyStatementList,
+  PyTargetExpression
+}
 import edgir.elem.elem
 import edg.util.Errorable
-import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption}
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption, ExceptSeq}
 import edg_ide.util.{ConnectBuilder, PortConnects, exceptable, requireExcept}
 
 object LiveTemplateConnect {
@@ -22,21 +32,46 @@ object LiveTemplateConnect {
       newConnects: Seq[PortConnects.Base],
       continuation: (String, PsiElement) => Unit
   ): Errorable[() => Unit] = exceptable {
+    val languageLevel = LanguageLevel.forElement(contextClass)
+    val psiElementGenerator = PyElementGenerator.getInstance(project)
 
     val movableLiveTemplate = new MovableLiveTemplate(actionName) {
       // TODO startTemplate should be able to fail - Errorable
       override def startTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
-        val caretElt = caretEltOpt.exceptNone("no elt at caret")
-        val caretStatement = InsertAction.snapInsertionEltOfType[PyStatement](caretElt).get
-        val containingPsiFn = PsiTreeUtil
-          .getParentOfType(caretStatement, classOf[PyFunction])
-          .exceptNull(s"caret not in a function")
-        val containingPsiClass = PsiTreeUtil
-          .getParentOfType(containingPsiFn, classOf[PyClass])
-          .exceptNull(s"caret not in a class")
-        requireExcept(containingPsiClass == contextClass, s"caret not in class of type ${contextClass.getName}")
-        caretStatement
-        ???
+        val validCaretEltOpt = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
+        // TODO support append to existing connect
+        val insertAfter = validCaretEltOpt
+          .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
+
+        val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
+        val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
+        val selfName = containingPsiFn.getParameterList.getParameters.toSeq
+          .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
+          .head
+          .getName
+        val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
+
+        val newConnectTemplate = psiElementGenerator.createFromText(
+          languageLevel,
+          classOf[PyAssignmentStatement],
+          s"$selfName.name = $selfName.connect()"
+        )
+        val newConnect =
+          containingStmtList.addAfter(newConnectTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
+        val newConnectArgs = newConnect.getAssignedValue
+          .asInstanceOf[PyCallExpression]
+          .getArgumentList
+
+        // TODO ADD ALL THE CONNECTS
+
+        val nameTemplateVar = new InsertionLiveTemplate.Reference(
+          "name",
+          newConnect.getTargets.head.asInstanceOf[PyTargetExpression],
+          InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
+          defaultValue = Some("")
+        )
+
+        new InsertionLiveTemplate(newConnect, IndexedSeq(nameTemplateVar))
       }
     }
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -4,10 +4,12 @@ import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.jetbrains.python.psi.PyClass
+import com.intellij.psi.util.PsiTreeUtil
+import com.jetbrains.python.psi.{PyClass, PyFunction, PyStatement}
 import edgir.elem.elem
 import edg.util.Errorable
-import edg_ide.util.{ConnectBuilder, PortConnects, exceptable}
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption}
+import edg_ide.util.{ConnectBuilder, PortConnects, exceptable, requireExcept}
 
 object LiveTemplateConnect {
   // Creates an action to start a live template to insert the connection
@@ -22,8 +24,18 @@ object LiveTemplateConnect {
   ): Errorable[() => Unit] = exceptable {
 
     val movableLiveTemplate = new MovableLiveTemplate(actionName) {
+      // TODO startTemplate should be able to fail - Errorable
       override def startTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
-        ???
+        val caretElt = caretEltOpt.exceptNone("no elt at caret")
+        val caretStatement = InsertAction.snapInsertionEltOfType[PyStatement](caretElt).get
+        val containingPsiFn = PsiTreeUtil
+          .getParentOfType(caretStatement, classOf[PyFunction])
+          .exceptNull(s"caret not in a function")
+        val containingPsiClass = PsiTreeUtil
+          .getParentOfType(containingPsiFn, classOf[PyClass])
+          .exceptNull(s"caret not in a class")
+        requireExcept(containingPsiClass == contextClass, s"caret not in class of type ${contextClass.getName}")
+        caretStatement
       }
     }
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -100,7 +100,7 @@ object LiveTemplateConnect {
         }
 
         val nameTemplateVar = new InsertionLiveTemplate.Reference(
-          "name",
+          "name (optional)",
           newConnect.getTargets.head.asInstanceOf[PyTargetExpression],
           defaultValue = Some("")
         )

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -17,7 +17,7 @@ object LiveTemplateConnect {
       project: Project,
       container: elem.HierarchyBlock,
       baseConnected: ConnectBuilder,
-      newConnects: PortConnects.ConstraintBase,
+      newConnects: Seq[PortConnects.Base],
       continuation: (String, PsiElement) => Unit
   ): Errorable[() => Unit] = exceptable {
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -1,0 +1,47 @@
+package edg_ide.psi_edits
+
+import com.intellij.codeInsight.template.impl.TemplateState
+import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.jetbrains.python.psi.PyClass
+import edgir.elem.elem
+import edg.util.Errorable
+import edg_ide.util.{ConnectBuilder, PortConnects, exceptable}
+
+object LiveTemplateConnect {
+  // Creates an action to start a live template to insert the connection
+  def createTemplateConnect(
+      contextClass: PyClass,
+      actionName: String,
+      project: Project,
+      container: elem.HierarchyBlock,
+      baseConnected: ConnectBuilder,
+      newConnects: PortConnects.ConstraintBase,
+      continuation: (String, PsiElement) => Unit
+  ): Errorable[() => Unit] = exceptable {
+
+    val movableLiveTemplate = new MovableLiveTemplate(actionName) {
+      override def startTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
+        ???
+      }
+    }
+
+    movableLiveTemplate.addTemplateStateListener(new TemplateFinishedListener {
+      override def templateFinished(state: TemplateState, brokenOff: Boolean): Unit = {
+        ???
+      }
+    })
+
+    val caretElt = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
+    def insertBlockFlow: Unit = {
+      writeCommandAction(project)
+        .withName(s"$actionName")
+        .compute(() => {
+          movableLiveTemplate.run(caretElt)
+        })
+    }
+
+    () => insertBlockFlow
+  }
+}

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -46,7 +46,6 @@ object LiveTemplateConnect {
       contextClass: PyClass,
       actionName: String,
       project: Project,
-      baseConnected: ConnectBuilder,
       startingConnect: PortConnects.Base,
       newConnects: Seq[PortConnects.Base],
       continuation: (Option[String], PsiElement) => Unit,

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -128,7 +128,7 @@ object LiveTemplateConnect {
 
         // validation complete, start the template
         val connectsToAdd = allConnects.filter(!matchingConnects.contains(_))
-        val newArgs = connectsToAdd.map { newConnect =>
+        connectsToAdd.foreach { newConnect =>
           callCandidate.getArgumentList.addArgument(psiElementGenerator.createExpressionFromText(
             languageLevel,
             connectedToRefCode(selfName, newConnect)
@@ -144,11 +144,12 @@ object LiveTemplateConnect {
         val allRequiredAttrs = allConnects.flatMap(connectedToRequiredAttr)
         val earliestPosition = TemplateUtils.getLastAttributeAssignment(contextClass, allRequiredAttrs, project)
 
-        caretEltOpt.foreach { caretElt => // check if caret is in a connect
-          tryStartStatementInsertionTemplate(caretElt, earliestPosition).foreach {
-            return _
-          }
-        } // otherwise continue to stmt insertion
+        // TODO live template insertion needs to support modifying AST nodes (instead of only addition)
+//        caretEltOpt.foreach { caretElt => // check if caret is in a connect
+//          tryStartStatementInsertionTemplate(caretElt, earliestPosition).foreach {
+//            return _
+//          }
+//        } // otherwise continue to stmt insertion
 
         val validCaretEltOpt = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
         val preInsertAfter = validCaretEltOpt

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -7,8 +7,8 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.{PsiElement, PsiWhiteSpace}
 import com.jetbrains.python.psi._
 import edg.util.Errorable
-import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption, ExceptSeq}
-import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
+import edg_ide.util.ExceptionNotifyImplicits.ExceptSeq
+import edg_ide.util.{DesignAnalysisUtils, exceptable}
 
 object LiveTemplateInsertBlock {
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -1,0 +1,162 @@
+package edg_ide.psi_edits
+
+import com.intellij.codeInsight.template.impl.TemplateState
+import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
+import com.intellij.openapi.project.Project
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.{PsiElement, PsiWhiteSpace}
+import com.jetbrains.python.psi._
+import edg.util.Errorable
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption, ExceptSeq}
+import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
+
+object LiveTemplateInsertBlock {
+
+  /** Creates an action to start a live template to insert a block.
+    */
+  def createTemplateBlock(
+      contextClass: PyClass,
+      libClass: PyClass,
+      actionName: String,
+      project: Project,
+      continuation: (String, PsiElement) => Unit
+  ): Errorable[() => Unit] = exceptable {
+    val languageLevel = LanguageLevel.forElement(libClass)
+    val psiElementGenerator = PyElementGenerator.getInstance(project)
+
+    // given some caret position, returns the best insertion position
+    def getInsertionElt(caretEltOpt: Option[PsiElement]): PsiElement = {
+      exceptable { // TODO better propagation of error messages
+        val caretElt = caretEltOpt.exceptNone("no elt at caret")
+        val caretStatement = InsertAction.snapInsertionEltOfType[PyStatement](caretElt).get
+        val containingPsiFn = PsiTreeUtil
+          .getParentOfType(caretStatement, classOf[PyFunction])
+          .exceptNull(s"caret not in a function")
+        val containingPsiClass = PsiTreeUtil
+          .getParentOfType(containingPsiFn, classOf[PyClass])
+          .exceptNull(s"caret not in a class")
+        requireExcept(containingPsiClass == contextClass, s"caret not in class of type ${libClass.getName}")
+        caretStatement
+      }.toOption.orElse {
+        val candidates =
+          InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES)
+        candidates.headOption
+      }.get // TODO insert contents() if needed
+    }
+
+    val movableLiveTemplate = new MovableLiveTemplate(actionName) {
+      override def startTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
+        val insertAfter = getInsertionElt(caretEltOpt)
+        val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
+        val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
+        val selfName = containingPsiFn.getParameterList.getParameters.toSeq
+          .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
+          .head
+          .getName
+
+        val newAssignTemplate = psiElementGenerator.createFromText(
+          languageLevel,
+          classOf[PyAssignmentStatement],
+          s"$selfName.name = $selfName.Block(${libClass.getName}())"
+        )
+        val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
+
+        val newAssign =
+          containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
+        val newArgList = newAssign.getAssignedValue
+          .asInstanceOf[PyCallExpression]
+          .getArgument(0, classOf[PyCallExpression])
+          .getArgumentList
+
+        val initParams =
+          DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
+        val allParams = initParams._1 ++ initParams._2
+
+        val nameTemplateVar = new InsertionLiveTemplate.Reference(
+          "name",
+          newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
+          InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
+          defaultValue = Some("")
+        )
+
+        val argTemplateVars = allParams.map { initParam =>
+          val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
+            case Some(typed) => f": $typed"
+            case None => ""
+          })
+
+          if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
+            newArgList.addArgument(psiElementGenerator.createEllipsis())
+            new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
+          } else { // optional argument
+            // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
+            newArgList.addArgument(
+              psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
+            )
+            new InsertionLiveTemplate.Variable(
+              f"$paramName (optional)",
+              newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
+              defaultValue = Some("")
+            )
+          }
+        }
+
+        new InsertionLiveTemplate(newAssign, IndexedSeq(nameTemplateVar) ++ argTemplateVars)
+      }
+    }
+
+    movableLiveTemplate.addTemplateStateListener(new TemplateFinishedListener {
+      override def templateFinished(state: TemplateState, brokenOff: Boolean): Unit = {
+        val expr = state.getExpressionContextForSegment(0)
+        if (expr.getTemplateEndOffset <= expr.getTemplateStartOffset) {
+          return // ignored if template was deleted, including through moving the template
+        }
+
+        val insertedName = state.getVariableValue("name").getText
+        if (insertedName.isEmpty && brokenOff) { // canceled by esc while name is empty
+          writeCommandAction(project)
+            .withName(s"cancel $actionName")
+            .compute(() => {
+              TemplateUtils.deleteTemplate(state)
+            })
+        } else {
+          var templateElem = state.getExpressionContextForSegment(0).getPsiElementAtStartOffset
+          while (templateElem.isInstanceOf[PsiWhiteSpace]) { // ignore inserted whitespace before the statement
+            templateElem = templateElem.getNextSibling
+          }
+          try {
+            val args = templateElem
+              .asInstanceOf[PyAssignmentStatement]
+              .getAssignedValue
+              .asInstanceOf[PyCallExpression] // the self.Block(...) call
+              .getArgument(0, classOf[PyCallExpression]) // the object instantiation
+              .getArgumentList // args to the object instantiation
+            val deleteArgs = args.getArguments.flatMap { // remove empty kwargs
+              case arg: PyKeywordArgument => if (arg.getValueExpression == null) Some(arg) else None
+              case _ => None // ignored
+            }
+            writeCommandAction(project)
+              .withName(s"clean $actionName")
+              .compute(() => {
+                deleteArgs.foreach(_.delete())
+              })
+          } finally {
+            continuation(insertedName, templateElem)
+          }
+        }
+      }
+    })
+
+    val caretElt = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
+
+    def insertBlockFlow: Unit = {
+      writeCommandAction(project)
+        .withName(s"$actionName")
+        .compute(() => {
+          movableLiveTemplate.run(caretElt)
+        })
+    }
+
+    () => insertBlockFlow
+  }
+}

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -122,9 +122,10 @@ object LiveTemplateInsertBlock {
               .compute(() => {
                 deleteArgs.foreach(_.delete())
               })
-          } finally {
-            continuation(insertedName, templateElem)
+          } catch {
+            case _: Throwable => // ignore
           }
+          continuation(insertedName, templateElem)
         }
       }
     })

--- a/src/main/scala/edg_ide/psi_edits/TemplateUtils.scala
+++ b/src/main/scala/edg_ide/psi_edits/TemplateUtils.scala
@@ -3,6 +3,10 @@ package edg_ide.psi_edits
 import com.intellij.codeInsight.template.{Template, TemplateEditingAdapter}
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.jetbrains.python.psi.{PyClass, PyFunction, PyStatement}
+import edg_ide.util.ExceptionNotifyImplicits.ExceptNotify
+import edg_ide.util.requireExcept
 
 import scala.collection.mutable
 
@@ -34,6 +38,19 @@ object TemplateUtils {
       }
     }
     templateState.update() // update to end the template
+  }
+
+  // given some caret position, returns the top-level statement if it's valid for statement insertion
+  def getInsertionStmt(caretElt: PsiElement, requiredContextClass: PyClass): Option[PyStatement] = {
+    val caretStatement = InsertAction.snapInsertionEltOfType[PyStatement](caretElt).get
+    val containingPsiFn = PsiTreeUtil
+      .getParentOfType(caretStatement, classOf[PyFunction])
+    if (containingPsiFn == null) return None
+    val containingPsiClass = PsiTreeUtil
+      .getParentOfType(containingPsiFn, classOf[PyClass])
+    if (containingPsiClass == null) return None
+    if (containingPsiClass != requiredContextClass) return None
+    Some(caretStatement)
   }
 }
 

--- a/src/main/scala/edg_ide/psi_edits/TemplateUtils.scala
+++ b/src/main/scala/edg_ide/psi_edits/TemplateUtils.scala
@@ -2,11 +2,12 @@ package edg_ide.psi_edits
 
 import com.intellij.codeInsight.template.{Template, TemplateEditingAdapter}
 import com.intellij.codeInsight.template.impl.TemplateState
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.python.psi.{PyClass, PyFunction, PyStatement}
 import edg_ide.util.ExceptionNotifyImplicits.ExceptNotify
-import edg_ide.util.requireExcept
+import edg_ide.util.{DesignAnalysisUtils, requireExcept}
 
 import scala.collection.mutable
 
@@ -51,6 +52,15 @@ object TemplateUtils {
     if (containingPsiClass == null) return None
     if (containingPsiClass != requiredContextClass) return None
     Some(caretStatement)
+  }
+
+  // given a class and a list of attributes, returns the last attribute assignment, if any
+  def getLastAttributeAssignment(psiClass: PyClass, attrs: Seq[String], project: Project): Option[PyStatement] = {
+    attrs.flatMap { attr =>
+      DesignAnalysisUtils.findAssignmentsTo(psiClass, attr, project)
+    }.sortWith { case (a, b) =>
+      DesignAnalysisUtils.elementAfterEdg(a, b, project).getOrElse(false)
+    }.lastOption
   }
 }
 

--- a/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
+++ b/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
@@ -195,16 +195,18 @@ class JBlockDiagramVisualizer(var rootNode: ElkNode, var showTop: Boolean = fals
     val elementGraphics = mouseOverElts.map { elt => elt -> mouseoverModifier } ++
       errorElts.map { elt => elt -> errorModifier } ++
       selected.map { elt => elt -> selectedModifier } ++
-      unselectable.map { elt => elt -> dimGraphics } ++
       staleElts.map { elt => elt -> staleModifier }
+    // unselectable handled separately - when highlighting is active, it is treated as dimmed with the rest
 
     val backgroundPaintGraphics = paintGraphics.create().asInstanceOf[Graphics2D]
     backgroundPaintGraphics.setBackground(this.getBackground)
     val painter = highlighted match {
       case None => // normal rendering
-        new StubEdgeElkNodePainter(rootNode, showTop, zoomLevel, elementGraphics = elementGraphics)
+        val innerElementGraphics = elementGraphics ++
+          unselectable.map { elt => elt -> dimGraphics }
+        new StubEdgeElkNodePainter(rootNode, showTop, zoomLevel, elementGraphics = innerElementGraphics)
       case Some(highlighted) => // default dim rendering
-        val highlightedElementGraphics = highlighted.toSeq.map { elt =>
+        val highlightedElementGraphics = (highlighted -- unselectable).toSeq.map { elt =>
           elt -> ElementGraphicsModifier( // undo the dim rendering for highlighted
             strokeGraphics = ElementGraphicsModifier.withColor(getForeground),
             textGraphics = ElementGraphicsModifier.withColor(getForeground)

--- a/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
+++ b/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
@@ -204,13 +204,12 @@ class JBlockDiagramVisualizer(var rootNode: ElkNode, var showTop: Boolean = fals
       case None => // normal rendering
         new StubEdgeElkNodePainter(rootNode, showTop, zoomLevel, elementGraphics = elementGraphics)
       case Some(highlighted) => // default dim rendering
-        val highlightedElementGraphics = elementGraphics ++
-          highlighted.map { elt =>
-            elt -> ElementGraphicsModifier( // undo the dim rendering for highlighted
-              strokeGraphics = ElementGraphicsModifier.withColor(getForeground),
-              textGraphics = ElementGraphicsModifier.withColor(getForeground)
-            )
-          }
+        val highlightedElementGraphics = highlighted.toSeq.map { elt =>
+          elt -> ElementGraphicsModifier( // undo the dim rendering for highlighted
+            strokeGraphics = ElementGraphicsModifier.withColor(getForeground),
+            textGraphics = ElementGraphicsModifier.withColor(getForeground)
+          )
+        } ++ elementGraphics
         new StubEdgeElkNodePainter(
           rootNode,
           showTop,

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -418,6 +418,9 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
     if (activeTool != defaultTool) { // revert to the default tool
       toolInterface.endTool() // TODO should we also preserve state like selected?
     }
+
+    stalePaths.clear()
+    updateStale()
   }
 
   /** Updates the design tree only, where the overall "top design" does not change. Mainly used for speculative updates

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -27,7 +27,7 @@ import edgrpc.hdl.{hdl => edgrpc}
 import org.eclipse.elk.graph.{ElkGraphElement, ElkNode}
 
 import java.awt.datatransfer.DataFlavor
-import java.awt.event.{ComponentAdapter, ComponentEvent, MouseAdapter, MouseEvent}
+import java.awt.event.{ComponentAdapter, ComponentEvent, KeyAdapter, KeyEvent, MouseAdapter, MouseEvent}
 import java.awt.{BorderLayout, GridBagConstraints, GridBagLayout}
 import java.io.{File, FileInputStream}
 import java.util.concurrent.{Callable, TimeUnit}
@@ -215,6 +215,12 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
       }
     }
   }
+  graph.addKeyListener(new KeyAdapter {
+    override def keyPressed(e: KeyEvent): Unit = {
+      activeTool.onKeyPress(e)
+    }
+  })
+
   private val centeringGraph = new JPanel(new GridBagLayout)
   centeringGraph.add(graph, new GridBagConstraints())
 

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -659,11 +659,16 @@ class LibraryPanel(project: Project) extends JPanel {
         case node: EdgirLibraryNode#PortNode =>
           searchTerms.forall(searchTerm => node.path.toSimpleString.toLowerCase().contains(searchTerm))
         case other => false
+      }.filter { path =>
+        !path.getPath.exists {
+          case node: EdgirLibraryNode#BlockNode
+            if node.path == EdgirLibraryTreeTableModel.kInternalBlockPath => true // don't expand InternalBlock
+          case _ => false
+        }
       }
       filteredPaths.foreach { filteredPath =>
         recursiveExpandPath(filteredPath)
       }
-
     }
   }
   libraryTreeSearch.getDocument.addDocumentListener(new DocumentListener() {

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -112,7 +112,7 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
 
   val (insertAction, insertItem) = if (EdgSettingsState.getInstance().useInsertionLiveTemplates) {
     val insertAction: Errorable[() => Unit] = exceptable {
-      InsertBlockAction
+      LiveTemplateInsertBlock
         .createTemplateBlock(
           contextPyClass.exceptError,
           blockPyClass.exceptError,

--- a/src/main/scala/edg_ide/ui/tools/BaseTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/BaseTool.scala
@@ -4,7 +4,7 @@ import com.intellij.openapi.project.Project
 import edg.wir.{DesignPath, Library}
 import edgir.schema.schema
 
-import java.awt.event.MouseEvent
+import java.awt.event.{KeyEvent, MouseEvent}
 
 trait ToolInterface {
   // Returns the top-level visualization (focus / context) path
@@ -47,4 +47,7 @@ trait BaseTool {
 
   // Mouse event that is generated on any mouse event in either the design tree or graph layout
   def onPathMouse(e: MouseEvent, path: DesignPath): Unit = {}
+
+  // Keyboard event generated on any key even in the graph layout
+  def onKeyPress(e: KeyEvent): Unit = {}
 }

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -278,7 +278,7 @@ class DesignPortPopupMenu(path: DesignPath, interface: ToolInterface)
   addSeparator()
 
   val startConnectAction = exceptable {
-    val connectTool = ConnectTool(interface, path).exceptError
+    val connectTool = NewConnectTool(interface, path).exceptError
     () => interface.startNewTool(connectTool)
   }
   private val startConnectItem = ContextMenuUtils.MenuItemFromErrorable(startConnectAction, "Start Connect")

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -9,7 +9,7 @@ import edg.util.Errorable
 import edg.wir.DesignPath
 import edg.wir.ProtoUtil.ParamProtoToSeqMap
 import edg_ide.dse._
-import edg_ide.ui.{BlockVisualizerService, ContextMenuUtils, DseService, PopupUtils}
+import edg_ide.ui.{BlockVisualizerService, ContextMenuUtils, DseService, EdgSettingsState, PopupUtils}
 import edg_ide.util.ExceptionNotifyImplicits.ExceptErrorable
 import edg_ide.util._
 import edg_ide.{EdgirUtils, PsiUtils}
@@ -278,7 +278,11 @@ class DesignPortPopupMenu(path: DesignPath, interface: ToolInterface)
   addSeparator()
 
   val startConnectAction = exceptable {
-    val connectTool = NewConnectTool(interface, path).exceptError
+    val connectTool = if (EdgSettingsState.getInstance().useInsertionLiveTemplates) {
+      NewConnectTool(interface, path).exceptError
+    } else {
+      ConnectTool(interface, path).exceptError
+    }
     () => interface.startNewTool(connectTool)
   }
   private val startConnectItem = ContextMenuUtils.MenuItemFromErrorable(startConnectAction, "Start Connect")

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -50,7 +50,7 @@ object NewConnectTool {
     val analysis = new BlockConnectedAnalysis(focusBlock)
     val (portConnectName, (_, portConstrs)) =
       analysis.connectedGroups.toSeq.find { case (name, (connecteds, constrs)) =>
-        connecteds.exists(_.topPortRef == portRef)
+        connecteds.exists(_.connect.topPortRef == portRef)
       }.exceptNone("no connection")
     val connectBuilder = ConnectBuilder(focusBlock, portLink, portConstrs)
       .exceptNone("invalid connections to port")
@@ -73,7 +73,7 @@ class NewConnectTool(
     interface.setStatus(name)
 
     // mark all current selections
-    val connectedPortRefs = currentConnectBuilder.connected.map(_._1.topPortRef)
+    val connectedPortRefs = currentConnectBuilder.connected.map(_._1.connect.topPortRef)
     interface.setGraphSelections(connectedPortRefs.map(containingBlockPath ++ _).toSet)
 
     // try all connections to determine additional possible connects

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -6,7 +6,7 @@ import edg.util.Errorable
 import edg.wir.{DesignPath, LibraryConnectivityAnalysis}
 import edg_ide.EdgirUtils
 import edg_ide.psi_edits.LiveTemplateConnect
-import edg_ide.ui.PopupUtils
+import edg_ide.ui.{BlockVisualizerService, PopupUtils}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption, ExceptSeq}
 import edg_ide.util.{
   BlockConnectedAnalysis,
@@ -183,6 +183,9 @@ class NewConnectTool(
       (connectedBlockOpt, containerPyClassOpt.toOption) match {
         case (Some(connectedBlock), Some(containerPyClass)) =>
           val continuation = (name: Option[String], inserted: PsiElement) => {
+            BlockVisualizerService(interface.getProject).visualizerPanelOption.foreach {
+              _.currentDesignModifyBlock(containingBlockPath)(_ => connectedBlock)
+            }
             interface.endTool()
           }
           LiveTemplateConnect.createTemplateConnect(

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -91,9 +91,10 @@ class NewConnectTool(
 
   val startingPortPath = containingBlockPath ++ startingPort.connect.topPortRef
 
-  var selectedConnects =
-    mutable.ArrayBuffer[PortConnectTyped[PortConnects.Base]]() // individual ports selected by the user
-  var currentConnectBuilder = baseConnectBuilder // corresponding to selectedPorts, may have more ports from net joins
+  // individual ports selected by the user
+  var selectedConnects = mutable.ArrayBuffer[PortConnectTyped[PortConnects.Base]]()
+  // corresponding to selectedPorts, may have more ports from net joins
+  var currentConnectBuilder = baseConnectBuilder
 
   def getCurrentName(): String = {
     if (selectedConnects.nonEmpty) {

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -1,0 +1,42 @@
+package edg_ide.ui.tools
+
+import edg.util.Errorable
+import edg.wir.DesignPath
+import edg_ide.EdgirUtils
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptNotify, ExceptOption}
+import edg_ide.util.{BlockConnectedAnalysis, ConnectBuilder, ConnectTypes, exceptable, requireExcept}
+import edgir.elem.elem
+
+object NewConnectTool {
+  def apply(interface: ToolInterface, portPath: DesignPath): Errorable[NewConnectTool] = exceptable {
+    val focusPath = interface.getFocus
+    val focusBlock = EdgirUtils
+      .resolveExact(focusPath, interface.getDesign)
+      .exceptNone("can't reach focus block")
+      .instanceOfExcept[elem.HierarchyBlock]("focus block not a block")
+
+    val portRef = { // get selected port as Seq(...) reference
+      val (containingBlockPath, containingBlock) = EdgirUtils.resolveDeepestBlock(portPath, interface.getDesign)
+      val portRef = portPath.postfixFromOption(containingBlockPath).exceptNone("port not in focus block")
+      val portName = portRef.steps.headOption.exceptNone("port path empty").getName
+
+      if (containingBlockPath == focusPath) { // boundary port
+        Seq(portName)
+      } else { // block port
+        val (blockParent, blockName) = containingBlockPath.split
+        requireExcept(blockParent == focusPath, "port not in focus block")
+        Seq(blockName, portName)
+      }
+    }
+
+    val analysis = new BlockConnectedAnalysis(focusBlock)
+    val portLink = ???
+    val portConnectedConstrs = ???
+    val connectBuilder = ConnectBuilder(focusBlock, portLink, portConnectedConstrs)
+
+    new NewConnectTool(interface, analysis)
+  }
+}
+
+class NewConnectTool(val interface: ToolInterface, baseConnectBuilder: ConnectBuilder, analysis: BlockConnectedAnalysis)
+    extends BaseTool {}

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -33,8 +33,9 @@ object NewConnectTool {
     val portLink = ???
     val portConnectedConstrs = ???
     val connectBuilder = ConnectBuilder(focusBlock, portLink, portConnectedConstrs)
+      .exceptNone("invalid connections to port")
 
-    new NewConnectTool(interface, analysis)
+    new NewConnectTool(interface, connectBuilder, analysis)
   }
 }
 

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -111,7 +111,7 @@ class NewConnectTool(
     if (selectedConnects.isEmpty) {
       interface.setStatus("[Esc] cancel;" + getCurrentName())
     } else {
-      interface.setStatus("[Esc] cancel; [Enter/DblClick] complete;" + getCurrentName())
+      interface.setStatus("[Esc] cancel; [Enter/DblClick] complete; " + getCurrentName())
     }
 
     // mark all current selections
@@ -143,7 +143,6 @@ class NewConnectTool(
   }
 
   override def init(): Unit = {
-    interface.setGraphSelections(Set())
     updateSelected()
   }
 
@@ -255,7 +254,7 @@ class NewConnectTool(
       }
     } else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 2) { // double-click finish shortcut
       completeConnect(e.getComponent)
-    } else if (SwingUtilities.isRightMouseButton(e) && e.getClickCount == 1) {}
+    }
   }
 
   override def onKeyPress(e: KeyEvent): Unit = {

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -5,7 +5,7 @@ import edg.util.Errorable
 import edg.wir.{DesignPath, LibraryConnectivityAnalysis}
 import edg_ide.EdgirUtils
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption, ExceptSeq}
-import edg_ide.util.{BlockConnectedAnalysis, ConnectBuilder, ConnectTypes, exceptable, requireExcept}
+import edg_ide.util.{BlockConnectedAnalysis, ConnectBuilder, PortConnects, exceptable, requireExcept}
 import edgir.elem.elem
 
 import java.awt.event.MouseEvent
@@ -66,18 +66,26 @@ class NewConnectTool(
     baseConnectBuilder: ConnectBuilder,
     analysis: BlockConnectedAnalysis
 ) extends BaseTool {
-  var selectedPorts = mutable.Set[Seq[String]]()
-  var currentConnectBuilder = baseConnectBuilder // corresponding to selectedPorts
+  var selectedPorts = mutable.Set[Seq[String]]() // individual ports selected by the user
+  var currentConnectBuilder = baseConnectBuilder // corresponding to selectedPorts, may have more ports from net joins
 
   def updateSelected(): Unit = { // updates selected in graph and text
     interface.setStatus(name)
+
+    // mark all current selections
+    val connectedPortRefs = currentConnectBuilder.connected.map(_._1.topPortRef)
+    interface.setGraphSelections(connectedPortRefs.map(containingBlockPath ++ _).toSet)
+
+    // try all connections to determine additional possible connects
+    val availablePortRefs = mutable.ArrayBuffer[Seq[String]]()
+    analysis.connectedGroups.map { case (name, (connecteds, constrs)) =>
+      val resultingConnectBuilder = currentConnectBuilder.append(connecteds)
+
+    }
 //    interface.setGraphSelections(priorConnect.getPorts.map(focusPath ++ _).toSet + portPath ++ selected.toSet)
 //    val availablePaths = connectsAvailable()
 //    val availableBlockPaths = availablePaths.map(_.split._1)
 //    interface.setGraphHighlights(Some(Set(focusPath) ++ availablePaths ++ availableBlockPaths))
-
-    val connectedPortRefs = currentConnectBuilder.connected.map(_._1.topPortRef)
-    interface.setGraphSelections(connectedPortRefs.map(containingBlockPath ++ _).toSet)
   }
 
   override def init(): Unit = {

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -189,7 +189,6 @@ class NewConnectTool(
             containerPyClass,
             getCurrentName(),
             interface.getProject,
-            analysis.block,
             baseConnectBuilder,
             startingPort,
             newConnects,

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -183,7 +183,6 @@ class NewConnectTool(
         EdgirConnectExecutor(
           analysis.block,
           linkNameOpt,
-          baseConnectBuilder,
           currentConnectBuilder,
           startingPort,
           newConnects

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -1,5 +1,6 @@
 package edg_ide.ui.tools
 
+import edg.EdgirUtils.SimpleLibraryPath
 import edg.util.Errorable
 import edg.wir.{DesignPath, LibraryConnectivityAnalysis}
 import edg_ide.EdgirUtils

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -191,7 +191,7 @@ class NewConnectTool(
 
         (connectedBlockOpt, containerPyClassOpt.toOption) match {
           case (Some(connectedBlock), Some(containerPyClass)) =>
-            val continuation = (x: String, y: PsiElement) => {
+            val continuation = (name: Option[String], inserted: PsiElement) => {
               interface.endTool()
             }
             LiveTemplateConnect.createTemplateConnect(
@@ -200,9 +200,10 @@ class NewConnectTool(
               interface.getProject,
               analysis.block,
               baseConnectBuilder,
+              startingPort,
               newConnects,
               continuation
-            )
+            ).exceptError()
           case _ =>
             if (connectedBlockOpt.isEmpty) {
               logger.error(s"failed to create connected IR block")

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -120,9 +120,4 @@ class BlockConnectedAnalysis(val block: elem.HierarchyBlock) {
     } ++ (disconnectedBoundaryPortConnections ++ disconnectedBlockPortConnections).map { connected =>
       (None, Seq(connected), Seq())
     }
-
-  // returns a list of active bridges, as the boundary port and the block port (link-facing bridge port)
-  // bridge arrays are not (current) a construct and not supported
-  // TODO: infer bridges and add to separate structure
-  val bridges: Seq[(PortConnects.BoundaryPort, PortConnects.BlockPort)] = Seq() // TODO IMPLEMENT ME
 }

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -1,0 +1,48 @@
+package edg_ide.util
+import edg.wir.ProtoUtil.ConstraintProtoToSeqMap
+import edgir.elem.elem
+import edgir.expr.expr
+
+import scala.collection.mutable
+
+// provides link-level connectivity information (e.g. all connected ports in a link) for a block
+class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
+  // TODO: gather all constraints by link; exports go here too as own pseudolink for consistency
+  // TODO: infer bridges and add to separate structure
+
+  // link name -> list of connected ports
+  protected val linkConnectivityBuilder = mutable.SeqMap[String, mutable.ArrayBuffer[ConnectTypes.Base]]()
+  protected val linkConstraintBuilder = mutable.SeqMap[String, mutable.ArrayBuffer[expr.ValueExpr]]()
+
+  // here, invalid constraints are silently discarded
+  block.constraints.toSeqMap.foreach { case (name, constr) =>
+    val linkNameOpt = constr.expr match { // get the link name / builder map key, if it is a valid constraint
+      case expr.ValueExpr.Expr.Connected(connected) =>
+        Some(connected.getLinkPort.getRef.steps.head.getName)
+      case expr.ValueExpr.Expr.ConnectedArray(connected) =>
+        Some(connected.getLinkPort.getRef.steps.head.getName)
+      case expr.ValueExpr.Expr.Exported(exported) => // note, can have multiple exports to a top level port for bundles
+        Some(exported.getExteriorPort.getRef.steps.head.getName)
+      case expr.ValueExpr.Expr.ExportedArray(exported) =>
+        Some(exported.getExteriorPort.getRef.steps.head.getName)
+      case _ => None // ignored
+    }
+    linkNameOpt.foreach { linkName => // if the link decoded successfully
+      val connectedPortsOpt = ConnectTypes.fromConnect(constr)
+      connectedPortsOpt.foreach { connectedPorts =>
+        linkConnectivityBuilder.getOrElseUpdate(linkName, mutable.ArrayBuffer()).addAll(connectedPorts)
+      }
+      linkConstraintBuilder.getOrElseUpdate(linkName, mutable.ArrayBuffer()).append(constr)
+    }
+  }
+
+  // returns all connections for this block, each connection being the ports attached (as ConnectTypes.Base)
+  // and list of constraints
+  // disconnected ports returned as a single port of BlockPort (for block ports), BoundaryPort (for boundary ports),
+  // BlockVectorUnit (for block arrays - even if slice capable), or BoundaryPortVctorUnit (for boundary arrays)
+  def connectedGroups: Seq[(Seq[ConnectTypes.Base], Seq[expr.ValueExpr])] = ???
+
+  // returns a list of active bridges, as the boundary port and the block port (link-facing bridge port)
+  // bridge arrays are not (current) a construct and not supported
+  def bridges: Seq[(ConnectTypes.BoundaryPort, ConnectTypes.BlockPort)] = ???
+}

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -7,7 +7,7 @@ import edgir.ref.ref
 import scala.collection.{SeqMap, mutable}
 
 // provides link-level connectivity information (e.g. all connected ports in a link) for a block
-class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
+class BlockConnectedAnalysis(val block: elem.HierarchyBlock) {
   // link name -> (list of connected ports, list of constrs)
   protected val linkConnectionBuilder =
     mutable.SeqMap[

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -76,7 +76,7 @@ class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
   // and list of constraints
   // disconnected ports returned as a single port of BlockPort (for block ports), BoundaryPort (for boundary ports),
   // BlockVectorUnit (for block arrays - even if slice capable), or BoundaryPortVectorUnit (for boundary arrays)
-  def connectedGroups: SeqMap[String, (Seq[ConnectTypes.Base], Seq[expr.ValueExpr])] =
+  val connectedGroups: SeqMap[String, (Seq[ConnectTypes.Base], Seq[expr.ValueExpr])] =
     linkConnectionBuilder.to(SeqMap).map { case (name, (connecteds, constrs)) =>
       name -> (connecteds.toSeq, constrs.toSeq)
     } ++ (disconnectedBoundaryPortConnections ++ disconnectedBlockPortConnections).map { case (name, connected) =>
@@ -86,5 +86,5 @@ class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
   // returns a list of active bridges, as the boundary port and the block port (link-facing bridge port)
   // bridge arrays are not (current) a construct and not supported
   // TODO: infer bridges and add to separate structure
-  def bridges: Seq[(ConnectTypes.BoundaryPort, ConnectTypes.BlockPort)] = ???
+  val bridges: Seq[(ConnectTypes.BoundaryPort, ConnectTypes.BlockPort)] = Seq() // TODO IMPLEMENT ME
 }

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -1,18 +1,18 @@
 package edg_ide.util
-import edg.wir.ProtoUtil.ConstraintProtoToSeqMap
+import edg.wir.ProtoUtil.{BlockProtoToSeqMap, ConstraintProtoToSeqMap, PortProtoToSeqMap}
 import edgir.elem.elem
 import edgir.expr.expr
 
-import scala.collection.mutable
+import scala.collection.{SeqMap, mutable}
 
 // provides link-level connectivity information (e.g. all connected ports in a link) for a block
 class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
   // TODO: gather all constraints by link; exports go here too as own pseudolink for consistency
   // TODO: infer bridges and add to separate structure
 
-  // link name -> list of connected ports
-  protected val linkConnectivityBuilder = mutable.SeqMap[String, mutable.ArrayBuffer[ConnectTypes.Base]]()
-  protected val linkConstraintBuilder = mutable.SeqMap[String, mutable.ArrayBuffer[expr.ValueExpr]]()
+  // link name -> (list of connected ports, list of constrs)
+  protected val linkConnectionBuilder =
+    mutable.SeqMap[String, (mutable.ArrayBuffer[ConnectTypes.ConstraintBase], mutable.ArrayBuffer[expr.ValueExpr])]()
 
   // here, invalid constraints are silently discarded
   block.constraints.toSeqMap.foreach { case (name, constr) =>
@@ -29,18 +29,69 @@ class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
     }
     linkNameOpt.foreach { linkName => // if the link decoded successfully
       val connectedPortsOpt = ConnectTypes.fromConnect(constr)
+      val (connected, constrs) =
+        linkConnectionBuilder.getOrElseUpdate(linkName, (mutable.ArrayBuffer(), mutable.ArrayBuffer()))
       connectedPortsOpt.foreach { connectedPorts =>
-        linkConnectivityBuilder.getOrElseUpdate(linkName, mutable.ArrayBuffer()).addAll(connectedPorts)
+        connected.addAll(connectedPorts)
       }
-      linkConstraintBuilder.getOrElseUpdate(linkName, mutable.ArrayBuffer()).append(constr)
+      constrs.append(constr)
+    }
+  }
+
+  protected val allConnectedPorts = linkConnectionBuilder.flatMap { case (name, (connecteds, constrs)) =>
+    connecteds.map {
+      case ConnectTypes.BlockPort(blockName, portName) => Seq(blockName, portName)
+      case ConnectTypes.BoundaryPort(portName, _) => Seq(portName)
+      case ConnectTypes.BlockVectorUnit(blockName, portName) => Seq(blockName, portName)
+      case ConnectTypes.BlockVectorSlicePort(blockName, portName, _) => Seq(blockName, portName)
+      case ConnectTypes.BlockVectorSliceVector(blockName, portName, _) => Seq(blockName, portName)
+      case ConnectTypes.BoundaryPortVectorUnit(portName) => Seq(portName)
+    }
+  }.toSet
+
+  protected val disconnectedBoundaryPortConnections = mutable.SeqMap[String, ConnectTypes.ConstraintBase]()
+  block.ports.toSeqMap.collect {
+    case (portName, port) if !allConnectedPorts.contains(Seq(portName)) =>
+      val connectOpt: Option[ConnectTypes.ConstraintBase] = port.is match {
+        case elem.PortLike.Is.Port(port) => Some(ConnectTypes.BoundaryPort(portName, Seq()))
+        case elem.PortLike.Is.Bundle(port) => Some(ConnectTypes.BoundaryPort(portName, Seq()))
+        case elem.PortLike.Is.Array(array) => Some(ConnectTypes.BoundaryPortVectorUnit(portName))
+        case _ => None
+      }
+      connectOpt.foreach { connect =>
+        disconnectedBoundaryPortConnections.put(s"$portName", connect)
+      }
+  }
+
+  protected val disconnectedBlockPortConnections = mutable.SeqMap[String, ConnectTypes.ConstraintBase]()
+  block.blocks.toSeqMap.foreach { case (subBlockName, subBlock) =>
+    subBlock.`type`.hierarchy.foreach { subBlock =>
+      subBlock.ports.toSeqMap.collect {
+        case (subBlockPortName, subBlockPort) if !allConnectedPorts.contains(Seq(subBlockName, subBlockPortName)) =>
+          val connectOpt: Option[ConnectTypes.ConstraintBase] = subBlockPort.is match {
+            case elem.PortLike.Is.Port(port) => Some(ConnectTypes.BlockPort(subBlockName, subBlockPortName))
+            case elem.PortLike.Is.Bundle(port) => Some(ConnectTypes.BlockPort(subBlockName, subBlockPortName))
+            case elem.PortLike.Is.Array(array) => Some(ConnectTypes.BlockVectorUnit(subBlockName, subBlockPortName))
+            case _ => None
+          }
+          connectOpt.foreach { connect =>
+            disconnectedBlockPortConnections.put(s"$subBlockName.$subBlockPortName", connect)
+          }
+      }
+
     }
   }
 
   // returns all connections for this block, each connection being the ports attached (as ConnectTypes.Base)
   // and list of constraints
   // disconnected ports returned as a single port of BlockPort (for block ports), BoundaryPort (for boundary ports),
-  // BlockVectorUnit (for block arrays - even if slice capable), or BoundaryPortVctorUnit (for boundary arrays)
-  def connectedGroups: Seq[(Seq[ConnectTypes.Base], Seq[expr.ValueExpr])] = ???
+  // BlockVectorUnit (for block arrays - even if slice capable), or BoundaryPortVectorUnit (for boundary arrays)
+  def connectedGroups: SeqMap[String, (Seq[ConnectTypes.Base], Seq[expr.ValueExpr])] =
+    linkConnectionBuilder.to(SeqMap).map { case (name, (connecteds, constrs)) =>
+      name -> (connecteds.toSeq, constrs.toSeq)
+    } ++ (disconnectedBoundaryPortConnections ++ disconnectedBlockPortConnections).map { case (name, connected) =>
+      name -> (Seq(connected), Seq())
+    }
 
   // returns a list of active bridges, as the boundary port and the block port (link-facing bridge port)
   // bridge arrays are not (current) a construct and not supported

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -7,9 +7,6 @@ import scala.collection.{SeqMap, mutable}
 
 // provides link-level connectivity information (e.g. all connected ports in a link) for a block
 class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
-  // TODO: gather all constraints by link; exports go here too as own pseudolink for consistency
-  // TODO: infer bridges and add to separate structure
-
   // link name -> (list of connected ports, list of constrs)
   protected val linkConnectionBuilder =
     mutable.SeqMap[String, (mutable.ArrayBuffer[ConnectTypes.ConstraintBase], mutable.ArrayBuffer[expr.ValueExpr])]()
@@ -95,5 +92,6 @@ class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
 
   // returns a list of active bridges, as the boundary port and the block port (link-facing bridge port)
   // bridge arrays are not (current) a construct and not supported
+  // TODO: infer bridges and add to separate structure
   def bridges: Seq[(ConnectTypes.BoundaryPort, ConnectTypes.BlockPort)] = ???
 }

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -36,14 +36,7 @@ class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
   }
 
   protected val allConnectedPorts = linkConnectionBuilder.flatMap { case (name, (connecteds, constrs)) =>
-    connecteds.map {
-      case ConnectTypes.BlockPort(blockName, portName) => Seq(blockName, portName)
-      case ConnectTypes.BoundaryPort(portName, _) => Seq(portName)
-      case ConnectTypes.BlockVectorUnit(blockName, portName) => Seq(blockName, portName)
-      case ConnectTypes.BlockVectorSlicePort(blockName, portName, _) => Seq(blockName, portName)
-      case ConnectTypes.BlockVectorSliceVector(blockName, portName, _) => Seq(blockName, portName)
-      case ConnectTypes.BoundaryPortVectorUnit(portName) => Seq(portName)
-    }
+    connecteds.map(_.topPortRef)
   }.toSet
 
   protected val disconnectedBoundaryPortConnections = mutable.SeqMap[String, ConnectTypes.ConstraintBase]()

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -3,7 +3,7 @@ import edg.wir.ProtoUtil.{BlockProtoToSeqMap, ConstraintProtoToSeqMap, PortProto
 import edgir.elem.elem
 import edgir.expr.expr
 
-import scala.collection.{SeqMap, mutable}
+import scala.collection.mutable
 
 // provides link-level connectivity information (e.g. all connected ports in a link) for a block
 class BlockConnectedAnalysis(val block: elem.HierarchyBlock) {
@@ -31,7 +31,7 @@ class BlockConnectedAnalysis(val block: elem.HierarchyBlock) {
           case Some(index) =>
             (connectionsBuilder(index)._2, connectionsBuilder(index)._3)
           case None =>
-            connectionsBuilder.append((None, mutable.ArrayBuffer(), mutable.ArrayBuffer()))
+            connectionsBuilder.append((Some(linkName), mutable.ArrayBuffer(), mutable.ArrayBuffer()))
             linkNameToConnectionIndex(linkName) = connectionsBuilder.length - 1
             (connectionsBuilder.last._2, connectionsBuilder.last._3)
         }

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -50,13 +50,16 @@ class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
     mutable.SeqMap[String, PortConnectTyped[PortConnects.ConstraintBase]]()
   block.ports.toSeqMap.collect {
     case (portName, port) if !allConnectedPorts.contains(Seq(portName)) =>
-      val connectOpt: Option[PortConnects.ConstraintBase] = port.is match {
-        case elem.PortLike.Is.Port(port) => Some(PortConnects.BoundaryPort(portName, Seq()))
-        case elem.PortLike.Is.Bundle(port) => Some(PortConnects.BoundaryPort(portName, Seq()))
-        case elem.PortLike.Is.Array(array) => Some(PortConnects.BoundaryPortVectorUnit(portName))
+      val connectTypedOpt = port.is match {
+        case elem.PortLike.Is.Port(port) =>
+          Some(PortConnectTyped(PortConnects.BoundaryPort(portName, Seq()), port.getSelfClass))
+        case elem.PortLike.Is.Bundle(port) =>
+          Some(PortConnectTyped(PortConnects.BoundaryPort(portName, Seq()), port.getSelfClass))
+        case elem.PortLike.Is.Array(array) =>
+          Some(PortConnectTyped(PortConnects.BoundaryPortVectorUnit(portName), array.getSelfClass))
         case _ => None
       }
-      connectOpt.foreach { connect =>
+      connectTypedOpt.foreach { connect =>
         disconnectedBoundaryPortConnections.put(s"$portName", connect)
       }
   }
@@ -67,13 +70,16 @@ class BlockConnectedAnalysis(block: elem.HierarchyBlock) {
     subBlock.`type`.hierarchy.foreach { subBlock =>
       subBlock.ports.toSeqMap.collect {
         case (subBlockPortName, subBlockPort) if !allConnectedPorts.contains(Seq(subBlockName, subBlockPortName)) =>
-          val connectOpt: Option[PortConnects.ConstraintBase] = subBlockPort.is match {
-            case elem.PortLike.Is.Port(port) => Some(PortConnects.BlockPort(subBlockName, subBlockPortName))
-            case elem.PortLike.Is.Bundle(port) => Some(PortConnects.BlockPort(subBlockName, subBlockPortName))
-            case elem.PortLike.Is.Array(array) => Some(PortConnects.BlockVectorUnit(subBlockName, subBlockPortName))
+          val connectTypedOpt = subBlockPort.is match {
+            case elem.PortLike.Is.Port(port) =>
+              Some(PortConnectTyped(PortConnects.BlockPort(subBlockName, subBlockPortName), port.getSelfClass))
+            case elem.PortLike.Is.Bundle(port) =>
+              Some(PortConnectTyped(PortConnects.BlockPort(subBlockName, subBlockPortName), port.getSelfClass))
+            case elem.PortLike.Is.Array(array) =>
+              Some(PortConnectTyped(PortConnects.BlockVectorUnit(subBlockName, subBlockPortName), array.getSelfClass))
             case _ => None
           }
-          connectOpt.foreach { connect =>
+          connectTypedOpt.foreach { connect =>
             disconnectedBlockPortConnections.put(s"$subBlockName.$subBlockPortName", connect)
           }
       }

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -1,4 +1,4 @@
-package edg
+package edg_ide.util
 
 import edg.ExprBuilder.ValueExpr
 import edg.util.SeqUtils

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -193,7 +193,7 @@ object ConnectBuilder {
   */
 class ConnectBuilder protected (
     container: elem.HierarchyBlock,
-    val availablePorts: Seq[(String, Boolean, ref.LibraryPath)], // name, is array, port type
+    protected val availablePorts: Seq[(String, Boolean, ref.LibraryPath)], // name, is array, port type
     val connected: Seq[(ConnectTypes.Base, ref.LibraryPath, String)], // connect type, used port type, port name
     val connectMode: ConnectMode.Base
 ) {

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -14,6 +14,8 @@ object ConnectTypes { // types of connections a port attached to a connection ca
   // TODO materialize into constraints? - how to add tack this on to an existing IR graph
   sealed trait Base {
     def getPortType(container: elem.HierarchyBlock): Option[ref.LibraryPath] // retrieves the type from the container
+
+    def topPortRef: Seq[String] // returns the top level port path, as (block, port) or (port) for boundary ports
   }
 
   // base trait for connect that can be generated from an IR constraint, as opposed to by GUI connects
@@ -41,6 +43,7 @@ object ConnectTypes { // types of connections a port attached to a connection ca
         .flatMap(_.ports.get(portName))
         .flatMap(typeOfSinglePort)
     }
+    override def topPortRef: Seq[String] = Seq(blockName, portName)
   }
 
   // single exported port only
@@ -53,6 +56,7 @@ object ConnectTypes { // types of connections a port attached to a connection ca
       }
       finalPort.flatMap(typeOfSinglePort)
     }
+    override def topPortRef: Seq[String] = Seq(portName)
   }
 
   // port array, connected as a unit; port array cannot be part of any other connection
@@ -62,6 +66,7 @@ object ConnectTypes { // types of connections a port attached to a connection ca
         .flatMap(_.ports.get(portName))
         .flatMap(typeOfArrayPort)
     }
+    override def topPortRef: Seq[String] = Seq(blockName, portName)
   }
 
   sealed trait BlockVectorSliceBase extends Base {
@@ -72,6 +77,7 @@ object ConnectTypes { // types of connections a port attached to a connection ca
         .flatMap(_.ports.get(portName))
         .flatMap(typeOfArrayPort)
     }
+    override def topPortRef: Seq[String] = Seq(blockName, portName)
   }
 
   // port-typed slice of a port array
@@ -92,6 +98,7 @@ object ConnectTypes { // types of connections a port attached to a connection ca
       container.ports.get(portName)
         .flatMap(typeOfArrayPort)
     }
+    override def topPortRef: Seq[String] = Seq(portName)
   }
 
   // turns an unlowered (but optionally expanded) connect expression into a structured connect type, if the form matches

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -3,7 +3,6 @@ package edg_ide.util
 import com.intellij.openapi.diagnostic.Logger
 import edg.EdgirUtils.SimpleLibraryPath
 import edg.ExprBuilder.ValueExpr
-import edg.util.SeqUtils
 import edg.wir.ProtoUtil.{BlockProtoToSeqMap, PortProtoToSeqMap}
 import edgir.elem.elem
 import edgir.elem.elem.HierarchyBlock

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -210,7 +210,7 @@ object ConnectBuilder {
             s"unable to compute available ports for ${link.getSelfClass.toSimpleString} in ${container.getSelfClass.toSimpleString}"
           )
         }
-        if (constrConnectTyped.isEmpty) {
+        if (constrConnectTypedOpt.isEmpty) {
           logger.warn(
             s"unable to compute connected ports for ${link.getSelfClass.toSimpleString} in ${container.getSelfClass.toSimpleString}"
           )

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -1,0 +1,233 @@
+package edg
+
+import edg.ExprBuilder.ValueExpr
+import edg.util.SeqUtils
+import edg.wir.ProtoUtil.{BlockProtoToSeqMap, PortProtoToSeqMap}
+import edgir.elem.elem
+import edgir.elem.elem.HierarchyBlock
+import edgir.expr.expr
+import edgir.ref.ref
+
+import scala.collection.mutable
+
+object ConnectTypes { // types of connections a port attached to a connection can be a part of
+  // TODO materialize into constraints? - how to add tack this on to an existing IR graph
+  sealed trait Base {
+    def getPortType(container: elem.HierarchyBlock): Option[ref.LibraryPath] // retrieves the type from the container
+  }
+
+  sealed trait PortBase extends Base // base type for any port-valued connection
+  sealed trait VectorBase extends Base // base type for any vector-valued connection
+  sealed trait AmbiguousBase extends Base // base type for any connection which can be port- or vector-valued
+
+  protected def typeOfSinglePort(portLike: elem.PortLike): Option[ref.LibraryPath] = portLike.is match {
+    case elem.PortLike.Is.Port(port) => port.selfClass
+    case elem.PortLike.Is.Bundle(port) => port.selfClass
+    case _ => None
+  }
+
+  protected def typeOfArrayPort(portLike: elem.PortLike): Option[ref.LibraryPath] = portLike.is match {
+    case elem.PortLike.Is.Array(array) => array.selfClass
+    case _ => None
+  }
+
+  // connects to bridges show up as this, though containing no information about the boundary port
+  case class BlockPort(blockName: String, portName: String) extends PortBase {
+    override def getPortType(container: HierarchyBlock): Option[ref.LibraryPath] = {
+      container.blocks.toSeqMap.get(blockName).flatMap(_.`type`.hierarchy)
+        .flatMap(_.ports.get(portName))
+        .flatMap(typeOfSinglePort)
+    }
+  }
+
+  // single exported port only
+  case class BoundaryPort(portName: String, innerNames: Seq[String]) extends PortBase {
+    override def getPortType(container: HierarchyBlock): Option[ref.LibraryPath] = {
+      val initPort = container.ports.get(portName)
+      val finalPort = innerNames.foldLeft(initPort) { case (prev, innerName) =>
+        prev.flatMap(_.is.bundle)
+          .flatMap(_.ports.get(innerName))
+      }
+      finalPort.flatMap(typeOfSinglePort)
+    }
+  }
+
+  // port array, connected as a unit; port array cannot be part of any other connection
+  case class BlockVectorUnit(blockName: String, portName: String) extends VectorBase {
+    override def getPortType(container: HierarchyBlock): Option[ref.LibraryPath] = {
+      container.blocks.toSeqMap.get(blockName).flatMap(_.`type`.hierarchy)
+        .flatMap(_.ports.get(portName))
+        .flatMap(typeOfArrayPort)
+    }
+  }
+
+  sealed trait BlockVectorSliceBase extends Base {
+    def blockName: String
+    def portName: String
+    override def getPortType(container: HierarchyBlock): Option[ref.LibraryPath] = { // same as BlockVectorUnit case
+      container.blocks.toSeqMap.get(blockName).flatMap(_.`type`.hierarchy)
+        .flatMap(_.ports.get(portName))
+        .flatMap(typeOfArrayPort)
+    }
+  }
+
+  // port-typed slice of a port array
+  case class BlockVectorSlicePort(blockName: String, portName: String, suggestedIndex: Option[String])
+      extends PortBase with BlockVectorSliceBase {}
+
+  // vector-typed slice of a port array, connected using allocated / requested
+  case class BlockVectorSliceVector(blockName: String, portName: String, suggestedIndex: Option[String])
+      extends VectorBase with BlockVectorSliceBase {}
+
+  // ambiguous slice of a port array, with no corresponding IR construct but used intuitively for GUI connections
+  case class BlockVectorSlice(blockName: String, portName: String, suggestedIndex: Option[String])
+      extends AmbiguousBase with BlockVectorSliceBase {}
+
+  // port array, connected as a unit; port array cannot be part of any other connection
+  case class BoundaryPortVectorUnit(portName: String) extends VectorBase {
+    override def getPortType(container: HierarchyBlock): Option[ref.LibraryPath] = {
+      container.ports.get(portName)
+        .flatMap(typeOfArrayPort)
+    }
+  }
+
+  // turns an unlowered (but optionally expanded) connect expression into a structured connect type, if the form matches
+  // None means the expression failed to decode
+  def fromConnect(constr: expr.ValueExpr): Option[Seq[Base]] = constr.expr match {
+    case expr.ValueExpr.Expr.Connected(connected) =>
+      singleBlockPortFromRef(connected.getBlockPort).map(Seq(_))
+    case expr.ValueExpr.Expr.Exported(exported) =>
+      val exterior = exported.getExteriorPort match {
+        case ValueExpr.Ref(Seq(portName, innerNames @ _*)) => Some(BoundaryPort(portName, innerNames))
+        case _ => None // invalid / unrecognized form
+      }
+      val interior = singleBlockPortFromRef(exported.getInternalBlockPort)
+      (exterior, interior) match {
+        case (Some(exterior), Some(interior)) => Some(Seq(exterior, interior))
+        case _ => None // at least one failed to decode
+      }
+    case expr.ValueExpr.Expr.ConnectedArray(connectedArray) =>
+      vectorBlockPortFromRef(connectedArray.getBlockPort).map(Seq(_))
+    case expr.ValueExpr.Expr.ExportedArray(exportedArray) =>
+      val exterior = exportedArray.getExteriorPort match {
+        // exported array only supported as a unit, the compiler cannot materialize subarray indices
+        case ValueExpr.Ref(Seq(portName)) => Some(BoundaryPortVectorUnit(portName))
+        case _ => None // invalid / unrecognized form
+      }
+      val interior = vectorBlockPortFromRef(exportedArray.getInternalBlockPort)
+      (exterior, interior) match {
+        case (Some(exterior), Some(interior)) => Some(Seq(exterior, interior))
+        case _ => None // at least one failed to decode
+      }
+    case _ => None
+  }
+
+  protected def singleBlockPortFromRef(ref: expr.ValueExpr): Option[Base] = ref match {
+    case ValueExpr.Ref(Seq(blockName, portName)) => Some(BlockPort(blockName, portName))
+    case ValueExpr.RefAllocate(Seq(blockName, portName), suggestedName) =>
+      Some(BlockVectorSlicePort(blockName, portName, suggestedName))
+    case _ => None // invalid / unrecognized form
+  }
+
+  protected def vectorBlockPortFromRef(ref: expr.ValueExpr): Option[Base] = ref match {
+    case ValueExpr.Ref(Seq(blockName, portName)) => Some(BlockVectorUnit(blockName, portName))
+    case ValueExpr.RefAllocate(Seq(blockName, portName), suggestedName) =>
+      Some(BlockVectorSliceVector(blockName, portName, suggestedName))
+    case _ => None // invalid / unrecognized form
+  }
+}
+
+object ConnectMode { // state of a connect-in-progress
+  trait Base
+  case object Port extends Base // connection between single ports, generates into link
+  case object Vector extends Base // connection with at least one full vector, generates into link array
+  case object Ambiguous extends Base // connection which can be either - but is ambiguous and cannot be created
+}
+
+object ConnectBuilder {
+  // creates a ConnectBuilder given all the connects to a link (found externally) and context data
+  def apply(
+      container: elem.HierarchyBlock,
+      link: elem.Link, // link is needed to determine available connects
+      constrs: Seq[expr.ValueExpr]
+  ): Option[ConnectBuilder] = {
+    val availableOpt = SeqUtils.getAllDefined(link.ports.toSeqMap.map { case (name, portLike) =>
+      (name, portLike.is)
+    }
+      .map {
+        case (name, elem.PortLike.Is.Port(port)) => port.selfClass.map((name, false, _))
+        case (name, elem.PortLike.Is.Bundle(port)) => port.selfClass.map((name, false, _))
+        case (name, elem.PortLike.Is.Array(array)) => array.selfClass.map((name, true, _))
+        case _ => None
+      }.toSeq)
+
+    val constrConnectsOpt = SeqUtils.getAllDefined(constrs.map(ConnectTypes.fromConnect)).map(_.flatten)
+    val constrConnectPortsOpt = constrConnectsOpt.flatMap { constrConnects =>
+      SeqUtils.getAllDefined(constrConnects.map { constrConnect =>
+        constrConnect.getPortType(container).map(portType => (constrConnect, portType))
+      })
+    }
+
+    (availableOpt, constrConnectPortsOpt) match {
+      case (Some(available), Some(constrConnectPorts)) =>
+        new ConnectBuilder(container, available, Seq(), ConnectMode.Ambiguous).append(constrConnectPorts)
+      case _ => None
+    }
+  }
+}
+
+/** Mildly analogous to the connect builder in the frontend HDL, this starts with a link, then ports can be added.
+  * Immutable, added ports return a new ConnectBuilder object (if the add was successful) or None (if the ports cannot
+  * be added). Accounts for bridging and vectors. Works at the link level of abstraction, no special support for
+  * bridges.
+  */
+class ConnectBuilder protected (
+    container: elem.HierarchyBlock,
+    val availablePorts: Seq[(String, Boolean, ref.LibraryPath)], // name, is array, port type
+    val connected: Seq[(ConnectTypes.Base, ref.LibraryPath, String)], // connect type, used port type, port name
+    val connectMode: ConnectMode.Base
+) {
+  // Attempts to append the connections (with attached port types) to the builder, returning a new builder
+  // (if successful) or None (if not a legal connect).
+  def append(newConnects: Seq[(ConnectTypes.Base, ref.LibraryPath)]): Option[ConnectBuilder] = {
+    val availablePortsBuilder = availablePorts.to(mutable.ArrayBuffer)
+    var connectModeBuilder = connectMode
+    var failedToAllocate: Boolean = false
+
+    val newConnected = newConnects.map { case (connect, portType) =>
+      val portName = availablePortsBuilder.indexWhere(_._3 == portType) match {
+        case -1 =>
+          failedToAllocate = true
+          ""
+        case index =>
+          val (portName, isArray, portType) = availablePortsBuilder(index)
+          connect match {
+            case _: ConnectTypes.PortBase =>
+              if (connectModeBuilder == ConnectMode.Vector) {
+                failedToAllocate = true
+              } else {
+                connectModeBuilder = ConnectMode.Port
+              }
+            case _: ConnectTypes.VectorBase =>
+              if (connectModeBuilder == ConnectMode.Port) {
+                failedToAllocate = true
+              } else {
+                connectModeBuilder = ConnectMode.Vector
+              }
+            case _: ConnectTypes.AmbiguousBase => // fine in either single or vector case
+          }
+          if (!isArray) {
+            availablePortsBuilder.remove(index)
+          }
+          portName
+      }
+      (connect, portType, portName)
+    }
+
+    if (failedToAllocate) {
+      None
+    } else {
+      Some(new ConnectBuilder(container, availablePortsBuilder.toSeq, connected ++ newConnected, connectModeBuilder))
+    }
+  }
+}

--- a/src/main/scala/edg_ide/util/DesignFindDisconnected.scala
+++ b/src/main/scala/edg_ide/util/DesignFindDisconnected.scala
@@ -38,9 +38,9 @@ object DesignFindDisconnected extends DesignBlockMap[(Seq[DesignPath], Seq[Strin
 
     val myConnectedPorts = myConstrExprs
       .collect { // extract block side expr
-        case expr.ValueExpr.Expr.Connected(expr.ConnectedExpr(Some(blockExpr), Some(linkExpr), _)) =>
+        case expr.ValueExpr.Expr.Connected(expr.ConnectedExpr(Some(blockExpr), Some(linkExpr), _, _)) =>
           blockExpr.expr
-        case expr.ValueExpr.Expr.Exported(expr.ExportedExpr(Some(exteriorExpr), Some(interiorExpr), _)) =>
+        case expr.ValueExpr.Expr.Exported(expr.ExportedExpr(Some(exteriorExpr), Some(interiorExpr), _, _)) =>
           interiorExpr.expr
       }
       .collect { // extract steps

--- a/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
+++ b/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
@@ -1,26 +1,30 @@
 package edg_ide.util
 
+import com.intellij.openapi.diagnostic.Logger
+import edg.ElemBuilder.Constraint
+import edg.ExprBuilder.Ref
 import edg.util.NameCreator
 import edgir.elem.elem
 import edgir.expr.expr
 
 object EdgirConnectExecutor {
+  private val logger = Logger.getInstance(this.getClass)
+
   // modifies the Block at the IR level to add new connections
   // this is only for visualization purposes, does not need to handle constraint prop and whatnot
   def apply(
       container: elem.HierarchyBlock,
       linkNameOpt: Option[String],
-      baseConnected: ConnectBuilder,
       newConnected: ConnectBuilder,
       startingPort: PortConnectTyped[PortConnects.Base],
       newConnects: Seq[PortConnectTyped[PortConnects.Base]]
   ): Option[elem.HierarchyBlock] = {
     if (newConnects.isEmpty) { // nop
       Some(container)
-    } else if (baseConnected.connected.isEmpty && PortConnectTyped.connectsIsExport(startingPort +: newConnects)) { // export
+    } else if (PortConnectTyped.connectsIsExport(newConnected.connected.map(_._1))) { // export
       throw new IllegalArgumentException("TODO IMPLEMENT ME new direct export connect")
     } else { // everything else is a link
-      applyLink(container, linkNameOpt, baseConnected, newConnected, startingPort, newConnects)
+      applyLink(container, linkNameOpt, newConnected, startingPort, newConnects)
     }
   }
 
@@ -28,24 +32,36 @@ object EdgirConnectExecutor {
       connect: PortConnectTyped[PortConnects.Base],
       connectBuilder: ConnectBuilder,
       linkName: String
-  ): expr.ValueExpr = connect.connect match {
-    // TODO: this produces a constraint that might not be valid (port arrays may not have the element),
-    // but is good enough for the visualizer
-    case PortConnects.BlockPort(blockName, portName) =>
-    case PortConnects.BoundaryPort(portName, _) =>
-      throw new IllegalArgumentException("TODO IMPLEMENT ME bridge connect")
-    case PortConnects.BlockVectorUnit(blockName, portName) =>
-    case PortConnects.BlockVectorSlicePort(blockName, portName, _) =>
-    case PortConnects.BlockVectorSliceVector(blockName, portName, _) =>
-    case PortConnects.BoundaryPortVectorUnit(portName) =>
-      throw new IllegalArgumentException("TODO IMPLEMENT ME bridge connect")
+  ): Option[expr.ValueExpr] = {
+    val linkPortName = connectBuilder.connected.find(_._1.connect == connect.connect).map(_._2).getOrElse {
+      logger.error(s"portConnectToConstraint: connect $connect not found in connected")
+      return None
+    }
+    val constr = connect.connect match {
+      // TODO: this produces a constraint that might not be valid (port arrays may not have the element),
+      // but is good enough for the visualizer
+      case PortConnects.BlockPort(blockName, portName) =>
+        Constraint.Connected(Ref(blockName, portName), Ref(linkName, linkPortName))
+      case PortConnects.BoundaryPort(portName, _) =>
+        throw new IllegalArgumentException("TODO IMPLEMENT ME bridge connect")
+      case PortConnects.BlockVectorUnit(blockName, portName) =>
+        throw new IllegalArgumentException("TODO IMPLEMENT ME link array connect")
+      case PortConnects.BlockVectorSlicePort(blockName, portName, _) =>
+        Constraint.ConnectedArray(Ref.Allocate(Ref(blockName, portName)), Ref(linkName, linkPortName))
+      case PortConnects.BlockVectorSliceVector(blockName, portName, _) =>
+        throw new IllegalArgumentException("TODO IMPLEMENT ME link array connect")
+      case PortConnects.BlockVectorSlice(blockPort, portName, _) =>
+        throw new IllegalArgumentException("TODO IMPLEMENT ME link array connect")
+      case PortConnects.BoundaryPortVectorUnit(portName) =>
+        throw new IllegalArgumentException("TODO IMPLEMENT ME bridge connect")
+    }
+    Some(constr)
   }
 
   // modifies the Block to add a link, or add connections to a link
   protected def applyLink(
       container: elem.HierarchyBlock,
       linkNameOpt: Option[String],
-      baseConnected: ConnectBuilder,
       newConnected: ConnectBuilder,
       startingPort: PortConnectTyped[PortConnects.Base],
       newConnects: Seq[PortConnectTyped[PortConnects.Base]]
@@ -56,22 +72,30 @@ object EdgirConnectExecutor {
       case Some(linkName) => linkName // link already exists, add to it
       case None => // no link exists, instantiate one
         val linkNewName = namer.newName("_new")
+        val newConstrOpt = portConnectToConstraint(startingPort, newConnected, linkNewName)
+        val newConstrSeq = newConstrOpt.map(newConstr =>
+          elem.NamedValueExpr(
+            name = namer.newName("_new"),
+            value = Some(newConstr)
+          )
+        ).toSeq
+
         containerBuilder = containerBuilder.update(
           _.links :+= elem.NamedLinkLike(
             name = linkNewName,
             value = Some(elem.LinkLike(elem.LinkLike.Type.Link(newConnected.linkLib)))
           ),
-          _.constraints :+= elem.NamedValueExpr(
-            name = namer.newName("_new"),
-            value = Some(portConnectToConstraint(startingPort, newConnected, linkNewName))
-          )
+          _.constraints :++= newConstrSeq
         )
         linkNewName
     }
-    val newConstraints = newConnects.map { newConnect =>
-      elem.NamedValueExpr(
-        name = namer.newName("_new"),
-        value = Some(portConnectToConstraint(startingPort, newConnected, linkName))
+    val newConstraints = newConnects.flatMap { newConnect =>
+      val newConstrOpt = portConnectToConstraint(newConnect, newConnected, linkName)
+      newConstrOpt.map(newConstr =>
+        elem.NamedValueExpr(
+          name = namer.newName("_new"),
+          value = Some(newConstr)
+        )
       )
     }
     containerBuilder = containerBuilder.update(

--- a/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
+++ b/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
@@ -1,6 +1,5 @@
 package edg_ide.util
 
-import com.intellij.openapi.diagnostic.Logger
 import edg.util.NameCreator
 import edgir.elem.elem
 import edgir.expr.expr
@@ -29,8 +28,17 @@ object EdgirConnectExecutor {
       connect: PortConnectTyped[PortConnects.Base],
       connectBuilder: ConnectBuilder,
       linkName: String
-  ): expr.ValueExpr = {
-    ???
+  ): expr.ValueExpr = connect.connect match {
+    // TODO: this produces a constraint that might not be valid (port arrays may not have the element),
+    // but is good enough for the visualizer
+    case PortConnects.BlockPort(blockName, portName) =>
+    case PortConnects.BoundaryPort(portName, _) =>
+      throw new IllegalArgumentException("TODO IMPLEMENT ME bridge connect")
+    case PortConnects.BlockVectorUnit(blockName, portName) =>
+    case PortConnects.BlockVectorSlicePort(blockName, portName, _) =>
+    case PortConnects.BlockVectorSliceVector(blockName, portName, _) =>
+    case PortConnects.BoundaryPortVectorUnit(portName) =>
+      throw new IllegalArgumentException("TODO IMPLEMENT ME bridge connect")
   }
 
   // modifies the Block to add a link, or add connections to a link

--- a/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
+++ b/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
@@ -8,9 +8,10 @@ object EdgirConnectExecutor {
   def apply(
       container: elem.HierarchyBlock,
       baseConnected: ConnectBuilder,
-      newConnects: PortConnects.ConstraintBase
-  ): elem.HierarchyBlock = {
+      newConnects: Seq[PortConnects.Base]
+  ): Option[elem.HierarchyBlock] = {
     // TODO needs link name, if prior link exists?
-    ???
+    // TODO IMPLEMENT ME
+    Some(container)
   }
 }

--- a/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
+++ b/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
@@ -1,17 +1,74 @@
 package edg_ide.util
 
+import com.intellij.openapi.diagnostic.Logger
+import edg.util.NameCreator
 import edgir.elem.elem
+import edgir.expr.expr
 
 object EdgirConnectExecutor {
   // modifies the Block at the IR level to add new connections
   // this is only for visualization purposes, does not need to handle constraint prop and whatnot
   def apply(
       container: elem.HierarchyBlock,
+      linkNameOpt: Option[String],
       baseConnected: ConnectBuilder,
-      newConnects: Seq[PortConnects.Base]
+      newConnected: ConnectBuilder,
+      startingPort: PortConnectTyped[PortConnects.Base],
+      newConnects: Seq[PortConnectTyped[PortConnects.Base]]
   ): Option[elem.HierarchyBlock] = {
-    // TODO needs link name, if prior link exists?
-    // TODO IMPLEMENT ME
-    Some(container)
+    if (newConnects.isEmpty) { // nop
+      Some(container)
+    } else if (baseConnected.connected.isEmpty && PortConnectTyped.connectsIsExport(startingPort +: newConnects)) { // export
+      throw new IllegalArgumentException("TODO IMPLEMENT ME new direct export connect")
+    } else { // everything else is a link
+      applyLink(container, linkNameOpt, baseConnected, newConnected, startingPort, newConnects)
+    }
+  }
+
+  protected def portConnectToConstraint(
+      connect: PortConnectTyped[PortConnects.Base],
+      connectBuilder: ConnectBuilder,
+      linkName: String
+  ): expr.ValueExpr = {
+    ???
+  }
+
+  // modifies the Block to add a link, or add connections to a link
+  protected def applyLink(
+      container: elem.HierarchyBlock,
+      linkNameOpt: Option[String],
+      baseConnected: ConnectBuilder,
+      newConnected: ConnectBuilder,
+      startingPort: PortConnectTyped[PortConnects.Base],
+      newConnects: Seq[PortConnectTyped[PortConnects.Base]]
+  ): Option[elem.HierarchyBlock] = {
+    var containerBuilder = container
+    val namer = NameCreator.fromBlock(container)
+    val linkName = linkNameOpt match {
+      case Some(linkName) => linkName // link already exists, add to it
+      case None => // no link exists, instantiate one
+        val linkNewName = namer.newName("_new")
+        containerBuilder = containerBuilder.update(
+          _.links :+= elem.NamedLinkLike(
+            name = linkNewName,
+            value = Some(elem.LinkLike(elem.LinkLike.Type.Link(newConnected.linkLib)))
+          ),
+          _.constraints :+= elem.NamedValueExpr(
+            name = namer.newName("_new"),
+            value = Some(portConnectToConstraint(startingPort, newConnected, linkNewName))
+          )
+        )
+        linkNewName
+    }
+    val newConstraints = newConnects.map { newConnect =>
+      elem.NamedValueExpr(
+        name = namer.newName("_new"),
+        value = Some(portConnectToConstraint(startingPort, newConnected, linkName))
+      )
+    }
+    containerBuilder = containerBuilder.update(
+      _.constraints :++= newConstraints
+    )
+    Some(containerBuilder)
   }
 }

--- a/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
+++ b/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
@@ -1,0 +1,16 @@
+package edg_ide.util
+
+import edgir.elem.elem
+
+object EdgirConnectExecutor {
+  // modifies the Block at the IR level to add new connections
+  // this is only for visualization purposes, does not need to handle constraint prop and whatnot
+  def apply(
+      container: elem.HierarchyBlock,
+      baseConnected: ConnectBuilder,
+      newConnects: PortConnects.ConstraintBase
+  ): elem.HierarchyBlock = {
+    // TODO needs link name, if prior link exists?
+    ???
+  }
+}

--- a/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
+++ b/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
@@ -38,7 +38,7 @@ object EdgirConnectExecutor {
       return None
     }
     val constr = connect.connect match {
-      // TODO: this produces a constraint that might not be valid (port arrays may not have the element),
+      // TODO: this produces a constraint that might not be valid (port arrays may not have the element, needs allocate),
       // but is good enough for the visualizer
       case PortConnects.BlockPort(blockName, portName) =>
         Constraint.Connected(Ref(blockName, portName), Ref(linkName, linkPortName))
@@ -47,7 +47,7 @@ object EdgirConnectExecutor {
       case PortConnects.BlockVectorUnit(blockName, portName) =>
         throw new IllegalArgumentException("TODO IMPLEMENT ME link array connect")
       case PortConnects.BlockVectorSlicePort(blockName, portName, _) =>
-        Constraint.Connected(Ref.Allocate(Ref(blockName, portName)), Ref(linkName, linkPortName))
+        Constraint.Connected(Ref(blockName, portName), Ref(linkName, linkPortName)) // TODO allocate on block side
       case PortConnects.BlockVectorSliceVector(blockName, portName, _) =>
         throw new IllegalArgumentException("TODO IMPLEMENT ME link array connect")
       case PortConnects.BlockVectorSlice(blockPort, portName, _) =>

--- a/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
+++ b/src/main/scala/edg_ide/util/EdgirConnectExecutor.scala
@@ -47,7 +47,7 @@ object EdgirConnectExecutor {
       case PortConnects.BlockVectorUnit(blockName, portName) =>
         throw new IllegalArgumentException("TODO IMPLEMENT ME link array connect")
       case PortConnects.BlockVectorSlicePort(blockName, portName, _) =>
-        Constraint.ConnectedArray(Ref.Allocate(Ref(blockName, portName)), Ref(linkName, linkPortName))
+        Constraint.Connected(Ref.Allocate(Ref(blockName, portName)), Ref(linkName, linkPortName))
       case PortConnects.BlockVectorSliceVector(blockName, portName, _) =>
         throw new IllegalArgumentException("TODO IMPLEMENT ME link array connect")
       case PortConnects.BlockVectorSlice(blockPort, portName, _) =>

--- a/src/main/scala/edg_ide/util/SeqUtils.scala
+++ b/src/main/scala/edg_ide/util/SeqUtils.scala
@@ -1,0 +1,16 @@
+package edg_ide.util
+
+object SeqUtils {
+  // if all elements defined, returns the seq of elements, else None
+  def getAllDefined[T](seq: Seq[Option[T]]): Option[Seq[T]] = {
+    val (some, none) = seq.partitionMap {
+      case Some(value) => Left(value)
+      case None => Right(None)
+    }
+    if (none.nonEmpty) {
+      None
+    } else {
+      Some(some)
+    }
+  }
+}

--- a/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
+++ b/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
@@ -12,7 +12,7 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
 
   it should "decode connections for non-array example" in {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleBlock)
-    analysis.connectedGroups.map(_._1) should equal(Seq(Some("link"), None, None, None))
+    analysis.connectedGroups.map(_._1) should equal(Seq(Some("link"), None, None, None, None))
     analysis.connectedGroups(0)._1 should equal(Some("link"))
     analysis.connectedGroups(0)._2 should equal(Seq(
       PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort")),
@@ -50,7 +50,7 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
 
   it should "decode connections for array example" in {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleArrayBlock)
-    analysis.connectedGroups.map(_._1) should equal(Seq(Some("link"), None))
+    analysis.connectedGroups.map(_._1) should equal(Seq(Some("link"), None, None))
 
     analysis.connectedGroups(0)._1 should equal(Some("link"))
     analysis.connectedGroups(0)._2 should equal(Seq(
@@ -67,9 +67,10 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
     analysis.connectedGroups(1)._3 shouldBe empty
 
     analysis.connectedGroups(2)._1 should equal(None)
-    analysis.connectedGroups(2)._2 should equal(Seq(
-      PortConnectTyped(PortConnects.BlockVectorUnit("unusedSinkArray", "port"), LibraryPath("sinkPort"))
-    ))
+    // TODO this should be an ambiguous BlockVectorUnit, but currently defaults to a VectorSlicePort
+//    analysis.connectedGroups(2)._2 should equal(Seq(
+//      PortConnectTyped(PortConnects.BlockVectorUnit("unusedSinkArray", "port"), LibraryPath("sinkPort"))
+//    ))
     analysis.connectedGroups(2)._3 shouldBe empty
   }
 }

--- a/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
+++ b/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
@@ -1,0 +1,55 @@
+package edg_ide.util.tests
+
+import edg_ide.util.{BlockConnectedAnalysis, ConnectTypes}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+class BlockConnectedAnalysisTest extends AnyFlatSpec {
+  behavior.of("BlockConnectedAnalysis")
+
+  private val connectBuilderTest = new ConnectBuilderTest() // for shared examples
+
+  it should "decode connections for non-array example" in {
+    val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleBlock)
+    analysis.connectedGroups.keys should equal(Set("link", "port", "bundle", "unusedSink.port"))
+    analysis.connectedGroups("link")._1 should equal(Seq(
+      ConnectTypes.BlockPort("source", "port"),
+      ConnectTypes.BlockPort("sink0", "port"),
+      ConnectTypes.BlockPort("sink1", "port"),
+      ConnectTypes.BlockVectorSlicePort("sinkArray", "port", None),
+    ))
+    analysis.connectedGroups("link")._2 should not be empty
+
+    analysis.connectedGroups("port")._1 should equal(Seq( // export
+      ConnectTypes.BoundaryPort("port", Seq()),
+      ConnectTypes.BlockPort("exportSource", "port"),
+    ))
+    analysis.connectedGroups("port")._2 should not be empty
+
+    analysis.connectedGroups("bundle")._1 should equal(Seq( // export into bundle elt
+      ConnectTypes.BoundaryPort("bundle", Seq("port")),
+      ConnectTypes.BlockPort("exportBundleSource", "port"),
+    ))
+    analysis.connectedGroups("bundle")._2 should not be empty
+
+    analysis.connectedGroups("unusedSink.port")._1 should equal(Seq( // export into bundle elt
+      ConnectTypes.BlockPort("unusedSink", "port")))
+    analysis.connectedGroups("unusedSink.port")._2 shouldBe empty
+  }
+
+  it should "decode connections for array example" in {
+    val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleArrayBlock)
+    analysis.connectedGroups.keys should equal(Set("link", "unusedSinkArray.port"))
+    analysis.connectedGroups("link")._1 should equal(Seq(
+      ConnectTypes.BlockVectorUnit("source", "port"),
+      ConnectTypes.BlockVectorUnit("sink0", "port"),
+      ConnectTypes.BlockVectorUnit("sink1", "port"),
+      ConnectTypes.BlockVectorSliceVector("sinkArray", "port", None),
+    ))
+    analysis.connectedGroups("link")._2 should not be empty
+
+    analysis.connectedGroups("unusedSinkArray.port")._1 should equal(Seq( // export into bundle elt
+      ConnectTypes.BlockVectorUnit("unusedSinkArray", "port")))
+    analysis.connectedGroups("unusedSinkArray.port")._2 shouldBe empty
+  }
+}

--- a/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
+++ b/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
@@ -31,7 +31,7 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
 
     analysis.connectedGroups(2)._1 should equal(None)
     analysis.connectedGroups(2)._2 should equal(Seq( // export into bundle elt
-      PortConnectTyped(PortConnects.BoundaryPort("bundle", Seq("port")), LibraryPath("sourcePort")),
+      PortConnectTyped(PortConnects.BoundaryPort("bundle", Seq("port")), LibraryPath("sourceBundle")),
       PortConnectTyped(PortConnects.BlockPort("exportBundleSource", "port"), LibraryPath("sourcePort")),
     ))
     analysis.connectedGroups(2)._3 should not be empty

--- a/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
+++ b/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
@@ -37,9 +37,15 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
     analysis.connectedGroups(2)._3 should not be empty
 
     analysis.connectedGroups(3)._1 should equal(None)
-    analysis.connectedGroups(3)._2 should equal(Seq( // export into bundle elt
-      PortConnectTyped(PortConnects.BlockPort("unusedSink", "port"), LibraryPath("sinkPort"))))
+    analysis.connectedGroups(3)._2 should equal(Seq( // array can have additional allocates
+      PortConnectTyped(PortConnects.BlockVectorSlicePort("sinkArray", "port", None), LibraryPath("sinkPort"))))
     analysis.connectedGroups(3)._3 shouldBe empty
+
+    analysis.connectedGroups(4)._1 should equal(None)
+    analysis.connectedGroups(4)._2 should equal(Seq(
+      PortConnectTyped(PortConnects.BlockPort("unusedSink", "port"), LibraryPath("sinkPort"))
+    ))
+    analysis.connectedGroups(4)._3 shouldBe empty
   }
 
   it should "decode connections for array example" in {
@@ -56,8 +62,14 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
     analysis.connectedGroups(0)._3 should not be empty
 
     analysis.connectedGroups(1)._1 should equal(None)
-    analysis.connectedGroups(1)._2 should equal(Seq( // export into bundle elt
-      PortConnectTyped(PortConnects.BlockVectorUnit("unusedSinkArray", "port"), LibraryPath("sinkPort"))))
+    analysis.connectedGroups(1)._2 should equal(Seq( // array can have additional allocates
+      PortConnectTyped(PortConnects.BlockVectorSliceVector("sinkArray", "port", None), LibraryPath("sinkPort"))))
     analysis.connectedGroups(1)._3 shouldBe empty
+
+    analysis.connectedGroups(2)._1 should equal(None)
+    analysis.connectedGroups(2)._2 should equal(Seq(
+      PortConnectTyped(PortConnects.BlockVectorUnit("unusedSinkArray", "port"), LibraryPath("sinkPort"))
+    ))
+    analysis.connectedGroups(2)._3 shouldBe empty
   }
 }

--- a/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
+++ b/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
@@ -1,6 +1,7 @@
 package edg_ide.util.tests
 
-import edg_ide.util.{BlockConnectedAnalysis, PortConnects}
+import edg.ElemBuilder._
+import edg_ide.util.{BlockConnectedAnalysis, PortConnectTyped, PortConnects}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -13,27 +14,27 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleBlock)
     analysis.connectedGroups.keys should equal(Set("link", "port", "bundle", "unusedSink.port"))
     analysis.connectedGroups("link")._1 should equal(Seq(
-      PortConnects.BlockPort("source", "port"),
-      PortConnects.BlockPort("sink0", "port"),
-      PortConnects.BlockPort("sink1", "port"),
-      PortConnects.BlockVectorSlicePort("sinkArray", "port", None),
+      PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort")),
+      PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort")),
+      PortConnectTyped(PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort")),
+      PortConnectTyped(PortConnects.BlockVectorSlicePort("sinkArray", "port", None), LibraryPath("sinkPort")),
     ))
     analysis.connectedGroups("link")._2 should not be empty
 
     analysis.connectedGroups("port")._1 should equal(Seq( // export
-      PortConnects.BoundaryPort("port", Seq()),
-      PortConnects.BlockPort("exportSource", "port"),
+      PortConnectTyped(PortConnects.BoundaryPort("port", Seq()), LibraryPath("sourcePort")),
+      PortConnectTyped(PortConnects.BlockPort("exportSource", "port"), LibraryPath("sourcePort")),
     ))
     analysis.connectedGroups("port")._2 should not be empty
 
     analysis.connectedGroups("bundle")._1 should equal(Seq( // export into bundle elt
-      PortConnects.BoundaryPort("bundle", Seq("port")),
-      PortConnects.BlockPort("exportBundleSource", "port"),
+      PortConnectTyped(PortConnects.BoundaryPort("bundle", Seq("port")), LibraryPath("sourcePort")),
+      PortConnectTyped(PortConnects.BlockPort("exportBundleSource", "port"), LibraryPath("sourcePort")),
     ))
     analysis.connectedGroups("bundle")._2 should not be empty
 
     analysis.connectedGroups("unusedSink.port")._1 should equal(Seq( // export into bundle elt
-      PortConnects.BlockPort("unusedSink", "port")))
+      PortConnectTyped(PortConnects.BlockPort("unusedSink", "port"), LibraryPath("sinkPort"))))
     analysis.connectedGroups("unusedSink.port")._2 shouldBe empty
   }
 
@@ -41,15 +42,15 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleArrayBlock)
     analysis.connectedGroups.keys should equal(Set("link", "unusedSinkArray.port"))
     analysis.connectedGroups("link")._1 should equal(Seq(
-      PortConnects.BlockVectorUnit("source", "port"),
-      PortConnects.BlockVectorUnit("sink0", "port"),
-      PortConnects.BlockVectorUnit("sink1", "port"),
-      PortConnects.BlockVectorSliceVector("sinkArray", "port", None),
+      PortConnectTyped(PortConnects.BlockVectorUnit("source", "port"), LibraryPath("sourcePort")),
+      PortConnectTyped(PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort")),
+      PortConnectTyped(PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort")),
+      PortConnectTyped(PortConnects.BlockVectorSliceVector("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
     analysis.connectedGroups("link")._2 should not be empty
 
     analysis.connectedGroups("unusedSinkArray.port")._1 should equal(Seq( // export into bundle elt
-      PortConnects.BlockVectorUnit("unusedSinkArray", "port")))
+      PortConnectTyped(PortConnects.BlockVectorUnit("unusedSinkArray", "port"), LibraryPath("sinkPort"))))
     analysis.connectedGroups("unusedSinkArray.port")._2 shouldBe empty
   }
 }

--- a/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
+++ b/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
@@ -12,45 +12,52 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
 
   it should "decode connections for non-array example" in {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleBlock)
-    analysis.connectedGroups.keys should equal(Set("link", "port", "bundle", "unusedSink.port"))
-    analysis.connectedGroups("link")._1 should equal(Seq(
+    analysis.connectedGroups.map(_._1) should equal(Seq(Some("link"), None, None, None))
+    analysis.connectedGroups(0)._1 should equal(Some("link"))
+    analysis.connectedGroups(0)._2 should equal(Seq(
       PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort")),
       PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort")),
       PortConnectTyped(PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort")),
       PortConnectTyped(PortConnects.BlockVectorSlicePort("sinkArray", "port", None), LibraryPath("sinkPort")),
     ))
-    analysis.connectedGroups("link")._2 should not be empty
+    analysis.connectedGroups(0)._3 should not be empty
 
-    analysis.connectedGroups("port")._1 should equal(Seq( // export
+    analysis.connectedGroups(1)._1 should equal(None)
+    analysis.connectedGroups(1)._2 should equal(Seq( // export
       PortConnectTyped(PortConnects.BoundaryPort("port", Seq()), LibraryPath("sourcePort")),
       PortConnectTyped(PortConnects.BlockPort("exportSource", "port"), LibraryPath("sourcePort")),
     ))
-    analysis.connectedGroups("port")._2 should not be empty
+    analysis.connectedGroups(1)._3 should not be empty
 
-    analysis.connectedGroups("bundle")._1 should equal(Seq( // export into bundle elt
+    analysis.connectedGroups(2)._1 should equal(None)
+    analysis.connectedGroups(2)._2 should equal(Seq( // export into bundle elt
       PortConnectTyped(PortConnects.BoundaryPort("bundle", Seq("port")), LibraryPath("sourcePort")),
       PortConnectTyped(PortConnects.BlockPort("exportBundleSource", "port"), LibraryPath("sourcePort")),
     ))
-    analysis.connectedGroups("bundle")._2 should not be empty
+    analysis.connectedGroups(2)._3 should not be empty
 
-    analysis.connectedGroups("unusedSink.port")._1 should equal(Seq( // export into bundle elt
+    analysis.connectedGroups(3)._1 should equal(None)
+    analysis.connectedGroups(3)._2 should equal(Seq( // export into bundle elt
       PortConnectTyped(PortConnects.BlockPort("unusedSink", "port"), LibraryPath("sinkPort"))))
-    analysis.connectedGroups("unusedSink.port")._2 shouldBe empty
+    analysis.connectedGroups(3)._3 shouldBe empty
   }
 
   it should "decode connections for array example" in {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleArrayBlock)
-    analysis.connectedGroups.keys should equal(Set("link", "unusedSinkArray.port"))
-    analysis.connectedGroups("link")._1 should equal(Seq(
+    analysis.connectedGroups.map(_._1) should equal(Seq(Some("link"), None))
+
+    analysis.connectedGroups(0)._1 should equal(Some("link"))
+    analysis.connectedGroups(0)._2 should equal(Seq(
       PortConnectTyped(PortConnects.BlockVectorUnit("source", "port"), LibraryPath("sourcePort")),
       PortConnectTyped(PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort")),
       PortConnectTyped(PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort")),
       PortConnectTyped(PortConnects.BlockVectorSliceVector("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
-    analysis.connectedGroups("link")._2 should not be empty
+    analysis.connectedGroups(0)._3 should not be empty
 
-    analysis.connectedGroups("unusedSinkArray.port")._1 should equal(Seq( // export into bundle elt
+    analysis.connectedGroups(1)._1 should equal(None)
+    analysis.connectedGroups(1)._2 should equal(Seq( // export into bundle elt
       PortConnectTyped(PortConnects.BlockVectorUnit("unusedSinkArray", "port"), LibraryPath("sinkPort"))))
-    analysis.connectedGroups("unusedSinkArray.port")._2 shouldBe empty
+    analysis.connectedGroups(1)._3 shouldBe empty
   }
 }

--- a/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
+++ b/src/test/scala/edg_ide/util/tests/BlockConnectedAnalysisTest.scala
@@ -1,6 +1,6 @@
 package edg_ide.util.tests
 
-import edg_ide.util.{BlockConnectedAnalysis, ConnectTypes}
+import edg_ide.util.{BlockConnectedAnalysis, PortConnects}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -13,27 +13,27 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleBlock)
     analysis.connectedGroups.keys should equal(Set("link", "port", "bundle", "unusedSink.port"))
     analysis.connectedGroups("link")._1 should equal(Seq(
-      ConnectTypes.BlockPort("source", "port"),
-      ConnectTypes.BlockPort("sink0", "port"),
-      ConnectTypes.BlockPort("sink1", "port"),
-      ConnectTypes.BlockVectorSlicePort("sinkArray", "port", None),
+      PortConnects.BlockPort("source", "port"),
+      PortConnects.BlockPort("sink0", "port"),
+      PortConnects.BlockPort("sink1", "port"),
+      PortConnects.BlockVectorSlicePort("sinkArray", "port", None),
     ))
     analysis.connectedGroups("link")._2 should not be empty
 
     analysis.connectedGroups("port")._1 should equal(Seq( // export
-      ConnectTypes.BoundaryPort("port", Seq()),
-      ConnectTypes.BlockPort("exportSource", "port"),
+      PortConnects.BoundaryPort("port", Seq()),
+      PortConnects.BlockPort("exportSource", "port"),
     ))
     analysis.connectedGroups("port")._2 should not be empty
 
     analysis.connectedGroups("bundle")._1 should equal(Seq( // export into bundle elt
-      ConnectTypes.BoundaryPort("bundle", Seq("port")),
-      ConnectTypes.BlockPort("exportBundleSource", "port"),
+      PortConnects.BoundaryPort("bundle", Seq("port")),
+      PortConnects.BlockPort("exportBundleSource", "port"),
     ))
     analysis.connectedGroups("bundle")._2 should not be empty
 
     analysis.connectedGroups("unusedSink.port")._1 should equal(Seq( // export into bundle elt
-      ConnectTypes.BlockPort("unusedSink", "port")))
+      PortConnects.BlockPort("unusedSink", "port")))
     analysis.connectedGroups("unusedSink.port")._2 shouldBe empty
   }
 
@@ -41,15 +41,15 @@ class BlockConnectedAnalysisTest extends AnyFlatSpec {
     val analysis = new BlockConnectedAnalysis(connectBuilderTest.exampleArrayBlock)
     analysis.connectedGroups.keys should equal(Set("link", "unusedSinkArray.port"))
     analysis.connectedGroups("link")._1 should equal(Seq(
-      ConnectTypes.BlockVectorUnit("source", "port"),
-      ConnectTypes.BlockVectorUnit("sink0", "port"),
-      ConnectTypes.BlockVectorUnit("sink1", "port"),
-      ConnectTypes.BlockVectorSliceVector("sinkArray", "port", None),
+      PortConnects.BlockVectorUnit("source", "port"),
+      PortConnects.BlockVectorUnit("sink0", "port"),
+      PortConnects.BlockVectorUnit("sink1", "port"),
+      PortConnects.BlockVectorSliceVector("sinkArray", "port", None),
     ))
     analysis.connectedGroups("link")._2 should not be empty
 
     analysis.connectedGroups("unusedSinkArray.port")._1 should equal(Seq( // export into bundle elt
-      ConnectTypes.BlockVectorUnit("unusedSinkArray", "port")))
+      PortConnects.BlockVectorUnit("unusedSinkArray", "port")))
     analysis.connectedGroups("unusedSinkArray.port")._2 shouldBe empty
   }
 }

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -1,8 +1,9 @@
-package edg
+package edg_ide.util.tests
 
-import edg.ElemBuilder.{Block, Constraint, LibraryPath, Link, Port}
+import edg.ElemBuilder._
 import edg.ExprBuilder.{Ref, ValInit}
 import edg.wir.ProtoUtil.ConstraintProtoToSeqMap
+import edg_ide.util.{ConnectBuilder, ConnectMode, ConnectTypes}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -1,0 +1,365 @@
+package edg
+
+import edg.ElemBuilder.{Block, Constraint, LibraryPath, Link, Port}
+import edg.ExprBuilder.{Ref, ValInit}
+import edg.wir.ProtoUtil.ConstraintProtoToSeqMap
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+import scala.collection.SeqMap
+
+class ConnectBuilderTest extends AnyFlatSpec {
+  behavior.of("ConnectBuilder")
+
+  val exampleBlock = Block.Block( // basic skeletal and structural example of a block with various connects
+    "topDesign",
+    ports = SeqMap(
+      "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+      "bundle" -> Port.Bundle(
+        "sourceBundle",
+        ports = SeqMap(
+          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+        )
+      ),
+    ),
+    blocks = SeqMap(
+      "source" -> Block.Block(
+        "sourceBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sink0" -> Block.Block(
+        "sinkBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sink1" -> Block.Block(
+        "sinkBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sinkArray" -> Block.Block(
+        "sinkArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sinkPort",
+            Seq("0"),
+            Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+      "exportSource" -> Block.Block(
+        "sourceBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "exportBundleSource" -> Block.Block(
+        "sourceBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+    ),
+    links = SeqMap(
+      "link" -> Link.Link("link"),
+    ),
+    constraints = SeqMap(
+      "sourceConnect" -> Constraint.Connected(Ref("source", "port"), Ref("link", "source")),
+      "sink0Connect" -> Constraint.Connected(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
+      "sink1Connect" -> Constraint.Connected(Ref("sink1", "port"), Ref.Allocate(Ref("link", "sinks"))),
+      "sinkArrayConnect" -> Constraint.Connected(
+        Ref.Allocate(Ref("sinkArray", "port")),
+        Ref.Allocate(Ref("link", "sinks"))
+      ),
+      "sourceExport" -> Constraint.Exported(Ref("port"), Ref("exportSource", "port")),
+      "bundleSourceExport" -> Constraint.Exported(Ref("bundle", "port"), Ref("exportBundleSource", "port")),
+    )
+  ).getHierarchy
+
+  val exampleArrayBlock = Block.Block( // basic example using link arrays
+    "topDesign",
+    ports = SeqMap(
+      "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+      "bundle" -> Port.Bundle(
+        "sourceBundle",
+        ports = SeqMap(
+          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+        )
+      ),
+    ),
+    blocks = SeqMap(
+      "source" -> Block.Block(
+        "sourceArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sourcePort",
+            Seq("0", "1"),
+            Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+      "sink0" -> Block.Block(
+        "sinkArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sinkPort",
+            Seq("0", "1"),
+            Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+      "sink1" -> Block.Block(
+        "sinkArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sinkPort",
+            Seq("0", "1"),
+            Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+      "sinkArray" -> Block.Block(
+        "sinkArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sinkPort",
+            Seq("0", "1"),
+            Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+    ),
+    links = SeqMap(
+      "link" -> Link.Array("link"),
+    ),
+    constraints = SeqMap(
+      "sourceConnect" -> Constraint.ConnectedArray(Ref("source", "port"), Ref("link", "source")),
+      "sink0Connect" -> Constraint.ConnectedArray(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
+      "sink1Connect" -> Constraint.ConnectedArray(Ref("sink1", "port"), Ref.Allocate(Ref("link", "sinks"))),
+      "sinkArrayConnect" -> Constraint.ConnectedArray(
+        Ref.Allocate(Ref("sinkArray", "port")),
+        Ref.Allocate(Ref("link", "sinks"))
+      ),
+    )
+  ).getHierarchy
+
+  val exampleLink = Link.Link(
+    "link",
+    ports = SeqMap(
+      "source" -> Port.Port("sourcePort"),
+      "sinks" -> Port.Array("sinkPort"),
+    ),
+    params = SeqMap(
+      "param" -> ValInit.Integer
+    ),
+  ).getLink
+
+  it should "decode connections and get types" in {
+    // basic connection forms
+    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("sourceConnect")) should equal(Some(Seq(
+      ConnectTypes.BlockPort("source", "port")
+    )))
+    ConnectTypes.BlockPort("source", "port").getPortType(exampleBlock) should equal(Some(LibraryPath("sourcePort")))
+
+    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("sink0Connect")) should equal(Some(Seq(
+      ConnectTypes.BlockPort("sink0", "port")
+    )))
+    ConnectTypes.BlockPort("sink0", "port").getPortType(exampleBlock) should equal(Some(LibraryPath("sinkPort")))
+
+    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("sourceExport")) should equal(Some(Seq(
+      ConnectTypes.BoundaryPort("port", Seq()),
+      ConnectTypes.BlockPort("exportSource", "port")
+    )))
+    ConnectTypes.BoundaryPort("port", Seq()).getPortType(exampleBlock) should equal(Some(LibraryPath("sourcePort")))
+    ConnectTypes.BlockPort("exportSource", "port").getPortType(exampleBlock) should equal(
+      Some(LibraryPath("sourcePort"))
+    )
+
+    // export into bundle component / vector element
+    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("bundleSourceExport")) should equal(Some(Seq(
+      ConnectTypes.BoundaryPort("bundle", Seq("port")),
+      ConnectTypes.BlockPort("exportBundleSource", "port")
+    )))
+    ConnectTypes.BoundaryPort("bundle", Seq("port")).getPortType(exampleBlock) should equal(
+      Some(LibraryPath("sourcePort"))
+    )
+    ConnectTypes.BlockPort("exportBundleSource", "port").getPortType(exampleBlock) should equal(
+      Some(LibraryPath("sourcePort"))
+    )
+  }
+
+  it should "build valid connects from empty, starting with a port" in {
+    val emptyConnect = ConnectBuilder(exampleBlock, exampleLink, Seq())
+    emptyConnect should not be empty
+    emptyConnect.get.connectMode should equal(ConnectMode.Ambiguous)
+
+    val sourceConnect = emptyConnect.get.append(Seq(
+      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"))
+    ))
+    sourceConnect should not be empty
+    sourceConnect.get.connectMode should equal(ConnectMode.Port)
+
+    val sink0Connect = sourceConnect.get.append(Seq(
+      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
+    ))
+    sink0Connect should not be empty
+    sink0Connect.get.connectMode should equal(ConnectMode.Port)
+    sink0Connect.get.connected should equal(Seq(
+      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
+      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+    ))
+  }
+
+  it should "build valid port connects from empty, starting with an ambiguous vector" in {
+    val emptyConnect = ConnectBuilder(exampleBlock, exampleLink, Seq())
+    val sliceConnect = emptyConnect.get.append(Seq(
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+    ))
+    sliceConnect should not be empty
+    sliceConnect.get.connectMode should equal(ConnectMode.Ambiguous) // stays ambiguous
+
+    val sink0Connect = sliceConnect.get.append(Seq(
+      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
+    ))
+    sink0Connect should not be empty
+    sink0Connect.get.connectMode should equal(ConnectMode.Port) // connection type resolved here
+    sink0Connect.get.connected should equal(Seq(
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+    ))
+  }
+
+  it should "build valid array connects from empty, starting with an ambiguous vector" in {
+    val emptyConnect = ConnectBuilder(exampleArrayBlock, exampleLink, Seq())
+    val sliceConnect = emptyConnect.get.append(Seq(
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+    ))
+
+    val sinkArrayConnect = sliceConnect.get.append(Seq(
+      (ConnectTypes.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"))
+    ))
+    sinkArrayConnect should not be empty
+    sinkArrayConnect.get.connectMode should equal(ConnectMode.Vector) // connection type resolved here
+    sinkArrayConnect.get.connected should equal(Seq(
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (ConnectTypes.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+    ))
+  }
+
+  it should "build valid connects with multiple allocations to an array" in {
+    val connect = ConnectBuilder(
+      exampleBlock,
+      exampleLink,
+      Seq(
+        exampleBlock.constraints.toSeqMap("sink0Connect"),
+        exampleBlock.constraints.toSeqMap("sink1Connect"),
+        exampleBlock.constraints.toSeqMap("sinkArrayConnect")
+      )
+    )
+    connect should not be empty
+    connect.get.connectMode should equal(ConnectMode.Port)
+  }
+
+  it should "build valid array connects with multiple allocations to an array" in {
+    val connect = ConnectBuilder(
+      exampleArrayBlock,
+      exampleLink,
+      Seq(
+        exampleArrayBlock.constraints.toSeqMap("sink0Connect"),
+        exampleArrayBlock.constraints.toSeqMap("sink1Connect"),
+        exampleArrayBlock.constraints.toSeqMap("sinkArrayConnect")
+      )
+    )
+    connect should not be empty
+    connect.get.connectMode should equal(ConnectMode.Vector)
+  }
+
+  it should "not overallocate single connects" in {
+    val sourceConnect = ConnectBuilder(
+      exampleBlock,
+      exampleLink,
+      Seq(exampleBlock.constraints.toSeqMap("sourceConnect"))
+    ).get
+    sourceConnect.append(Seq(
+      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"))
+    )) shouldBe empty
+  }
+
+  it should "not overallocate vector connects" in {
+    val sourceConnect = ConnectBuilder(
+      exampleArrayBlock,
+      exampleLink,
+      Seq(exampleArrayBlock.constraints.toSeqMap("sourceConnect"))
+    ).get
+    sourceConnect.append(Seq(
+      (ConnectTypes.BlockVectorSlice("source", "port", None), LibraryPath("sourcePort"))
+    )) shouldBe empty
+  }
+
+  it should "not mix port and vector connects" in {
+    val sourceConnect = ConnectBuilder(
+      exampleArrayBlock,
+      exampleLink,
+      Seq(exampleArrayBlock.constraints.toSeqMap("sourceConnect"))
+    ).get
+    sourceConnect.append(Seq(
+      (ConnectTypes.BlockPort("sink", "port"), LibraryPath("sinkPort"))
+    )) shouldBe empty
+  }
+
+  it should "allow appending vector slices in port mode" in {
+    val sourceConnect = ConnectBuilder(
+      exampleBlock,
+      exampleLink,
+      Seq(
+        exampleBlock.constraints.toSeqMap("sourceConnect"),
+        exampleBlock.constraints.toSeqMap("sink0Connect")
+      )
+    ).get
+    val sinkConnected = sourceConnect.append(Seq(
+      (ConnectTypes.BlockPort("sink1", "port"), LibraryPath("sinkPort"))
+    ))
+    sinkConnected should not be empty
+    val sliceConnected = sinkConnected.get.append(Seq(
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+    ))
+    sliceConnected should not be empty
+    sliceConnected.get.connectMode should equal(ConnectMode.Port)
+    sliceConnected.get.connected should equal(Seq(
+      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
+      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
+      (ConnectTypes.BlockPort("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+    ))
+  }
+
+  it should "allow appending vector slices in vector mode" in {
+    val sourceConnect = ConnectBuilder(
+      exampleArrayBlock,
+      exampleLink,
+      Seq(
+        exampleArrayBlock.constraints.toSeqMap("sourceConnect"),
+        exampleArrayBlock.constraints.toSeqMap("sink0Connect")
+      )
+    ).get
+    val sinkConnected = sourceConnect.append(Seq(
+      (ConnectTypes.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"))
+    ))
+    sinkConnected should not be empty
+    val sliceConnected = sinkConnected.get.append(Seq(
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+    ))
+    sliceConnected should not be empty
+    sliceConnected.get.connectMode should equal(ConnectMode.Vector)
+    sliceConnected.get.connected should equal(Seq(
+      (ConnectTypes.BlockVectorUnit("source", "port"), LibraryPath("sourcePort"), "source"),
+      (ConnectTypes.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
+      (ConnectTypes.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
+      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+    ))
+  }
+}

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -195,7 +195,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
       PortConnects.BlockPort("exportBundleSource", "port")
     )))
     PortConnects.BoundaryPort("bundle", Seq("port")).getPortType(exampleBlock) should equal(
-      Some(LibraryPath("sourcePort"))
+      Some(LibraryPath("sourceBundle"))
     )
     PortConnects.BlockPort("exportBundleSource", "port").getPortType(exampleBlock) should equal(
       Some(LibraryPath("sourcePort"))

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -64,6 +64,12 @@ class ConnectBuilderTest extends AnyFlatSpec {
           "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
         ),
       ),
+      "unusedSink" -> Block.Block(
+        "sinkBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
     ),
     links = SeqMap(
       "link" -> Link.Link("link"),
@@ -84,13 +90,6 @@ class ConnectBuilderTest extends AnyFlatSpec {
   val exampleArrayBlock = Block.Block( // basic example using link arrays
     "topDesign",
     ports = SeqMap(
-      "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
-      "bundle" -> Port.Bundle(
-        "sourceBundle",
-        ports = SeqMap(
-          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
-        )
-      ),
     ),
     blocks = SeqMap(
       "source" -> Block.Block(
@@ -124,6 +123,16 @@ class ConnectBuilderTest extends AnyFlatSpec {
         ),
       ),
       "sinkArray" -> Block.Block(
+        "sinkArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sinkPort",
+            Seq("0", "1"),
+            Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+      "unusedSinkArray" -> Block.Block(
         "sinkArrayBlock",
         ports = SeqMap(
           "port" -> Port.Array(

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -3,7 +3,7 @@ package edg_ide.util.tests
 import edg.ElemBuilder._
 import edg.ExprBuilder.{Ref, ValInit}
 import edg.wir.ProtoUtil.ConstraintProtoToSeqMap
-import edg_ide.util.{ConnectBuilder, ConnectMode, PortConnects}
+import edg_ide.util.{ConnectBuilder, ConnectMode, PortConnectTyped, PortConnects}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -208,55 +208,55 @@ class ConnectBuilderTest extends AnyFlatSpec {
     emptyConnect.get.connectMode should equal(ConnectMode.Ambiguous)
 
     val sourceConnect = emptyConnect.get.append(Seq(
-      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
+      PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
     ))
     sourceConnect should not be empty
     sourceConnect.get.connectMode should equal(ConnectMode.Port)
 
     val sink0Connect = sourceConnect.get.append(Seq(
-      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
     ))
     sink0Connect should not be empty
     sink0Connect.get.connectMode should equal(ConnectMode.Port)
     sink0Connect.get.connected should equal(Seq(
-      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
-      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+      (PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort")), "source"),
+      (PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort")), "sinks")
     ))
   }
 
   it should "build valid port connects from empty, starting with an ambiguous vector" in {
     val emptyConnect = ConnectBuilder(exampleBlock, exampleLink, Seq())
     val sliceConnect = emptyConnect.get.append(Seq(
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
     sliceConnect should not be empty
     sliceConnect.get.connectMode should equal(ConnectMode.Ambiguous) // stays ambiguous
 
     val sink0Connect = sliceConnect.get.append(Seq(
-      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
     ))
     sink0Connect should not be empty
     sink0Connect.get.connectMode should equal(ConnectMode.Port) // connection type resolved here
     sink0Connect.get.connected should equal(Seq(
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
-      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+      (PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort")), "sinks"),
+      (PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort")), "sinks")
     ))
   }
 
   it should "build valid array connects from empty, starting with an ambiguous vector" in {
     val emptyConnect = ConnectBuilder(exampleArrayBlock, exampleLink, Seq())
     val sliceConnect = emptyConnect.get.append(Seq(
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
 
     val sinkArrayConnect = sliceConnect.get.append(Seq(
-      (PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"))
     ))
     sinkArrayConnect should not be empty
     sinkArrayConnect.get.connectMode should equal(ConnectMode.Vector) // connection type resolved here
     sinkArrayConnect.get.connected should equal(Seq(
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
-      (PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+      (PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort")), "sinks"),
+      (PortConnectTyped(PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort")), "sinks")
     ))
   }
 
@@ -295,7 +295,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
       Seq(exampleBlock.constraints.toSeqMap("sourceConnect"))
     ).get
     sourceConnect.append(Seq(
-      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
+      PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
     )) shouldBe empty
   }
 
@@ -306,7 +306,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
       Seq(exampleArrayBlock.constraints.toSeqMap("sourceConnect"))
     ).get
     sourceConnect.append(Seq(
-      (PortConnects.BlockVectorSlice("source", "port", None), LibraryPath("sourcePort"))
+      PortConnectTyped(PortConnects.BlockVectorSlice("source", "port", None), LibraryPath("sourcePort"))
     )) shouldBe empty
   }
 
@@ -317,7 +317,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
       Seq(exampleArrayBlock.constraints.toSeqMap("sourceConnect"))
     ).get
     sourceConnect.append(Seq(
-      (PortConnects.BlockPort("sink", "port"), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockPort("sink", "port"), LibraryPath("sinkPort"))
     )) shouldBe empty
   }
 
@@ -331,19 +331,19 @@ class ConnectBuilderTest extends AnyFlatSpec {
       )
     ).get
     val sinkConnected = sourceConnect.append(Seq(
-      (PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort"))
     ))
     sinkConnected should not be empty
     val sliceConnected = sinkConnected.get.append(Seq(
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
     sliceConnected should not be empty
     sliceConnected.get.connectMode should equal(ConnectMode.Port)
     sliceConnected.get.connected should equal(Seq(
-      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
-      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
-      (PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort")), "source"),
+      (PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort")), "sinks"),
+      (PortConnectTyped(PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort")), "sinks"),
+      (PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort")), "sinks"),
     ))
   }
 
@@ -357,19 +357,19 @@ class ConnectBuilderTest extends AnyFlatSpec {
       )
     ).get
     val sinkConnected = sourceConnect.append(Seq(
-      (PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"))
     ))
     sinkConnected should not be empty
     val sliceConnected = sinkConnected.get.append(Seq(
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
     sliceConnected should not be empty
     sliceConnected.get.connectMode should equal(ConnectMode.Vector)
     sliceConnected.get.connected should equal(Seq(
-      (PortConnects.BlockVectorUnit("source", "port"), LibraryPath("sourcePort"), "source"),
-      (PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
-      (PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
-      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (PortConnectTyped(PortConnects.BlockVectorUnit("source", "port"), LibraryPath("sourcePort")), "source"),
+      (PortConnectTyped(PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort")), "sinks"),
+      (PortConnectTyped(PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort")), "sinks"),
+      (PortConnectTyped(PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort")), "sinks"),
     ))
   }
 }

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -3,7 +3,7 @@ package edg_ide.util.tests
 import edg.ElemBuilder._
 import edg.ExprBuilder.{Ref, ValInit}
 import edg.wir.ProtoUtil.ConstraintProtoToSeqMap
-import edg_ide.util.{ConnectBuilder, ConnectMode, ConnectTypes}
+import edg_ide.util.{ConnectBuilder, ConnectMode, PortConnects}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -170,34 +170,34 @@ class ConnectBuilderTest extends AnyFlatSpec {
 
   it should "decode connections and get types" in {
     // basic connection forms
-    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("sourceConnect")) should equal(Some(Seq(
-      ConnectTypes.BlockPort("source", "port")
+    PortConnects.fromConnect(exampleBlock.constraints.toSeqMap("sourceConnect")) should equal(Some(Seq(
+      PortConnects.BlockPort("source", "port")
     )))
-    ConnectTypes.BlockPort("source", "port").getPortType(exampleBlock) should equal(Some(LibraryPath("sourcePort")))
+    PortConnects.BlockPort("source", "port").getPortType(exampleBlock) should equal(Some(LibraryPath("sourcePort")))
 
-    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("sink0Connect")) should equal(Some(Seq(
-      ConnectTypes.BlockPort("sink0", "port")
+    PortConnects.fromConnect(exampleBlock.constraints.toSeqMap("sink0Connect")) should equal(Some(Seq(
+      PortConnects.BlockPort("sink0", "port")
     )))
-    ConnectTypes.BlockPort("sink0", "port").getPortType(exampleBlock) should equal(Some(LibraryPath("sinkPort")))
+    PortConnects.BlockPort("sink0", "port").getPortType(exampleBlock) should equal(Some(LibraryPath("sinkPort")))
 
-    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("sourceExport")) should equal(Some(Seq(
-      ConnectTypes.BoundaryPort("port", Seq()),
-      ConnectTypes.BlockPort("exportSource", "port")
+    PortConnects.fromConnect(exampleBlock.constraints.toSeqMap("sourceExport")) should equal(Some(Seq(
+      PortConnects.BoundaryPort("port", Seq()),
+      PortConnects.BlockPort("exportSource", "port")
     )))
-    ConnectTypes.BoundaryPort("port", Seq()).getPortType(exampleBlock) should equal(Some(LibraryPath("sourcePort")))
-    ConnectTypes.BlockPort("exportSource", "port").getPortType(exampleBlock) should equal(
+    PortConnects.BoundaryPort("port", Seq()).getPortType(exampleBlock) should equal(Some(LibraryPath("sourcePort")))
+    PortConnects.BlockPort("exportSource", "port").getPortType(exampleBlock) should equal(
       Some(LibraryPath("sourcePort"))
     )
 
     // export into bundle component / vector element
-    ConnectTypes.fromConnect(exampleBlock.constraints.toSeqMap("bundleSourceExport")) should equal(Some(Seq(
-      ConnectTypes.BoundaryPort("bundle", Seq("port")),
-      ConnectTypes.BlockPort("exportBundleSource", "port")
+    PortConnects.fromConnect(exampleBlock.constraints.toSeqMap("bundleSourceExport")) should equal(Some(Seq(
+      PortConnects.BoundaryPort("bundle", Seq("port")),
+      PortConnects.BlockPort("exportBundleSource", "port")
     )))
-    ConnectTypes.BoundaryPort("bundle", Seq("port")).getPortType(exampleBlock) should equal(
+    PortConnects.BoundaryPort("bundle", Seq("port")).getPortType(exampleBlock) should equal(
       Some(LibraryPath("sourcePort"))
     )
-    ConnectTypes.BlockPort("exportBundleSource", "port").getPortType(exampleBlock) should equal(
+    PortConnects.BlockPort("exportBundleSource", "port").getPortType(exampleBlock) should equal(
       Some(LibraryPath("sourcePort"))
     )
   }
@@ -208,55 +208,55 @@ class ConnectBuilderTest extends AnyFlatSpec {
     emptyConnect.get.connectMode should equal(ConnectMode.Ambiguous)
 
     val sourceConnect = emptyConnect.get.append(Seq(
-      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"))
+      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
     ))
     sourceConnect should not be empty
     sourceConnect.get.connectMode should equal(ConnectMode.Port)
 
     val sink0Connect = sourceConnect.get.append(Seq(
-      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
+      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
     ))
     sink0Connect should not be empty
     sink0Connect.get.connectMode should equal(ConnectMode.Port)
     sink0Connect.get.connected should equal(Seq(
-      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
-      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
+      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
     ))
   }
 
   it should "build valid port connects from empty, starting with an ambiguous vector" in {
     val emptyConnect = ConnectBuilder(exampleBlock, exampleLink, Seq())
     val sliceConnect = emptyConnect.get.append(Seq(
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
     sliceConnect should not be empty
     sliceConnect.get.connectMode should equal(ConnectMode.Ambiguous) // stays ambiguous
 
     val sink0Connect = sliceConnect.get.append(Seq(
-      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
+      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
     ))
     sink0Connect should not be empty
     sink0Connect.get.connectMode should equal(ConnectMode.Port) // connection type resolved here
     sink0Connect.get.connected should equal(Seq(
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
-      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks")
     ))
   }
 
   it should "build valid array connects from empty, starting with an ambiguous vector" in {
     val emptyConnect = ConnectBuilder(exampleArrayBlock, exampleLink, Seq())
     val sliceConnect = emptyConnect.get.append(Seq(
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
 
     val sinkArrayConnect = sliceConnect.get.append(Seq(
-      (ConnectTypes.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"))
+      (PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"))
     ))
     sinkArrayConnect should not be empty
     sinkArrayConnect.get.connectMode should equal(ConnectMode.Vector) // connection type resolved here
     sinkArrayConnect.get.connected should equal(Seq(
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
-      (ConnectTypes.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks")
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks")
     ))
   }
 
@@ -295,7 +295,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
       Seq(exampleBlock.constraints.toSeqMap("sourceConnect"))
     ).get
     sourceConnect.append(Seq(
-      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"))
+      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
     )) shouldBe empty
   }
 
@@ -306,7 +306,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
       Seq(exampleArrayBlock.constraints.toSeqMap("sourceConnect"))
     ).get
     sourceConnect.append(Seq(
-      (ConnectTypes.BlockVectorSlice("source", "port", None), LibraryPath("sourcePort"))
+      (PortConnects.BlockVectorSlice("source", "port", None), LibraryPath("sourcePort"))
     )) shouldBe empty
   }
 
@@ -317,7 +317,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
       Seq(exampleArrayBlock.constraints.toSeqMap("sourceConnect"))
     ).get
     sourceConnect.append(Seq(
-      (ConnectTypes.BlockPort("sink", "port"), LibraryPath("sinkPort"))
+      (PortConnects.BlockPort("sink", "port"), LibraryPath("sinkPort"))
     )) shouldBe empty
   }
 
@@ -331,19 +331,19 @@ class ConnectBuilderTest extends AnyFlatSpec {
       )
     ).get
     val sinkConnected = sourceConnect.append(Seq(
-      (ConnectTypes.BlockPort("sink1", "port"), LibraryPath("sinkPort"))
+      (PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort"))
     ))
     sinkConnected should not be empty
     val sliceConnected = sinkConnected.get.append(Seq(
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
     sliceConnected should not be empty
     sliceConnected.get.connectMode should equal(ConnectMode.Port)
     sliceConnected.get.connected should equal(Seq(
-      (ConnectTypes.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
-      (ConnectTypes.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
-      (ConnectTypes.BlockPort("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"), "source"),
+      (PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
     ))
   }
 
@@ -357,19 +357,19 @@ class ConnectBuilderTest extends AnyFlatSpec {
       )
     ).get
     val sinkConnected = sourceConnect.append(Seq(
-      (ConnectTypes.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"))
+      (PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"))
     ))
     sinkConnected should not be empty
     val sliceConnected = sinkConnected.get.append(Seq(
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"))
     ))
     sliceConnected should not be empty
     sliceConnected.get.connectMode should equal(ConnectMode.Vector)
     sliceConnected.get.connected should equal(Seq(
-      (ConnectTypes.BlockVectorUnit("source", "port"), LibraryPath("sourcePort"), "source"),
-      (ConnectTypes.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
-      (ConnectTypes.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
-      (ConnectTypes.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockVectorUnit("source", "port"), LibraryPath("sourcePort"), "source"),
+      (PortConnects.BlockVectorUnit("sink0", "port"), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockVectorUnit("sink1", "port"), LibraryPath("sinkPort"), "sinks"),
+      (PortConnects.BlockVectorSlice("sinkArray", "port", None), LibraryPath("sinkPort"), "sinks"),
     ))
   }
 }

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -160,7 +160,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
   val exampleLink = Link.Link(
     "link",
     ports = SeqMap(
-      "source" -> Port.Port("sourcePort"),
+      "source" -> Port.Library("sourcePort"),
       "sinks" -> Port.Array("sinkPort"),
     ),
     params = SeqMap(

--- a/src/test/scala/edg_ide/util/tests/EdgirConnectExecutorTest.scala
+++ b/src/test/scala/edg_ide/util/tests/EdgirConnectExecutorTest.scala
@@ -15,7 +15,7 @@ class EdgirConnectExecutorTest extends AnyFlatSpec {
 
   private val connectBuilderTest = new ConnectBuilderTest() // for shared examples
 
-  val emptyBlock = Block.Block( // basic skeletal and structural example of a block with various connects
+  val emptyBlock = Block.Block(
     "topDesign",
     ports = SeqMap(
       "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
@@ -66,8 +66,8 @@ class EdgirConnectExecutorTest extends AnyFlatSpec {
     ))
     connected.constraints.toSeqMap should equal(SeqMap(
       "_new2" -> Constraint.Connected(Ref("source", "port"), Ref("_new", "source")),
-      "_new3" -> Constraint.Connected(Ref("sink0", "port"), Ref("_new", "sinks")), // TODO should be allocate
-      "_new4" -> Constraint.Connected(Ref("sink1", "port"), Ref("_new", "sinks")), // TODO should be allocate
+      "_new3" -> Constraint.Connected(Ref("sink0", "port"), Ref("_new", "sinks")), // TODO link allocate
+      "_new4" -> Constraint.Connected(Ref("sink1", "port"), Ref("_new", "sinks")), // TODO link allocate
     ))
   }
 
@@ -84,9 +84,93 @@ class EdgirConnectExecutorTest extends AnyFlatSpec {
       "_new" -> elem.LinkLike(elem.LinkLike.Type.Link(connectBuilderTest.exampleLink))
     ))
     connected.constraints.toSeqMap should equal(SeqMap(
-      "_new2" -> Constraint.Connected(Ref("sink0", "port"), Ref("_new", "sinks")), // TODO should be allocate
+      "_new2" -> Constraint.Connected(Ref("sink0", "port"), Ref("_new", "sinks")), // TODO link allocate
       "_new3" -> Constraint.Connected(Ref("source", "port"), Ref("_new", "source")),
-      "_new4" -> Constraint.Connected(Ref("sink1", "port"), Ref("_new", "sinks")), // TODO should be allocate
+      "_new4" -> Constraint.Connected(Ref("sink1", "port"), Ref("_new", "sinks")), // TODO link allocate
+    ))
+  }
+
+  it should "create a new link, with vector slice port" in {
+    val startingPort = PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
+    val newConnects = Seq(
+      PortConnectTyped(PortConnects.BlockVectorSlicePort("sinkArray", "port", None), LibraryPath("sinkPort")),
+    )
+    val newConnected = ConnectBuilder(emptyBlock, connectBuilderTest.exampleLink, Seq()).get
+      .append(startingPort +: newConnects).get
+    val connected = EdgirConnectExecutor(emptyBlock, None, newConnected, startingPort, newConnects).get
+    connected.links.toSeqMap should equal(SeqMap(
+      "_new" -> elem.LinkLike(elem.LinkLike.Type.Link(connectBuilderTest.exampleLink))
+    ))
+    connected.constraints.toSeqMap should equal(SeqMap(
+      "_new2" -> Constraint.Connected(Ref("source", "port"), Ref("_new", "source")),
+      "_new3" -> Constraint.Connected(
+        Ref.Allocate(Ref("sinkArray", "port")),
+        Ref("_new", "sinks")
+      ), // TODO link allocate
+    ))
+  }
+
+  val connectedBlock = Block.Block(
+    "topDesign",
+    ports = SeqMap(
+      "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+    ),
+    blocks = SeqMap(
+      "source" -> Block.Block(
+        "sourceBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sink0" -> Block.Block(
+        "sinkBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sink1" -> Block.Block(
+        "sinkBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sinkArray" -> Block.Block(
+        "sinkArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sinkPort",
+            Seq("0"),
+            Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+    ),
+    links = SeqMap(
+      "link" -> Link.Link("link"),
+    ),
+    constraints = SeqMap(
+      "sourceConnect" -> Constraint.Connected(Ref("source", "port"), Ref("link", "source")),
+      "sink0Connect" -> Constraint.Connected(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
+    ),
+  ).getHierarchy
+
+  it should "append to existing link" in {
+    val startingPort = PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
+    val newConnects = Seq(
+      PortConnectTyped(PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort")),
+    )
+    val newConnected = ConnectBuilder(
+      connectedBlock,
+      connectBuilderTest.exampleLink,
+      connectedBlock.constraints.toSeqMap.values.toSeq
+    ).get
+      .append(newConnects).get
+    val connected = EdgirConnectExecutor(connectedBlock, Some("link"), newConnected, startingPort, newConnects).get
+    connected.links.toSeqMap.keys should equal(Set("link")) // no new port should be added
+    connected.constraints.toSeqMap should equal(SeqMap(
+      "sourceConnect" -> Constraint.Connected(Ref("source", "port"), Ref("link", "source")),
+      "sink0Connect" -> Constraint.Connected(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
+      "_new" -> Constraint.Connected(Ref("sink1", "port"), Ref("link", "sinks")), // TODO should be allocate
     ))
   }
 }

--- a/src/test/scala/edg_ide/util/tests/EdgirConnectExecutorTest.scala
+++ b/src/test/scala/edg_ide/util/tests/EdgirConnectExecutorTest.scala
@@ -103,10 +103,7 @@ class EdgirConnectExecutorTest extends AnyFlatSpec {
     ))
     connected.constraints.toSeqMap should equal(SeqMap(
       "_new2" -> Constraint.Connected(Ref("source", "port"), Ref("_new", "source")),
-      "_new3" -> Constraint.Connected(
-        Ref.Allocate(Ref("sinkArray", "port")),
-        Ref("_new", "sinks")
-      ), // TODO link allocate
+      "_new3" -> Constraint.Connected(Ref("sinkArray", "port"), Ref("_new", "sinks")), // TODO link and block allocate
     ))
   }
 

--- a/src/test/scala/edg_ide/util/tests/EdgirConnectExecutorTest.scala
+++ b/src/test/scala/edg_ide/util/tests/EdgirConnectExecutorTest.scala
@@ -1,0 +1,92 @@
+package edg_ide.util.tests
+
+import edgir.elem.elem
+import edg.ElemBuilder._
+import edg.ExprBuilder.{Ref, ValInit}
+import edg.wir.ProtoUtil.{ConstraintProtoToSeqMap, LinkProtoToSeqMap}
+import edg_ide.util.{BlockConnectedAnalysis, ConnectBuilder, EdgirConnectExecutor, PortConnectTyped, PortConnects}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+import scala.collection.SeqMap
+
+class EdgirConnectExecutorTest extends AnyFlatSpec {
+  behavior.of("EdgirConnectExecutor")
+
+  private val connectBuilderTest = new ConnectBuilderTest() // for shared examples
+
+  val emptyBlock = Block.Block( // basic skeletal and structural example of a block with various connects
+    "topDesign",
+    ports = SeqMap(
+      "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+    ),
+    blocks = SeqMap(
+      "source" -> Block.Block(
+        "sourceBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sink0" -> Block.Block(
+        "sinkBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sink1" -> Block.Block(
+        "sinkBlock",
+        ports = SeqMap(
+          "port" -> Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer)),
+        ),
+      ),
+      "sinkArray" -> Block.Block(
+        "sinkArrayBlock",
+        ports = SeqMap(
+          "port" -> Port.Array(
+            "sinkPort",
+            Seq("0"),
+            Port.Port("sinkPort", params = SeqMap("param" -> ValInit.Integer))
+          ),
+        ),
+      ),
+    ),
+  ).getHierarchy
+
+  it should "create a new link, source first" in {
+    val startingPort = PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort"))
+    val newConnects = Seq(
+      PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort")),
+      PortConnectTyped(PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort")),
+    )
+    val newConnected = ConnectBuilder(emptyBlock, connectBuilderTest.exampleLink, Seq()).get
+      .append(startingPort +: newConnects).get
+    val connected = EdgirConnectExecutor(emptyBlock, None, newConnected, startingPort, newConnects).get
+    connected.links.toSeqMap should equal(SeqMap(
+      "_new" -> elem.LinkLike(elem.LinkLike.Type.Link(connectBuilderTest.exampleLink))
+    ))
+    connected.constraints.toSeqMap should equal(SeqMap(
+      "_new2" -> Constraint.Connected(Ref("source", "port"), Ref("_new", "source")),
+      "_new3" -> Constraint.Connected(Ref("sink0", "port"), Ref("_new", "sinks")), // TODO should be allocate
+      "_new4" -> Constraint.Connected(Ref("sink1", "port"), Ref("_new", "sinks")), // TODO should be allocate
+    ))
+  }
+
+  it should "create a new link, sink first" in {
+    val startingPort = PortConnectTyped(PortConnects.BlockPort("sink0", "port"), LibraryPath("sinkPort"))
+    val newConnects = Seq(
+      PortConnectTyped(PortConnects.BlockPort("source", "port"), LibraryPath("sourcePort")),
+      PortConnectTyped(PortConnects.BlockPort("sink1", "port"), LibraryPath("sinkPort")),
+    )
+    val newConnected = ConnectBuilder(emptyBlock, connectBuilderTest.exampleLink, Seq()).get
+      .append(startingPort +: newConnects).get
+    val connected = EdgirConnectExecutor(emptyBlock, None, newConnected, startingPort, newConnects).get
+    connected.links.toSeqMap should equal(SeqMap(
+      "_new" -> elem.LinkLike(elem.LinkLike.Type.Link(connectBuilderTest.exampleLink))
+    ))
+    connected.constraints.toSeqMap should equal(SeqMap(
+      "_new2" -> Constraint.Connected(Ref("sink0", "port"), Ref("_new", "sinks")), // TODO should be allocate
+      "_new3" -> Constraint.Connected(Ref("source", "port"), Ref("_new", "source")),
+      "_new4" -> Constraint.Connected(Ref("sink1", "port"), Ref("_new", "sinks")), // TODO should be allocate
+    ))
+  }
+}

--- a/src/test/scala/edg_ide/util/tests/SeqUtilsTest.scala
+++ b/src/test/scala/edg_ide/util/tests/SeqUtilsTest.scala
@@ -1,0 +1,24 @@
+package edg_ide.util.tests
+
+import edg_ide.util.SeqUtils
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+class SeqUtilsTest extends AnyFlatSpec {
+  behavior.of("IterableUtils")
+
+  it should "work for Some" in {
+    SeqUtils.getAllDefined(Seq(Some(1))) should equal(Some(Seq(1)))
+    SeqUtils.getAllDefined(Seq(Some(1), Some(2))) should equal(Some(Seq(1, 2)))
+  }
+
+  it should "work for None" in {
+    SeqUtils.getAllDefined(Seq(None)) should equal(None)
+    SeqUtils.getAllDefined(Seq(None, None)) should equal(None)
+  }
+
+  it should "work for mixed" in {
+    SeqUtils.getAllDefined(Seq(Some(1), None)) should equal(None)
+    SeqUtils.getAllDefined(Seq(Some(1), None, Some(3))) should equal(None)
+  }
+}


### PR DESCRIPTION
Adds insertion live template support for GUI connect operations. Experimental, partially implemented (for single ports only, limited support for arrays and boundary ports), currently behind a toggle in the settings menu.

Architecturally, this separates the connect-builder (which determines which connections are allowed to a link) from the block analysis (which determines which ports are in a connected group, and what connects are available to a port), from the IR mutator (the executor, which takes a connectivity change and updates the Block IR), from the code generator / insertion live template. Probably more code to before, but in chunks that actually make more sense. Prior, GUI connects were much more monolithic code-wise.

Other functional changes:
- Fix getting the nearest insertion location when above the class level - prior it crashed because it would traverse to the folder level and can’t getTextRange. Now it detects a null text range is invalid.

Other refactoring / infrastructural changes:
- Updates to support the new connect expansion.
  - Refactor the IR-to-graph parsing to use the expanded versions, if available.
- Move the insert block live template to its own file
- Support no variables in insertion live template

Future TODOs
- Support suggested index - perhaps as template field
- Don’t allow name when connecting to an existing named link
- Support connect append in live template
- Support boundary ports including bridging
- Better support for array types