### PR TITLE
Improve live templates

### DIFF
--- a/src/main/scala/edg_ide/EdgirUtils.scala
+++ b/src/main/scala/edg_ide/EdgirUtils.scala
@@ -5,6 +5,7 @@ import edgir.ref.ref
 import edgir.schema.schema
 import edg.wir.DesignPath
 import edg.ElemBuilder
+import edg.ElemBuilder.LibraryPath
 import edg.wir.ProtoUtil._
 
 object EdgirUtils {
@@ -13,6 +14,10 @@ object EdgirUtils {
   // TODO this needs better flagging
   def isCategory(blockType: ref.LibraryPath): Boolean = {
     blockType.getTarget.getName.contains("Categories")
+  }
+
+  def isInternal(blockType: ref.LibraryPath): Boolean = {
+    blockType == LibraryPath("edg_core.Categories.InternalBlock")
   }
 
   val FootprintBlockType: ref.LibraryPath =

--- a/src/main/scala/edg_ide/EdgirUtils.scala
+++ b/src/main/scala/edg_ide/EdgirUtils.scala
@@ -20,9 +20,6 @@ object EdgirUtils {
     blockType == LibraryPath("edg_core.Categories.InternalBlock")
   }
 
-  val FootprintBlockType: ref.LibraryPath =
-    ElemBuilder.LibraryPath("electronics_model.CircuitBlock.CircuitBlock")
-
   // TODO refactor into common utils elsewhere
   def typeOfBlockLike(blockLike: elem.BlockLike): Option[ref.LibraryPath] = blockLike.`type` match {
     case elem.BlockLike.Type.Hierarchy(block) => Some(block.getSelfClass)

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -106,8 +106,8 @@ object EdgirGraph {
     case Seq() => Seq( // in the loading pass, the source is the block side and the target is the link side
         EdgirEdge(
           ConnectWrapper(path + constrName, constr),
-          source = Ref.unapply(connected.getBlockPort.getRef).get.slice(0, 2), // only block and port, ignore arrays
-          target = Ref.unapply(connected.getLinkPort.getRef).get.slice(0, 2)
+          source = connected.getBlockPort.getRef.steps.slice(0, 2).map(_.getName), // only block and port, ignore arrays
+          target = connected.getLinkPort.getRef.steps.slice(0, 2).map(_.getName)
         ))
     case Seq(expanded) => connectedToEdge(path, constrName, constr, expanded)
     case _ => throw new IllegalArgumentException("unexpected multiple expanded")
@@ -119,11 +119,12 @@ object EdgirGraph {
       constr: expr.ValueExpr,
       exported: expr.ExportedExpr
   ): Seq[EdgirEdge] = exported.expanded match {
-    case Seq() => Seq( // in the loading pass, the source is the block side and the target is the external port
+    case Seq() =>
+      Seq( // in the loading pass, the source is the block side and the target is the external port
         EdgirEdge(
           ConnectWrapper(path + constrName, constr),
-          source = Ref.unapply(exported.getInternalBlockPort.getRef).get.slice(0, 2),
-          target = Ref.unapply(exported.getExteriorPort.getRef).get.slice(0, 1)
+          source = exported.getInternalBlockPort.getRef.steps.slice(0, 2).map(_.getName),
+          target = exported.getExteriorPort.getRef.steps.slice(0, 1).map(_.getName)
         ))
     case Seq(expanded) => exportedToEdge(path, constrName, constr, expanded)
     case _ => throw new IllegalArgumentException("unexpected multiple expanded")

--- a/src/main/scala/edg_ide/edgir_graph/InferEdgeDirectionTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/InferEdgeDirectionTransform.scala
@@ -35,7 +35,9 @@ object InferEdgeDirectionTransform {
       "sinks",
       "crystal",
       "device",
-      "devices", // SWD, USB, SPI
+      "devices", // SWD, USB
+      "targets", // I2C
+      "peripherals", // SPI
       "transceiver" // CAN logic
     )
     val bidirs = Set(
@@ -54,7 +56,7 @@ object InferEdgeDirectionTransform {
         linkPort
     }
     if (unknownPorts.nonEmpty) {
-      logger.warn(s"unknown port ${unknownPorts.mkString(", ")}")
+      logger.warn(s"unknown port ${unknownPorts.mkString(", ")} in ${link.path}")
     }
 
     val strongSourcePorts = ports.collect {

--- a/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutLinkTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutLinkTransform.scala
@@ -61,11 +61,11 @@ class RemoveHighFanoutLinkTransform(minConnects: Int, allowedLinkTypes: Set[Libr
 
     val filteredEdges = node.edges.map {
       // Transform to degenerate edges
-      case edge @ EdgirEdge(data, Seq(sourceNode, _*), target)
+      case EdgirEdge(data, Seq(sourceNode, _*), target)
         if highFanoutLinkNameWraps.contains(Seq(sourceNode)) =>
         val linkWrap = highFanoutLinkNameWraps(Seq(sourceNode))
         EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), target, target)
-      case edge @ EdgirEdge(data, source, Seq(targetNode, _*))
+      case EdgirEdge(data, source, Seq(targetNode, _*))
         if highFanoutLinkNameWraps.contains(Seq(targetNode)) =>
         val linkWrap = highFanoutLinkNameWraps(Seq(targetNode))
         EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), source, source)

--- a/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutLinkTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutLinkTransform.scala
@@ -61,11 +61,11 @@ class RemoveHighFanoutLinkTransform(minConnects: Int, allowedLinkTypes: Set[Libr
 
     val filteredEdges = node.edges.map {
       // Transform to degenerate edges
-      case EdgirEdge(data, Seq(sourceNode, sourcePort), target)
+      case edge @ EdgirEdge(data, Seq(sourceNode, _*), target)
         if highFanoutLinkNameWraps.contains(Seq(sourceNode)) =>
         val linkWrap = highFanoutLinkNameWraps(Seq(sourceNode))
         EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), target, target)
-      case EdgirEdge(data, source, Seq(targetNode, targetPort))
+      case edge @ EdgirEdge(data, source, Seq(targetNode, _*))
         if highFanoutLinkNameWraps.contains(Seq(targetNode)) =>
         val linkWrap = highFanoutLinkNameWraps(Seq(targetNode))
         EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), source, source)

--- a/src/main/scala/edg_ide/psi_edits/InsertAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertAction.scala
@@ -13,6 +13,7 @@ import edg_ide.ui.{BlockVisualizerService, PopupUtils}
 import edg_ide.util.ExceptionNotifyImplicits._
 import edg_ide.util.{DesignAnalysisUtils, exceptable, requireExcept}
 
+import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.{ListHasAsScala, SeqHasAsJava}
 import scala.reflect.ClassTag
 
@@ -57,6 +58,20 @@ object InsertAction {
       }
     }
     prevElementOf(element)
+  }
+
+  // given a PSI element, returns the closest element (self or towards root) that is an immediate child of
+  // a containerPsiType; or None if containerPsiType is not in its parents
+  @tailrec
+  def snapToContainerChild(element: PsiElement, containerPsiType: Class[_ <: PsiElement]): Option[PsiElement] = {
+    if (element.getParent == null) {
+      return None
+    }
+    if (containerPsiType.isAssignableFrom(element.getParent.getClass)) {
+      Some(element)
+    } else {
+      snapToContainerChild(element.getParent, containerPsiType)
+    }
   }
 
   // Given a PSI element, returns the insertion point element of type PsiType.

--- a/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
@@ -202,7 +202,9 @@ class InsertionLiveTemplate(elt: PsiElement, variables: IndexedSeq[InsertionLive
       new OpenFileDescriptor(project, elt.getContainingFile.getVirtualFile, elt.getTextRange.getStartOffset)
     val editor = FileEditorManager.getInstance(project).openTextEditor(fileDescriptor, true)
 
-    TemplateManager.getInstance(project).getActiveTemplate(editor).exceptEquals(null, "another template active")
+    if (TemplateManager.getInstance(project).getActiveTemplate(editor) != null) {
+      exceptable.fail("another template active")
+    }
 
     // opens / sets the focus onto the relevant text editor, so the user can start typing
     editor.getCaretModel.moveToOffset(

--- a/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
@@ -105,7 +105,7 @@ abstract class InsertionLiveTemplate(containingFile: PsiFile) {
   // insert the AST for the template, storing whatever state is needed for deletion
   // this happens in an externally-scoped write command action
   // can fail (returns an error message), in which case no AST changes should happen
-  protected def buildTemplateAst(): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])]
+  protected def buildTemplateAst(editor: Editor): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])]
 
   // IMPLEMENT ME
   // deletes the AST for the template, assuming the template has started (can read state from buildTemplateAst)
@@ -246,7 +246,7 @@ abstract class InsertionLiveTemplate(containingFile: PsiFile) {
       exceptable.fail("another template is already active")
     }
 
-    val (templateElt, variables) = buildTemplateAst().exceptError
+    val (templateElt, variables) = buildTemplateAst(editor).exceptError
 
     editor.getCaretModel.moveToOffset(
       templateElt.getTextOffset

--- a/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
@@ -4,11 +4,10 @@ import com.intellij.codeInsight.highlighting.HighlightManager
 import com.intellij.codeInsight.template.impl.{ConstantNode, TemplateState}
 import com.intellij.codeInsight.template.{Template, TemplateBuilderImpl, TemplateEditingAdapter, TemplateManager}
 import com.intellij.lang.LanguageNamesValidation
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.editor.markup.RangeHighlighter
-import com.intellij.openapi.fileEditor.{FileEditorManager, OpenFileDescriptor, TextEditor}
+import com.intellij.openapi.fileEditor.{FileEditorManager, TextEditor}
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.{ComponentValidator, ValidationInfo}
 import com.intellij.openapi.util.TextRange
@@ -106,7 +105,7 @@ abstract class InsertionLiveTemplate(containingFile: PsiFile) {
   // insert the AST for the template, storing whatever state is needed for deletion
   // this happens in an externally-scoped write command action
   // can fail (returns an error message), in which case no AST changes should happen
-  protected def buildTemplateAst(): Errorable[(PsiElement, IndexedSeq[InsertionLiveTemplateVariable])]
+  protected def buildTemplateAst(): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])]
 
   // IMPLEMENT ME
   // deletes the AST for the template, assuming the template has started (can read state from buildTemplateAst)
@@ -117,7 +116,7 @@ abstract class InsertionLiveTemplate(containingFile: PsiFile) {
 
   private class TemplateListener(
       editor: Editor,
-      variables: IndexedSeq[InsertionLiveTemplateVariable],
+      variables: Seq[InsertionLiveTemplateVariable],
       tooltip: JBPopup,
       highlighters: Iterable[RangeHighlighter]
   ) extends TemplateEditingAdapter {

--- a/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertionLiveTemplate.scala
@@ -101,13 +101,7 @@ object InsertionLiveTemplate {
   *   - tooltips
   *   - better API
   */
-abstract class InsertionLiveTemplate(
-    containingFile: PsiFile,
-    overrideVariableValues: Map[String, String],
-    helpTooltip: String
-) {
-  private lazy val logger = Logger.getInstance(this.getClass)
-
+abstract class InsertionLiveTemplate(containingFile: PsiFile) {
   // IMPLEMENT ME
   // insert the AST for the template, storing whatever state is needed for deletion
   // this happens in an externally-scoped write command action
@@ -218,7 +212,7 @@ abstract class InsertionLiveTemplate(
   // starts this template and returns the TemplateState if successfully started
   // caller should make sure another template isn't active in the same editor, otherwise weird things can happen
   // must be called from an externally-scoped writeCommandAction
-  def run(): Errorable[TemplateState] = exceptable {
+  def run(helpTooltip: String, overrideVariableValues: Map[String, String]): Errorable[TemplateState] = exceptable {
     val project = containingFile.getProject
     val fileDescriptor =
       new OpenFileDescriptor(project, containingFile.getVirtualFile, 0)

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -195,10 +195,15 @@ class ConnectInsertionLiveTemplate(
     if (nameOpt.isEmpty && newAssignStmt.nonEmpty) { // if name not specified, make the connect anonymous
       try {
         val templateAssign = newAssignStmt.get
+        val replacement = psiElementGenerator.createFromText( // must be wrapped in PyExprStatement
+          languageLevel,
+          classOf[PyStatement],
+          templateAssign.getAssignedValue.getText
+        )
         writeCommandAction(project)
           .withName(s"clean $actionName")
           .compute(() => {
-            templateAssign.replace(templateAssign.getAssignedValue)
+            templateAssign.replace(replacement)
           })
       } catch {
         case _: Throwable => // ignore

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -92,7 +92,8 @@ object LiveTemplateConnect {
           defaultValue = Some("")
         )
 
-        new InsertionLiveTemplate(newConnect, IndexedSeq(nameTemplateVar))
+//        new InsertionLiveTemplate(newConnect, IndexedSeq(nameTemplateVar))
+        ???
       }
 
       // if caretElt is in a PyCallExpression that is a connect involving any of the ports in this connection,
@@ -135,7 +136,8 @@ object LiveTemplateConnect {
           ))
         }
 
-        Some(new InsertionLiveTemplate(callCandidate, IndexedSeq()))
+//        Some(new InsertionLiveTemplate(callCandidate, IndexedSeq()))
+        ???
       }
 
       // TODO startTemplate should be able to fail - Errorable

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -141,31 +141,32 @@ object LiveTemplateConnect {
       }
 
       // TODO startTemplate should be able to fail - Errorable
-      override def createTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
-        // find earliest insertion position (after all refs are defined)
-        val allRequiredAttrs = allConnects.flatMap(connectedToRequiredAttr)
-        val earliestPosition = TemplateUtils.getLastAttributeAssignment(contextClass, allRequiredAttrs, project)
-
-        // TODO live template insertion needs to support modifying AST nodes (instead of only addition)
-//        caretEltOpt.foreach { caretElt => // check if caret is in a connect
-//          tryStartStatementInsertionTemplate(caretElt, earliestPosition).foreach {
-//            return _
+      override def createTemplate(): InsertionLiveTemplate = {
+//        // find earliest insertion position (after all refs are defined)
+//        val allRequiredAttrs = allConnects.flatMap(connectedToRequiredAttr)
+//        val earliestPosition = TemplateUtils.getLastAttributeAssignment(contextClass, allRequiredAttrs, project)
+//
+//        // TODO live template insertion needs to support modifying AST nodes (instead of only addition)
+////        caretEltOpt.foreach { caretElt => // check if caret is in a connect
+////          tryStartStatementInsertionTemplate(caretElt, earliestPosition).foreach {
+////            return _
+////          }
+////        } // otherwise continue to stmt insertion
+//
+//        val validCaretEltOpt = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
+//        val preInsertAfter = validCaretEltOpt
+//          .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
+//
+//        // adjust insertion position to be after all assignments to required references
+//        val insertAfter = earliestPosition.map { earliestPosition =>
+//          if (!DesignAnalysisUtils.elementAfterEdg(preInsertAfter, earliestPosition, project).getOrElse(true)) {
+//            preInsertAfter
+//          } else {
+//            earliestPosition
 //          }
-//        } // otherwise continue to stmt insertion
-
-        val validCaretEltOpt = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
-        val preInsertAfter = validCaretEltOpt
-          .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
-
-        // adjust insertion position to be after all assignments to required references
-        val insertAfter = earliestPosition.map { earliestPosition =>
-          if (!DesignAnalysisUtils.elementAfterEdg(preInsertAfter, earliestPosition, project).getOrElse(true)) {
-            preInsertAfter
-          } else {
-            earliestPosition
-          }
-        }.getOrElse(preInsertAfter)
-        startStatementInsertionTemplate(insertAfter)
+//        }.getOrElse(preInsertAfter)
+//        startStatementInsertionTemplate(insertAfter)
+        ???
       }
     }
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -2,6 +2,7 @@ package edg_ide.psi_edits
 
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -18,6 +19,8 @@ class ConnectInsertionLiveTemplate(
     continuation: (Option[String], PsiElement) => Unit
 ) extends InsertionLiveTemplate(contextClass.getContainingFile) {
   protected val kTemplateVariableName = "name (optional)"
+
+  private lazy val logger = Logger.getInstance(this.getClass)
 
   protected val project = contextClass.getProject
   protected val languageLevel = LanguageLevel.forElement(contextClass)
@@ -206,7 +209,7 @@ class ConnectInsertionLiveTemplate(
             templateAssign.replace(replacement)
           })
       } catch {
-        case _: Throwable => // ignore
+        case exc: Throwable => logger.error("error while completing template", exc)
       }
     }
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -139,7 +139,7 @@ object LiveTemplateConnect {
       }
 
       // TODO startTemplate should be able to fail - Errorable
-      override def startTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
+      override def createTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
         // find earliest insertion position (after all refs are defined)
         val allRequiredAttrs = allConnects.flatMap(connectedToRequiredAttr)
         val earliestPosition = TemplateUtils.getLastAttributeAssignment(contextClass, allRequiredAttrs, project)

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -13,8 +13,7 @@ import scala.collection.mutable
 
 class ConnectInsertionLiveTemplate(
     contextClass: PyClass,
-    startingConnect: PortConnects.Base,
-    newConnects: Seq[PortConnects.Base],
+    allConnects: Seq[PortConnects.Base],
     actionName: String,
     continuation: (Option[String], PsiElement) => Unit
 ) extends InsertionLiveTemplate(contextClass.getContainingFile) {
@@ -23,7 +22,6 @@ class ConnectInsertionLiveTemplate(
   protected val project = contextClass.getProject
   protected val languageLevel = LanguageLevel.forElement(contextClass)
   protected val psiElementGenerator = PyElementGenerator.getInstance(project)
-  protected val allConnects = startingConnect +: newConnects
 
   protected var createdPsiElts = mutable.ArrayBuffer[PsiElement]()
   protected var newAssignStmt: Option[PyAssignmentStatement] = None // only if an assign was inserted
@@ -226,14 +224,13 @@ object LiveTemplateConnect {
   // Creates an action to start a live template to insert the connection
   def createTemplateConnect(
       contextClass: PyClass,
-      startingConnect: PortConnects.Base,
-      newConnects: Seq[PortConnects.Base],
+      allConnects: Seq[PortConnects.Base],
       actionName: String,
       continuation: (Option[String], PsiElement) => Unit,
   ): MovableLiveTemplate = {
     new MovableLiveTemplate(actionName) {
       override def createTemplate(): InsertionLiveTemplate = {
-        new ConnectInsertionLiveTemplate(contextClass, startingConnect, newConnects, actionName, continuation)
+        new ConnectInsertionLiveTemplate(contextClass, allConnects, actionName, continuation)
       }
     }
   }

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -7,7 +7,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.{PsiElement, PsiWhiteSpace}
 import com.jetbrains.python.psi._
 import edg.util.Errorable
-import edg_ide.util.ExceptionNotifyImplicits.{ExceptOption, ExceptSeq}
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptOption, ExceptSeq}
 import edg_ide.util.{DesignAnalysisUtils, PortConnects, exceptable}
 
 object LiveTemplateConnect {
@@ -51,7 +51,7 @@ object LiveTemplateConnect {
       startingConnect: PortConnects.Base,
       newConnects: Seq[PortConnects.Base],
       continuation: (Option[String], PsiElement) => Unit,
-  ): Errorable[() => Unit] = exceptable {
+  ): Errorable[MovableLiveTemplate] = exceptable {
     val languageLevel = LanguageLevel.forElement(contextClass)
     val psiElementGenerator = PyElementGenerator.getInstance(project)
     val allConnects = startingConnect +: newConnects
@@ -205,16 +205,6 @@ object LiveTemplateConnect {
         }
       }
     })
-
-    val caretElt = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
-    def insertBlockFlow: Unit = {
-      writeCommandAction(project)
-        .withName(s"$actionName")
-        .compute(() => {
-          movableLiveTemplate.run(caretElt)
-        })
-    }
-
-    () => insertBlockFlow
+    movableLiveTemplate
   }
 }

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateConnect.scala
@@ -2,16 +2,30 @@ package edg_ide.psi_edits
 
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
-import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.{PsiElement, PsiWhiteSpace}
 import com.jetbrains.python.psi._
 import edg.util.Errorable
-import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptOption, ExceptSeq}
 import edg_ide.util.{DesignAnalysisUtils, PortConnects, exceptable}
 
-object LiveTemplateConnect {
+import scala.collection.mutable
+
+class ConnectInsertionLiveTemplate(
+    contextClass: PyClass,
+    startingConnect: PortConnects.Base,
+    newConnects: Seq[PortConnects.Base],
+    actionName: String,
+    continuation: (Option[String], PsiElement) => Unit
+) extends InsertionLiveTemplate(contextClass.getContainingFile) {
   protected val kTemplateVariableName = "name (optional)"
+
+  protected val project = contextClass.getProject
+  protected val languageLevel = LanguageLevel.forElement(contextClass)
+  protected val psiElementGenerator = PyElementGenerator.getInstance(project)
+  protected val allConnects = startingConnect +: newConnects
+
+  protected var createdPsiElts = mutable.ArrayBuffer[PsiElement]()
+  protected var newAssignStmt: Option[PyAssignmentStatement] = None // only if an assign was inserted
 
   // generate the reference Python HDL code for a PortConnect
   protected def connectedToRefCode(selfName: String, connect: PortConnects.Base): String = connect match {
@@ -43,171 +57,176 @@ object LiveTemplateConnect {
     case PortConnects.BoundaryPortVectorUnit(portName) => Some(portName)
   }
 
-  // Creates an action to start a live template to insert the connection
-  def createTemplateConnect(
-      contextClass: PyClass,
-      actionName: String,
-      project: Project,
-      startingConnect: PortConnects.Base,
-      newConnects: Seq[PortConnects.Base],
-      continuation: (Option[String], PsiElement) => Unit,
-  ): Errorable[MovableLiveTemplate] = exceptable {
-    val languageLevel = LanguageLevel.forElement(contextClass)
-    val psiElementGenerator = PyElementGenerator.getInstance(project)
-    val allConnects = startingConnect +: newConnects
+  // starts the live template insertion as a statement
+  protected def startStatementInsertionTemplate(
+      insertAfter: PsiElement
+  ): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])] = exceptable {
+    val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
+    val selfName = containingPsiFn.getParameterList.getParameters.toSeq
+      .head.getName
+    val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
 
-    val movableLiveTemplate = new MovableLiveTemplate(actionName) {
-      // starts the live template insertion as a statement
-      protected def startStatementInsertionTemplate(
-          insertAfter: PsiElement
-      ): InsertionLiveTemplate = {
-        val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
-        val selfName = containingPsiFn.getParameterList.getParameters.toSeq
-          .headOption.exceptNone(s"function ${containingPsiFn.getName} has no self")
-          .getName
-        val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
+    // TODO don't allow name when appending to a named connect (?)
+    val newConnectTemplate = psiElementGenerator.createFromText(
+      languageLevel,
+      classOf[PyAssignmentStatement],
+      s"$selfName.name = $selfName.connect()"
+    )
+    val newConnect =
+      containingStmtList.addAfter(newConnectTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
+    newAssignStmt = Some(newConnect)
+    createdPsiElts += newConnect
 
-        // TODO don't allow name when appending to a named connect (?)
-        val newConnectTemplate = psiElementGenerator.createFromText(
-          languageLevel,
-          classOf[PyAssignmentStatement],
-          s"$selfName.name = $selfName.connect()"
-        )
-        val newConnect =
-          containingStmtList.addAfter(newConnectTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
-        val newConnectArgs = newConnect.getAssignedValue
-          .asInstanceOf[PyCallExpression]
-          .getArgumentList
+    val newConnectArgs = newConnect.getAssignedValue
+      .asInstanceOf[PyCallExpression]
+      .getArgumentList
 
-        allConnects.foreach { newConnect =>
-          newConnectArgs.addArgument(psiElementGenerator.createExpressionFromText(
-            languageLevel,
-            connectedToRefCode(selfName, newConnect)
-          ))
+    allConnects.foreach { newConnect =>
+      newConnectArgs.addArgument(psiElementGenerator.createExpressionFromText(
+        languageLevel,
+        connectedToRefCode(selfName, newConnect)
+      ))
+    }
+
+    val nameTemplateVar = new InsertionLiveTemplate.Reference(
+      kTemplateVariableName,
+      newConnect.getTargets.head.asInstanceOf[PyTargetExpression],
+      defaultValue = Some("")
+    )
+
+    (newConnect, Seq(nameTemplateVar))
+  }
+
+  // if caretElt is in a PyCallExpression that is a connect involving any of the ports in this connection,
+  // return the InsertionLiveTemplate, otherwise None
+  protected def tryStartAppendTemplate(
+      caretElt: PsiElement,
+      earliestPosition: Option[PsiElement]
+  ): Option[(PsiElement, Seq[InsertionLiveTemplateVariable])] = {
+    val callCandidate = PsiTreeUtil.getParentOfType(caretElt, classOf[PyCallExpression])
+    if (callCandidate == null) return None
+
+    val containingPsiFn = PsiTreeUtil.getParentOfType(caretElt, classOf[PyFunction])
+    val selfName = containingPsiFn.getParameterList.getParameters.toSeq
+      .headOption.getOrElse(return None)
+      .getName
+    val connectReference = psiElementGenerator.createExpressionFromText(languageLevel, s"$selfName.connect")
+    if (!callCandidate.getCallee.textMatches(connectReference)) return None
+
+    val isAfterEarliest = earliestPosition.flatMap( // aka is in valid position
+      DesignAnalysisUtils.elementAfterEdg(_, callCandidate, project)).getOrElse(true)
+    if (!isAfterEarliest) return None
+
+    val matchingConnects = callCandidate.getArgumentList.getArguments.flatMap(arg =>
+      allConnects.flatMap { connect =>
+        if (arg.textMatches(connectedToRefCode(selfName, connect))) {
+          Some(connect)
+        } else {
+          None
         }
-
-        val nameTemplateVar = new InsertionLiveTemplate.Reference(
-          kTemplateVariableName,
-          newConnect.getTargets.head.asInstanceOf[PyTargetExpression],
-          defaultValue = Some("")
-        )
-
-//        new InsertionLiveTemplate(newConnect, IndexedSeq(nameTemplateVar))
-        ???
       }
+    )
+    if (matchingConnects.isEmpty) return None
 
-      // if caretElt is in a PyCallExpression that is a connect involving any of the ports in this connection,
-      // return the InsertionLiveTemplate, otherwise None
-      protected def tryStartStatementInsertionTemplate(
-          caretElt: PsiElement,
-          earliestPosition: Option[PsiElement]
-      ): Option[InsertionLiveTemplate] = {
-        val callCandidate = PsiTreeUtil.getParentOfType(caretElt, classOf[PyCallExpression])
-        if (callCandidate == null) return None
+    // validation complete, start the template
+    val connectsToAdd = allConnects.filter(!matchingConnects.contains(_))
+    connectsToAdd.foreach { newConnect =>
+      callCandidate.getArgumentList.addArgument(psiElementGenerator.createExpressionFromText(
+        languageLevel,
+        connectedToRefCode(selfName, newConnect)
+      ))
+    }
 
-        val containingPsiFn = PsiTreeUtil.getParentOfType(caretElt, classOf[PyFunction])
-        val selfName = containingPsiFn.getParameterList.getParameters.toSeq
-          .headOption.getOrElse(return None)
-          .getName
-        val connectReference = psiElementGenerator.createExpressionFromText(languageLevel, s"$selfName.connect")
-        if (!callCandidate.getCallee.textMatches(connectReference)) return None
+    Some((callCandidate, Seq()))
+  }
 
-        val isAfterEarliest = earliestPosition.flatMap( // aka is in valid position
-          DesignAnalysisUtils.elementAfterEdg(_, callCandidate, project)).getOrElse(true)
-        if (!isAfterEarliest) return None
+  override protected def buildTemplateAst(): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])] = {
+    // find earliest insertion position (after all refs are defined)
+    val allRequiredAttrs = allConnects.flatMap(connectedToRequiredAttr)
+    val earliestPosition = TemplateUtils.getLastAttributeAssignment(contextClass, allRequiredAttrs, project)
 
-        val matchingConnects = callCandidate.getArgumentList.getArguments.flatMap(arg =>
-          allConnects.flatMap { connect =>
-            if (arg.textMatches(connectedToRefCode(selfName, connect))) {
-              Some(connect)
-            } else {
-              None
-            }
-          }
-        )
-        if (matchingConnects.isEmpty) return None
+    val caretInsertAfterOpt = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
+      .flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
 
-        // validation complete, start the template
-        val connectsToAdd = allConnects.filter(!matchingConnects.contains(_))
-        connectsToAdd.foreach { newConnect =>
-          callCandidate.getArgumentList.addArgument(psiElementGenerator.createExpressionFromText(
-            languageLevel,
-            connectedToRefCode(selfName, newConnect)
-          ))
-        }
-
-//        Some(new InsertionLiveTemplate(callCandidate, IndexedSeq()))
-        ???
+    caretInsertAfterOpt.foreach { caretElt => // check if caret is in a connect
+      tryStartAppendTemplate(caretElt, earliestPosition).foreach { rtn =>
+        return Errorable.Success(rtn)
       }
+    } // otherwise continue to stmt insertion
 
-      // TODO startTemplate should be able to fail - Errorable
-      override def createTemplate(): InsertionLiveTemplate = {
-//        // find earliest insertion position (after all refs are defined)
-//        val allRequiredAttrs = allConnects.flatMap(connectedToRequiredAttr)
-//        val earliestPosition = TemplateUtils.getLastAttributeAssignment(contextClass, allRequiredAttrs, project)
-//
-//        // TODO live template insertion needs to support modifying AST nodes (instead of only addition)
-////        caretEltOpt.foreach { caretElt => // check if caret is in a connect
-////          tryStartStatementInsertionTemplate(caretElt, earliestPosition).foreach {
-////            return _
-////          }
-////        } // otherwise continue to stmt insertion
-//
-//        val validCaretEltOpt = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
-//        val preInsertAfter = validCaretEltOpt
-//          .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
-//
-//        // adjust insertion position to be after all assignments to required references
-//        val insertAfter = earliestPosition.map { earliestPosition =>
-//          if (!DesignAnalysisUtils.elementAfterEdg(preInsertAfter, earliestPosition, project).getOrElse(true)) {
-//            preInsertAfter
-//          } else {
-//            earliestPosition
-//          }
-//        }.getOrElse(preInsertAfter)
-//        startStatementInsertionTemplate(insertAfter)
-        ???
+    val insertAfter = caretInsertAfterOpt.getOrElse(InsertAction.findInsertionElements(
+      contextClass,
+      InsertBlockAction.VALID_FUNCTION_NAMES
+    ).head)
+
+    // adjust insertion position to be after all assignments to required references
+    val validInsertAfter = earliestPosition.map { earliestPosition =>
+      if (!DesignAnalysisUtils.elementAfterEdg(insertAfter, earliestPosition, project).getOrElse(true)) {
+        insertAfter
+      } else {
+        earliestPosition
+      }
+    }.getOrElse(insertAfter)
+
+    startStatementInsertionTemplate(validInsertAfter)
+  }
+
+  override def deleteTemplate(): Unit = {
+    createdPsiElts.foreach { createdPsiElt =>
+      createdPsiElt.delete()
+    }
+    createdPsiElts.clear()
+    newAssignStmt = None
+  }
+
+  override protected def cleanCompletedTemplate(state: TemplateState): Unit = {
+    super.cleanCompletedTemplate(state)
+
+    // getExpressionContextForSegment seems needed to update the PSI element, otherwise .getAssignedValue returns null
+    state.getExpressionContextForSegment(0).getPsiElementAtStartOffset
+
+    val nameOpt = Option(state.getVariableValue(kTemplateVariableName)).map(_.getText).filter(_.nonEmpty)
+    if (nameOpt.isEmpty && newAssignStmt.nonEmpty) { // if name not specified, make the connect anonymous
+      try {
+        val templateAssign = newAssignStmt.get
+        writeCommandAction(project)
+          .withName(s"clean $actionName")
+          .compute(() => {
+            templateAssign.replace(templateAssign.getAssignedValue)
+          })
+      } catch {
+        case _: Throwable => // ignore
       }
     }
 
-    movableLiveTemplate.addTemplateStateListener(new TemplateFinishedListener {
-      override def templateFinished(state: TemplateState, brokenOff: Boolean): Unit = {
-        val expr = state.getExpressionContextForSegment(0)
-        if (expr.getTemplateEndOffset <= expr.getTemplateStartOffset) {
-          return // ignored if template was deleted, including through moving the template
-        }
+    continuation(nameOpt, createdPsiElts.head)
+  }
 
-        val nameVar = Option(state.getVariableValue(kTemplateVariableName))
-        val insertedNameOpt = nameVar.map(_.getText).filter(_.nonEmpty)
-        if (insertedNameOpt.isEmpty && brokenOff) { // canceled by esc while name is empty
-          writeCommandAction(project)
-            .withName(s"cancel $actionName")
-            .compute(() => {
-              TemplateUtils.deleteTemplate(state)
-            })
-        } else { // commit
-          var templateElem = state.getExpressionContextForSegment(0).getPsiElementAtStartOffset
-          while (templateElem.isInstanceOf[PsiWhiteSpace]) { // ignore inserted whitespace before the statement
-            templateElem = templateElem.getNextSibling
-          }
+  override protected def cleanCanceledTemplate(state: TemplateState): Unit = {
+    super.cleanCanceledTemplate(state)
 
-          if (nameVar.nonEmpty && insertedNameOpt.isEmpty) { // if name not specified, make the connect anonymous
-            try {
-              val templateAssign = templateElem.asInstanceOf[PyAssignmentStatement]
-              writeCommandAction(project)
-                .withName(s"clean $actionName")
-                .compute(() => {
-                  templateElem.replace(templateAssign.getAssignedValue)
-                })
-            } catch {
-              case _: Throwable => // ignore
-            }
-          }
+    val nameOpt = Option(state.getVariableValue(kTemplateVariableName)).map(_.getText).filter(_.nonEmpty)
+    if (nameOpt.isEmpty) { // canceled by esc while name is empty
+      writeCommandAction(project).withName(s"cancel $actionName").compute(() => {
+        deleteTemplate()
+      })
+    }
+  }
+}
 
-          continuation(insertedNameOpt, templateElem)
-        }
+object LiveTemplateConnect {
+  // Creates an action to start a live template to insert the connection
+  def createTemplateConnect(
+      contextClass: PyClass,
+      startingConnect: PortConnects.Base,
+      newConnects: Seq[PortConnects.Base],
+      actionName: String,
+      continuation: (Option[String], PsiElement) => Unit,
+  ): MovableLiveTemplate = {
+    new MovableLiveTemplate(actionName) {
+      override def createTemplate(): InsertionLiveTemplate = {
+        new ConnectInsertionLiveTemplate(contextClass, startingConnect, newConnects, actionName, continuation)
       }
-    })
-    movableLiveTemplate
+    }
   }
 }

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -136,7 +136,7 @@ object LiveTemplateInsertBlock {
       continuation: (String, PsiElement) => Unit
   ): MovableLiveTemplate = {
     new MovableLiveTemplate(actionName) {
-      override def createTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
+      override def createTemplate(): InsertionLiveTemplate = {
         new BlockInsertionLiveTemplate(contextClass, libClass, actionName, continuation)
       }
     }

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -18,11 +18,11 @@ class BlockInsertionLiveTemplate(
 ) extends InsertionLiveTemplate(contextClass.getContainingFile) {
   private lazy val logger = Logger.getInstance(this.getClass)
 
-  val languageLevel = LanguageLevel.forElement(libClass)
-  val project = contextClass.getProject
-  val psiElementGenerator = PyElementGenerator.getInstance(project)
+  protected val languageLevel = LanguageLevel.forElement(libClass)
+  protected val project = contextClass.getProject
+  protected val psiElementGenerator = PyElementGenerator.getInstance(project)
 
-  var newAssignStmt: Option[PyAssignmentStatement] = None
+  protected var newAssignStmt: Option[PyAssignmentStatement] = None
 
   override protected def buildTemplateAst(): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])] = exceptable {
     val insertAfter = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
@@ -32,8 +32,7 @@ class BlockInsertionLiveTemplate(
     val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
     val selfName = containingPsiFn.getParameterList.getParameters.toSeq
       .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
-      .head
-      .getName
+      .head.getName
 
     val newAssignTemplate = psiElementGenerator.createFromText(
       languageLevel,
@@ -89,6 +88,7 @@ class BlockInsertionLiveTemplate(
 
   override def deleteTemplate(): Unit = {
     newAssignStmt.foreach(_.delete())
+    newAssignStmt = None
   }
 
   override protected def cleanCompletedTemplate(state: TemplateState): Unit = {

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -25,68 +25,68 @@ class BlockInsertionLiveTemplate(
 
   protected var newAssignStmt: Option[PyAssignmentStatement] = None
 
-  override protected def buildTemplateAst(editor: Editor): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])] =
-    exceptable {
-      val insertAfter = Option(contextClass.getContainingFile.findElementAt(editor.getCaretModel.getOffset))
-        .flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
-        .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
-      val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
-      val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
-      val selfName = containingPsiFn.getParameterList.getParameters.toSeq
-        .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
-        .head.getName
+  override protected def buildTemplateAst(editor: Editor)
+      : Errorable[(PsiElement, Seq[PsiElement], Seq[InsertionLiveTemplateVariable])] = exceptable {
+    val insertAfter = Option(contextClass.getContainingFile.findElementAt(editor.getCaretModel.getOffset))
+      .flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
+      .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
+    val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
+    val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
+    val selfName = containingPsiFn.getParameterList.getParameters.toSeq
+      .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
+      .head.getName
 
-      val newAssignTemplate = psiElementGenerator.createFromText(
-        languageLevel,
-        classOf[PyAssignmentStatement],
-        s"$selfName.name = $selfName.Block(${libClass.getName}())"
-      )
-      val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
+    val newAssignTemplate = psiElementGenerator.createFromText(
+      languageLevel,
+      classOf[PyAssignmentStatement],
+      s"$selfName.name = $selfName.Block(${libClass.getName}())"
+    )
+    val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
 
-      val newAssign =
-        containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
-      newAssignStmt = Some(newAssign)
+    val newAssign =
+      containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
+    newAssignStmt = Some(newAssign)
 
-      val newArgList = newAssign.getAssignedValue
-        .asInstanceOf[PyCallExpression]
-        .getArgument(0, classOf[PyCallExpression])
-        .getArgumentList
+    val newArgList = newAssign.getAssignedValue
+      .asInstanceOf[PyCallExpression]
+      .getArgument(0, classOf[PyCallExpression])
+      .getArgumentList
 
-      val initParams =
-        DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
-      val allParams = initParams._1 ++ initParams._2
+    val initParams =
+      DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
+    val allParams = initParams._1 ++ initParams._2
 
-      val nameTemplateVar = new InsertionLiveTemplate.Reference(
-        "name",
-        newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
-        InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
-        defaultValue = Some("")
-      )
+    val nameTemplateVar = new InsertionLiveTemplate.Reference(
+      "name",
+      newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
+      InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
+      defaultValue = Some("")
+    )
 
-      val argTemplateVars = allParams.map { initParam =>
-        val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
-          case Some(typed) => f": $typed"
-          case None => ""
-        })
+    val argTemplateVars = allParams.map { initParam =>
+      val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
+        case Some(typed) => f": $typed"
+        case None => ""
+      })
 
-        if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
-          newArgList.addArgument(psiElementGenerator.createEllipsis())
-          new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
-        } else { // optional argument
-          // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
-          newArgList.addArgument(
-            psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
-          )
-          new InsertionLiveTemplate.Variable(
-            f"$paramName (optional)",
-            newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
-            defaultValue = Some("")
-          )
-        }
+      if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
+        newArgList.addArgument(psiElementGenerator.createEllipsis())
+        new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
+      } else { // optional argument
+        // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
+        newArgList.addArgument(
+          psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
+        )
+        new InsertionLiveTemplate.Variable(
+          f"$paramName (optional)",
+          newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
+          defaultValue = Some("")
+        )
       }
-
-      (newAssign, nameTemplateVar +: argTemplateVars)
     }
+
+    (newAssign, Seq(), nameTemplateVar +: argTemplateVars)
+  }
 
   override def deleteTemplate(): Unit = {
     newAssignStmt.foreach(_.delete())

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -26,7 +26,7 @@ object LiveTemplateInsertBlock {
 
     val movableLiveTemplate = new MovableLiveTemplate(actionName) {
       // TODO startTemplate should be able to fail - Errorable
-      override def startTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
+      override def createTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
         val insertAfter = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
           .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
         val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -2,13 +2,89 @@ package edg_ide.psi_edits
 
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
-import com.intellij.openapi.project.Project
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.{PsiElement, PsiWhiteSpace}
 import com.jetbrains.python.psi._
 import edg.util.Errorable
 import edg_ide.util.ExceptionNotifyImplicits.ExceptSeq
 import edg_ide.util.{DesignAnalysisUtils, exceptable}
+
+class BlockInsertionLiveTemplate(contextClass: PyClass, libClass: PyClass)
+    extends InsertionLiveTemplate(contextClass.getContainingFile) {
+  val languageLevel = LanguageLevel.forElement(libClass)
+  val project = contextClass.getProject
+  val psiElementGenerator = PyElementGenerator.getInstance(project)
+
+  var newAssignStmt: Option[PsiElement] = None
+
+  override protected def buildTemplateAst(): Errorable[(PsiElement, IndexedSeq[InsertionLiveTemplateVariable])] =
+    exceptable {
+      val caretEltOpt = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
+      val insertAfter = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
+        .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
+      val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
+      val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
+      val selfName = containingPsiFn.getParameterList.getParameters.toSeq
+        .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
+        .head
+        .getName
+
+      val newAssignTemplate = psiElementGenerator.createFromText(
+        languageLevel,
+        classOf[PyAssignmentStatement],
+        s"$selfName.name = $selfName.Block(${libClass.getName}())"
+      )
+      val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
+
+      val newAssign =
+        containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
+      newAssignStmt = Some(newAssign)
+
+      val newArgList = newAssign.getAssignedValue
+        .asInstanceOf[PyCallExpression]
+        .getArgument(0, classOf[PyCallExpression])
+        .getArgumentList
+
+      val initParams =
+        DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
+      val allParams = initParams._1 ++ initParams._2
+
+      val nameTemplateVar = new InsertionLiveTemplate.Reference(
+        "name",
+        newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
+        InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
+        defaultValue = Some("")
+      )
+
+      val argTemplateVars = allParams.map { initParam =>
+        val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
+          case Some(typed) => f": $typed"
+          case None => ""
+        })
+
+        if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
+          newArgList.addArgument(psiElementGenerator.createEllipsis())
+          new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
+        } else { // optional argument
+          // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
+          newArgList.addArgument(
+            psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
+          )
+          new InsertionLiveTemplate.Variable(
+            f"$paramName (optional)",
+            newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
+            defaultValue = Some("")
+          )
+        }
+      }
+
+      (newAssign, IndexedSeq(nameTemplateVar) ++ argTemplateVars)
+    }
+
+  override def deleteTemplate(): Unit = {
+    newAssignStmt.foreach(_.delete())
+  }
+}
 
 object LiveTemplateInsertBlock {
 
@@ -18,72 +94,13 @@ object LiveTemplateInsertBlock {
       contextClass: PyClass,
       libClass: PyClass,
       actionName: String,
-      project: Project,
       continuation: (String, PsiElement) => Unit
   ): Errorable[MovableLiveTemplate] = exceptable {
-    val languageLevel = LanguageLevel.forElement(libClass)
-    val psiElementGenerator = PyElementGenerator.getInstance(project)
+    val project = contextClass.getProject
 
     val movableLiveTemplate = new MovableLiveTemplate(actionName) {
-      // TODO startTemplate should be able to fail - Errorable
       override def createTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
-        val insertAfter = caretEltOpt.flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
-          .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
-        val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
-        val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
-        val selfName = containingPsiFn.getParameterList.getParameters.toSeq
-          .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
-          .head
-          .getName
-
-        val newAssignTemplate = psiElementGenerator.createFromText(
-          languageLevel,
-          classOf[PyAssignmentStatement],
-          s"$selfName.name = $selfName.Block(${libClass.getName}())"
-        )
-        val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
-
-        val newAssign =
-          containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
-        val newArgList = newAssign.getAssignedValue
-          .asInstanceOf[PyCallExpression]
-          .getArgument(0, classOf[PyCallExpression])
-          .getArgumentList
-
-        val initParams =
-          DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
-        val allParams = initParams._1 ++ initParams._2
-
-        val nameTemplateVar = new InsertionLiveTemplate.Reference(
-          "name",
-          newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
-          InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
-          defaultValue = Some("")
-        )
-
-        val argTemplateVars = allParams.map { initParam =>
-          val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
-            case Some(typed) => f": $typed"
-            case None => ""
-          })
-
-          if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
-            newArgList.addArgument(psiElementGenerator.createEllipsis())
-            new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
-          } else { // optional argument
-            // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
-            newArgList.addArgument(
-              psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
-            )
-            new InsertionLiveTemplate.Variable(
-              f"$paramName (optional)",
-              newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
-              defaultValue = Some("")
-            )
-          }
-        }
-
-        new InsertionLiveTemplate(newAssign, IndexedSeq(nameTemplateVar) ++ argTemplateVars)
+        new BlockInsertionLiveTemplate(contextClass, libClass)
       }
     }
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -3,8 +3,8 @@ package edg_ide.psi_edits
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.{PsiElement, PsiFile, PsiWhiteSpace}
 import com.jetbrains.python.psi._
 import edg.util.Errorable
 import edg_ide.util.ExceptionNotifyImplicits.ExceptSeq

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -2,20 +2,27 @@ package edg_ide.psi_edits
 
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.{PsiElement, PsiWhiteSpace}
+import com.intellij.psi.{PsiElement, PsiFile, PsiWhiteSpace}
 import com.jetbrains.python.psi._
 import edg.util.Errorable
 import edg_ide.util.ExceptionNotifyImplicits.ExceptSeq
 import edg_ide.util.{DesignAnalysisUtils, exceptable}
 
-class BlockInsertionLiveTemplate(contextClass: PyClass, libClass: PyClass)
-    extends InsertionLiveTemplate(contextClass.getContainingFile) {
+class BlockInsertionLiveTemplate(
+    contextClass: PyClass,
+    libClass: PyClass,
+    actionName: String,
+    continuation: (String, PsiElement) => Unit
+) extends InsertionLiveTemplate(contextClass.getContainingFile) {
+  private lazy val logger = Logger.getInstance(this.getClass)
+
   val languageLevel = LanguageLevel.forElement(libClass)
   val project = contextClass.getProject
   val psiElementGenerator = PyElementGenerator.getInstance(project)
 
-  var newAssignStmt: Option[PsiElement] = None
+  var newAssignStmt: Option[PyAssignmentStatement] = None
 
   override protected def buildTemplateAst(): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])] = exceptable {
     val insertAfter = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
@@ -83,6 +90,39 @@ class BlockInsertionLiveTemplate(contextClass: PyClass, libClass: PyClass)
   override def deleteTemplate(): Unit = {
     newAssignStmt.foreach(_.delete())
   }
+
+  override protected def cleanCompletedTemplate(state: TemplateState): Unit = {
+    super.cleanCompletedTemplate(state)
+
+    // getExpressionContextForSegment seems needed to update the PSI element, otherwise .getAssignedValue returns null
+    state.getExpressionContextForSegment(0).getPsiElementAtStartOffset
+    try {
+      writeCommandAction(project).withName(s"clean $actionName").compute(() => {
+        val args = newAssignStmt.get
+          .getAssignedValue.asInstanceOf[PyCallExpression] // the self.Block(...) call
+          .getArgument(0, classOf[PyCallExpression]) // the object instantiation
+          .getArgumentList // args to the object instantiation
+        val deleteArgs = args.getArguments.flatMap { // remove empty kwargs
+          case arg: PyKeywordArgument if arg.getValueExpression == null => Some(arg)
+          case _ => None // ignored
+        }
+        deleteArgs.foreach(_.delete())
+      })
+    } catch {
+      case exc: Throwable => logger.error("error while completing template", exc)
+    }
+    continuation(state.getVariableValue("name").getText, newAssignStmt.get)
+  }
+
+  override protected def cleanCanceledTemplate(state: TemplateState): Unit = {
+    super.cleanCanceledTemplate(state)
+
+    if (state.getVariableValue("name").getText.isEmpty) { // canceled by esc while name is empty
+      writeCommandAction(project).withName(s"cancel $actionName").compute(() => {
+        deleteTemplate()
+      })
+    }
+  }
 }
 
 object LiveTemplateInsertBlock {
@@ -94,58 +134,11 @@ object LiveTemplateInsertBlock {
       libClass: PyClass,
       actionName: String,
       continuation: (String, PsiElement) => Unit
-  ): Errorable[MovableLiveTemplate] = exceptable {
-    val project = contextClass.getProject
-
-    val movableLiveTemplate = new MovableLiveTemplate(actionName) {
+  ): MovableLiveTemplate = {
+    new MovableLiveTemplate(actionName) {
       override def createTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate = {
-        new BlockInsertionLiveTemplate(contextClass, libClass)
+        new BlockInsertionLiveTemplate(contextClass, libClass, actionName, continuation)
       }
     }
-
-    movableLiveTemplate.addTemplateStateListener(new TemplateFinishedListener {
-      override def templateFinished(state: TemplateState, brokenOff: Boolean): Unit = {
-        val expr = state.getExpressionContextForSegment(0)
-        if (expr.getTemplateEndOffset <= expr.getTemplateStartOffset) {
-          return // ignored if template was deleted, including through moving the template
-        }
-
-        val insertedName = state.getVariableValue("name").getText
-        if (insertedName.isEmpty && brokenOff) { // canceled by esc while name is empty
-          writeCommandAction(project)
-            .withName(s"cancel $actionName")
-            .compute(() => {
-              TemplateUtils.deleteTemplate(state)
-            })
-        } else {
-          var templateElem = state.getExpressionContextForSegment(0).getPsiElementAtStartOffset
-          while (templateElem.isInstanceOf[PsiWhiteSpace]) { // ignore inserted whitespace before the statement
-            templateElem = templateElem.getNextSibling
-          }
-          try {
-            val args = templateElem
-              .asInstanceOf[PyAssignmentStatement]
-              .getAssignedValue
-              .asInstanceOf[PyCallExpression] // the self.Block(...) call
-              .getArgument(0, classOf[PyCallExpression]) // the object instantiation
-              .getArgumentList // args to the object instantiation
-            val deleteArgs = args.getArguments.flatMap { // remove empty kwargs
-              case arg: PyKeywordArgument => if (arg.getValueExpression == null) Some(arg) else None
-              case _ => None // ignored
-            }
-            writeCommandAction(project)
-              .withName(s"clean $actionName")
-              .compute(() => {
-                deleteArgs.foreach(_.delete())
-              })
-          } catch {
-            case _: Throwable => // ignore
-          }
-          continuation(insertedName, templateElem)
-        }
-      }
-    })
-
-    movableLiveTemplate
   }
 }

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -31,7 +31,6 @@ class BlockInsertionLiveTemplate(
       .flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
       .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
     val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
-    val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
     val selfName = containingPsiFn.getParameterList.getParameters.toSeq
       .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
       .head.getName
@@ -59,7 +58,7 @@ class BlockInsertionLiveTemplate(
     val nameTemplateVar = new InsertionLiveTemplate.Reference(
       "name",
       newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
-      InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
+      InsertionLiveTemplate.validatePythonName(_, _, Some(contextClass)),
       defaultValue = Some("")
     )
 

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -3,6 +3,7 @@ package edg_ide.psi_edits
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.python.psi._
@@ -24,67 +25,68 @@ class BlockInsertionLiveTemplate(
 
   protected var newAssignStmt: Option[PyAssignmentStatement] = None
 
-  override protected def buildTemplateAst(): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])] = exceptable {
-    val insertAfter = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
-      .flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
-      .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
-    val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
-    val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
-    val selfName = containingPsiFn.getParameterList.getParameters.toSeq
-      .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
-      .head.getName
+  override protected def buildTemplateAst(editor: Editor): Errorable[(PsiElement, Seq[InsertionLiveTemplateVariable])] =
+    exceptable {
+      val insertAfter = Option(contextClass.getContainingFile.findElementAt(editor.getCaretModel.getOffset))
+        .flatMap(TemplateUtils.getInsertionStmt(_, contextClass))
+        .getOrElse(InsertAction.findInsertionElements(contextClass, InsertBlockAction.VALID_FUNCTION_NAMES).head)
+      val containingPsiFn = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyFunction])
+      val containingPsiClass = PsiTreeUtil.getParentOfType(containingPsiFn, classOf[PyClass])
+      val selfName = containingPsiFn.getParameterList.getParameters.toSeq
+        .exceptEmpty(s"function ${containingPsiFn.getName} has no self")
+        .head.getName
 
-    val newAssignTemplate = psiElementGenerator.createFromText(
-      languageLevel,
-      classOf[PyAssignmentStatement],
-      s"$selfName.name = $selfName.Block(${libClass.getName}())"
-    )
-    val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
+      val newAssignTemplate = psiElementGenerator.createFromText(
+        languageLevel,
+        classOf[PyAssignmentStatement],
+        s"$selfName.name = $selfName.Block(${libClass.getName}())"
+      )
+      val containingStmtList = PsiTreeUtil.getParentOfType(insertAfter, classOf[PyStatementList])
 
-    val newAssign =
-      containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
-    newAssignStmt = Some(newAssign)
+      val newAssign =
+        containingStmtList.addAfter(newAssignTemplate, insertAfter).asInstanceOf[PyAssignmentStatement]
+      newAssignStmt = Some(newAssign)
 
-    val newArgList = newAssign.getAssignedValue
-      .asInstanceOf[PyCallExpression]
-      .getArgument(0, classOf[PyCallExpression])
-      .getArgumentList
+      val newArgList = newAssign.getAssignedValue
+        .asInstanceOf[PyCallExpression]
+        .getArgument(0, classOf[PyCallExpression])
+        .getArgumentList
 
-    val initParams =
-      DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
-    val allParams = initParams._1 ++ initParams._2
+      val initParams =
+        DesignAnalysisUtils.initParamsOf(libClass, project).toOption.getOrElse((Seq(), Seq()))
+      val allParams = initParams._1 ++ initParams._2
 
-    val nameTemplateVar = new InsertionLiveTemplate.Reference(
-      "name",
-      newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
-      InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
-      defaultValue = Some("")
-    )
+      val nameTemplateVar = new InsertionLiveTemplate.Reference(
+        "name",
+        newAssign.getTargets.head.asInstanceOf[PyTargetExpression],
+        InsertionLiveTemplate.validatePythonName(_, _, Some(containingPsiClass)),
+        defaultValue = Some("")
+      )
 
-    val argTemplateVars = allParams.map { initParam =>
-      val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
-        case Some(typed) => f": $typed"
-        case None => ""
-      })
+      val argTemplateVars = allParams.map { initParam =>
+        val paramName = initParam.getName() + (Option(initParam.getAnnotationValue) match {
+          case Some(typed) => f": $typed"
+          case None => ""
+        })
 
-      if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
-        newArgList.addArgument(psiElementGenerator.createEllipsis())
-        new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
-      } else { // optional argument
-        // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
-        newArgList.addArgument(
-          psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
-        )
-        new InsertionLiveTemplate.Variable(
-          f"$paramName (optional)",
-          newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
-          defaultValue = Some("")
-        )
+        if (initParam.getDefaultValue == null) { // required argument, needs ellipsis
+          newArgList.addArgument(psiElementGenerator.createEllipsis())
+          new InsertionLiveTemplate.Variable(paramName, newArgList.getArguments.last)
+        } else { // optional argument
+          // ellipsis is generated in the AST to give the thing a handle, the template replaces it with an empty
+          newArgList.addArgument(
+            psiElementGenerator.createKeywordArgument(languageLevel, initParam.getName, "...")
+          )
+          new InsertionLiveTemplate.Variable(
+            f"$paramName (optional)",
+            newArgList.getArguments.last.asInstanceOf[PyKeywordArgument].getValueExpression,
+            defaultValue = Some("")
+          )
+        }
       }
-    }
 
-    (newAssign, nameTemplateVar +: argTemplateVars)
-  }
+      (newAssign, nameTemplateVar +: argTemplateVars)
+    }
 
   override def deleteTemplate(): Unit = {
     newAssignStmt.foreach(_.delete())

--- a/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
+++ b/src/main/scala/edg_ide/psi_edits/LiveTemplateInsertBlock.scala
@@ -20,7 +20,7 @@ object LiveTemplateInsertBlock {
       actionName: String,
       project: Project,
       continuation: (String, PsiElement) => Unit
-  ): Errorable[() => Unit] = exceptable {
+  ): Errorable[MovableLiveTemplate] = exceptable {
     val languageLevel = LanguageLevel.forElement(libClass)
     val psiElementGenerator = PyElementGenerator.getInstance(project)
 
@@ -130,16 +130,6 @@ object LiveTemplateInsertBlock {
       }
     })
 
-    val caretElt = InsertAction.getCaretForNewClassStatement(contextClass, project).toOption
-
-    def insertBlockFlow: Unit = {
-      writeCommandAction(project)
-        .withName(s"$actionName")
-        .compute(() => {
-          movableLiveTemplate.run(caretElt)
-        })
-    }
-
-    () => insertBlockFlow
+    movableLiveTemplate
   }
 }

--- a/src/main/scala/edg_ide/psi_edits/MovableLiveTemplate.scala
+++ b/src/main/scala/edg_ide/psi_edits/MovableLiveTemplate.scala
@@ -25,7 +25,7 @@ abstract class MovableLiveTemplate(actionName: String) {
   // inserts the new element for this template and returns the inserted element
   // this is run in the same writeCommandAction as the template creation
   // implement me
-  def createTemplate(caretEltOpt: Option[PsiElement], priorVariableValues: Map[String, String]): InsertionLiveTemplate
+  def createTemplate(caretEltOpt: Option[PsiElement]): InsertionLiveTemplate
 
   class MovingMouseListener(templateState: TemplateState) extends EditorMouseListener {
     override def mouseClicked(event: EditorMouseEvent): Unit = {
@@ -83,7 +83,7 @@ abstract class MovableLiveTemplate(actionName: String) {
   ): Errorable[TemplateState] = exceptable {
     // on error, this fails without updating state variables, as if it wasn't started
     val priorTemplateValues = priorTemplatePosValues.map(_._2).getOrElse(Map())
-    val templateState = createTemplate(caretEltOpt, priorTemplateValues).run().exceptError
+    val templateState = createTemplate(caretEltOpt).run(kHelpTooltip, priorTemplateValues).exceptError
     currentTemplateState = Some(templateState)
     templateStateListeners.foreach(templateState.addTemplateStateListener(_))
     priorTemplatePosValues.foreach { case (templatePrev, _) => // advance to the previous variable position

--- a/src/main/scala/edg_ide/psi_edits/TemplateUtils.scala
+++ b/src/main/scala/edg_ide/psi_edits/TemplateUtils.scala
@@ -12,35 +12,6 @@ import edg_ide.util.{DesignAnalysisUtils, requireExcept}
 import scala.collection.mutable
 
 object TemplateUtils {
-  // deletes the template text, ending the template
-  // must be run within a writeCommandAction
-  def deleteTemplate(templateState: TemplateState): Unit = {
-    val templateExpression = templateState.getExpressionContextForSegment(0)
-    val templateEndOffset = templateExpression.getTemplateEndOffset
-    var templateElem = templateExpression.getPsiElementAtStartOffset
-
-    // separate the traversal from deletion, so the end offsets are stable as we build the deletion list
-    val deleteElems = mutable.ListBuffer[PsiElement]()
-    while (templateElem != null && templateElem.getTextOffset <= templateEndOffset) {
-      if (templateElem.getTextRange.getStartOffset < templateExpression.getTemplateStartOffset) {
-        // getPsiElementAtStartOffset may return a non-contained element if the template is empty
-        templateElem = templateElem.getNextSibling
-      } else if (templateElem.getTextRange.getEndOffset <= templateExpression.getTemplateEndOffset) {
-        deleteElems.append(templateElem)
-        templateElem = templateElem.getNextSibling
-      } else { // otherwise recurse into element to get a partial range
-        templateElem = templateElem.getFirstChild
-      }
-    }
-
-    deleteElems.foreach { deleteElem =>
-      if (deleteElem.isValid) { // guard in case the element changed from a prior deletion
-        deleteElem.delete()
-      }
-    }
-    templateState.update() // update to end the template
-  }
-
   // given some caret position, returns the top-level statement if it's valid for statement insertion
   def getInsertionStmt(caretElt: PsiElement, requiredContextClass: PyClass): Option[PyStatement] = {
     val caretStatement = InsertAction.snapInsertionEltOfType[PyStatement](caretElt).get

--- a/src/main/scala/edg_ide/swing/EdgirLibraryTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/EdgirLibraryTreeTableModel.scala
@@ -119,15 +119,9 @@ class EdgirLibraryNode(project: Project, library: edg.wir.Library) extends Edgir
         .map { childPath => new BlockNode(childPath, library.allBlocks(childPath), this) }
         .toSeq
         .sortWith { case (a, b) =>
-          if (
-            a.path == EdgirLibraryTreeTableModel.kInternalBlockPath &&
-            b.path != EdgirLibraryTreeTableModel.kInternalBlockPath
-          ) {
+          if (EdgirUtils.isInternal(a.path) && !EdgirUtils.isInternal(b.path)) {
             false
-          } else if (
-            a.path != EdgirLibraryTreeTableModel.kInternalBlockPath &&
-            b.path == EdgirLibraryTreeTableModel.kInternalBlockPath
-          ) {
+          } else if (!EdgirUtils.isInternal(a.path) && EdgirUtils.isInternal(b.path)) {
             true
           } else {
             a.toString < b.toString
@@ -171,10 +165,6 @@ class EdgirLibraryNode(project: Project, library: edg.wir.Library) extends Edgir
       library.allLinks.map { case (path, _) => new LinkNode(path) }
     }.toSeq.sortBy { _.toString }
   }
-}
-
-object EdgirLibraryTreeTableModel {
-  val kInternalBlockPath = LibraryPath("edg_core.Categories.InternalBlock")
 }
 
 class EdgirLibraryTreeTableModel(project: Project, library: edg.wir.Library)

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -117,7 +117,6 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
           contextPyClass.exceptError,
           blockPyClass.exceptError,
           s"Insert $blockTypeName",
-          project,
           insertContinuation
         ).exceptError
 

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -113,19 +113,14 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
   val (insertAction, insertItem) = if (EdgSettingsState.getInstance().useInsertionLiveTemplates) {
     val insertAction: Errorable[() => Unit] = exceptable {
       EdgirUtils.isCategory(blockType).exceptTrue("can't insert category")
-
-      val movableLiveTemplate = LiveTemplateInsertBlock
-        .createTemplateBlock(
-          contextPyClass.exceptError,
-          blockPyClass.exceptError,
-          s"Insert $blockTypeName",
-          insertContinuation
-        )
-
       () =>
-        movableLiveTemplate.start(
-          project
-        ).exceptError
+        LiveTemplateInsertBlock
+          .createTemplateBlock(
+            contextPyClass.exceptError,
+            blockPyClass.exceptError,
+            s"Insert $blockTypeName",
+            insertContinuation
+          ).start(project).exceptError
     }
     val insertItem = ContextMenuUtils.MenuItemFromErrorable(insertAction, s"Insert into $contextPyName")
     (insertAction, insertItem)

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -20,7 +20,7 @@ import edg_ide.edgir_graph._
 import edg_ide.psi_edits._
 import edg_ide.swing._
 import edg_ide.swing.blocks.JBlockDiagramVisualizer
-import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption}
+import edg_ide.util.ExceptionNotifyImplicits.{ExceptBoolean, ExceptErrorable, ExceptNotify, ExceptOption}
 import edg_ide.util._
 import edg_ide.{EdgirUtils, PsiUtils}
 import edgir.elem.elem
@@ -112,6 +112,8 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
 
   val (insertAction, insertItem) = if (EdgSettingsState.getInstance().useInsertionLiveTemplates) {
     val insertAction: Errorable[() => Unit] = exceptable {
+      EdgirUtils.isCategory(blockType).exceptTrue("can't insert category")
+
       val movableLiveTemplate = LiveTemplateInsertBlock
         .createTemplateBlock(
           contextPyClass.exceptError,
@@ -664,8 +666,8 @@ class LibraryPanel(project: Project) extends JPanel {
         case other => false
       }.filter { path =>
         !path.getPath.exists {
-          case node: EdgirLibraryNode#BlockNode
-            if node.path == EdgirLibraryTreeTableModel.kInternalBlockPath => true // don't expand InternalBlock
+          case node: EdgirLibraryNode#BlockNode if EdgirUtils.isInternal(node.path) =>
+            true // don't expand InternalBlock
           case _ => false
         }
       }

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -112,15 +112,20 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
 
   val (insertAction, insertItem) = if (EdgSettingsState.getInstance().useInsertionLiveTemplates) {
     val insertAction: Errorable[() => Unit] = exceptable {
-      LiveTemplateInsertBlock
+      val movableLiveTemplate = LiveTemplateInsertBlock
         .createTemplateBlock(
           contextPyClass.exceptError,
           blockPyClass.exceptError,
           s"Insert $blockTypeName",
           project,
           insertContinuation
-        )
-        .exceptError
+        ).exceptError
+
+      () =>
+        movableLiveTemplate.start(
+          project,
+          InsertAction.getCaretForNewClassStatement(contextPyClass.exceptError, project).toOption
+        ).exceptError
     }
     val insertItem = ContextMenuUtils.MenuItemFromErrorable(insertAction, s"Insert into $contextPyName")
     (insertAction, insertItem)

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -118,7 +118,7 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
           blockPyClass.exceptError,
           s"Insert $blockTypeName",
           insertContinuation
-        ).exceptError
+        )
 
       () =>
         movableLiveTemplate.start(

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -122,8 +122,7 @@ class LibraryBlockPopupMenu(blockType: ref.LibraryPath, project: Project) extend
 
       () =>
         movableLiveTemplate.start(
-          project,
-          InsertAction.getCaretForNewClassStatement(contextPyClass.exceptError, project).toOption
+          project
         ).exceptError
     }
     val insertItem = ContextMenuUtils.MenuItemFromErrorable(insertAction, s"Insert into $contextPyName")

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -205,14 +205,12 @@ class NewConnectTool(
           }
 
           exceptionPopup.atMouse(component) {
-            val movableLiveTemplate = LiveTemplateConnect.createTemplateConnect(
+            LiveTemplateConnect.createTemplateConnect(
               containerPyClass,
               startingPort.connect +: newConnects.map(_.connect),
               getCurrentName(),
               continuation
-            )
-
-            movableLiveTemplate.start(interface.getProject).exceptError
+            ).start(interface.getProject).exceptError
           }
         case _ =>
           if (connectedBlockOpt.isEmpty) {

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -227,8 +227,7 @@ class NewConnectTool(
               continuation
             ).exceptError
 
-            val caretElt = InsertAction.getCaretForNewClassStatement(containerPyClass, interface.getProject).toOption
-            movableLiveTemplate.start(interface.getProject, caretElt).exceptError
+            movableLiveTemplate.start(interface.getProject).exceptError
           }
         case _ =>
           if (connectedBlockOpt.isEmpty) {

--- a/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/NewConnectTool.scala
@@ -220,12 +220,11 @@ class NewConnectTool(
           exceptionPopup.atMouse(component) {
             val movableLiveTemplate = LiveTemplateConnect.createTemplateConnect(
               containerPyClass,
-              getCurrentName(),
-              interface.getProject,
               startingPort.connect,
               newConnects.map(_.connect),
+              getCurrentName(),
               continuation
-            ).exceptError
+            )
 
             movableLiveTemplate.start(interface.getProject).exceptError
           }

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -27,6 +27,7 @@ object PortConnects { // types of connections a port attached to a connection ca
   sealed trait AmbiguousBase extends Base // base type for any connection which can be port- or vector-valued
 
   protected def typeOfSinglePort(portLike: elem.PortLike): Option[ref.LibraryPath] = portLike.is match {
+    case elem.PortLike.Is.LibElem(lib) => Some(lib)
     case elem.PortLike.Is.Port(port) => port.selfClass
     case elem.PortLike.Is.Bundle(port) => port.selfClass
     case _ => None


### PR DESCRIPTION
Major refactoring for insertion live template infrastructure:
- `InsertionLiveTemplate` now manages the entire template lifecycle, from AST creation (which the user must subclass and implement), deletion (to support a larger variety of AST changes), and optional clean-on-completion or cancelation hooks
  - Refactor AST creation code into these
  - Eliminate the prior hack-tastic deleteTemplate - up to the InsertionLiveTemplate subclass to store the AST nodes to delete, no longer inferred by infrastructure
- The API now takes a container, optionally specific elements for the template (e.g. if only adding to an argument list), and variables (compared to only container before, where the change had to be a unitary PsiElement)
- Prevent multiple templates from starting, InsertionLiveTemplate.run returns Errorable
- Better selection of insertion position at caret, in particular works better when selecting comments (prior, it required inserting at a statement)
- When cleaning fails, log errors to the console
- MovableLiveTemplate: store variable values by name when moving, and store position by name - allows robustness when the template variables change as they are moved
- MovableLiveTemplate: explicitly finish the template before starting a new one, instead of relying on .update()

Improve block diagram visualization robustness:
- Support ALLOCATE in parsing constraints: instead of matching Ref.unapply, take the first two steps and getName on them
- Support new names for link ports (controller, targets) in infer edge direction
- Better support for longer prefixes in block diagram transforms

Connection Live Template:
- ConnectBuilder: support LibElem, since the new fast path won't build out all the ports
- Connect execution (connect live template, IR transform) now takes in the aggregate list of connected ports, and figures out what to do with them
  - Not distinguishing a starting port makes sense, since the starting port may be the one being appended to a link


Other refactoring:
- Define isInternal in EdgirUtils and refactor to use this function, to determine when to deprioritize (for UI purposes) items
- Prevent insertion of categories (insertion live template only)
