### PR TITLE
Hide unrelated ideal model errors when not sweeping those parts

### DIFF
--- a/src/main/scala/edg_ide/dse/DseResult.scala
+++ b/src/main/scala/edg_ide/dse/DseResult.scala
@@ -14,7 +14,7 @@ case class DseResult(
     searchRefinements: Refinements,
     compiler: Compiler,
     compiled: Design,
-    errors: Seq[CompilerError],
+    errors: Seq[CompilerError], // excluding unrelated ideal errors
     objectives: SeqMap[DseObjective, Any],
     compileTime: Long
 ) {

--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -10,6 +10,7 @@ import edg.compiler._
 import edg.util.{StreamUtils, timeExec}
 import edg.wir.Refinements
 import edg_ide.dse.{DseConfigElement, DseObjective, DseResult, DseSearchGenerator}
+import edg_ide.swing.dse.DseResultModel
 import edg_ide.ui.{BlockVisualizerService, DseService, EdgCompilerService}
 import edgir.schema.schema
 import edgir.schema.schema.Design
@@ -265,7 +266,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
                   searchRefinements,
                   compiler,
                   compiled,
-                  errors,
+                  DseResultModel.filterUnrelatedIdeal(errors, options.searchConfigs),
                   objectiveValues,
                   compileTime
                 )

--- a/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
+++ b/src/main/scala/edg_ide/swing/dse/DseResultTreeTableModel.scala
@@ -3,7 +3,7 @@ package edg_ide.swing.dse
 import com.intellij.ui.JBColor
 import com.intellij.ui.treeStructure.treetable.TreeTableModel
 import edg.compiler.CompilerError
-import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseResult}
+import edg_ide.dse.{CombinedDseResultSet, DseConfigElement, DseObjective, DseResult, DseSubclassSearch}
 import edg_ide.swing.SeqTreeTableModel
 
 import java.awt.{Color, Component}
@@ -155,6 +155,18 @@ object DseResultModel {
       case CompilerError.FailedAssertion(_, constrName, _, _, _) if constrName == kIdealConstraintName => true
       case _ => false
     }
+
+  // Filters the error set and removes ideal errors that are unrelated to the current search
+  def filterUnrelatedIdeal(errors: Seq[CompilerError], configs: Seq[DseConfigElement]): Seq[CompilerError] = {
+    val subclassSearchPaths = configs.collect {
+      case DseSubclassSearch(path, _) => path
+    }
+    errors.filter {
+      case CompilerError.FailedAssertion(path, constrName, _, _, _)
+        if constrName == kIdealConstraintName && !subclassSearchPaths.contains(path) => false
+      case _ => true
+    }
+  }
 }
 
 class DseResultTreeRenderer extends DefaultTreeCellRenderer {


### PR DESCRIPTION
Self-explanatory, ideal parts only show in yellow now when those parts are being swept over.

Also updates the base HDL to not scan unnecessary MCUs.