### PR TITLE
Wire colors for voltage lines

### DIFF
--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -198,6 +198,7 @@ object ElkEdgirGraphUtils {
             case elem.LinkLike.Type.Link(link) => link.selfClass
             case elem.LinkLike.Type.LibElem(lib) => Some(lib)
             case elem.LinkLike.Type.Array(link) => link.selfClass
+            case _ => None
           }
         case _ => None
       }

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -453,7 +453,8 @@ class CompileProcessHandler(
               mappers = Seq(
                 new ElkEdgirGraphUtils.TitleMapper(compiler),
                 ElkEdgirGraphUtils.DesignPathMapper,
-                ElkEdgirGraphUtils.PortArrayMapper
+                ElkEdgirGraphUtils.PortArrayMapper,
+                new ElkEdgirGraphUtils.WireColorMapper(compiler),
               ),
               options.pdfFile
             )

--- a/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
@@ -1,7 +1,6 @@
 package edg_ide.swing.blocks
 
 import edg_ide.swing.ColorUtil
-import edg_ide.swing.blocks.ElkNodeUtil.edgeSectionPairs
 import org.eclipse.elk.core.options._
 import org.eclipse.elk.graph._
 
@@ -163,9 +162,8 @@ class ElkNodePainter(
     val thisG = modifierG(getFixedEdgeBaseG(parentG, blockG, edge))
 
     edge.getSections.asScala.foreach { section =>
-      edgeSectionPairs(section).foreach { case (line1, line2) =>
-        thisG.drawLine(line1._1.toInt, line1._2.toInt, line2._1.toInt, line2._2.toInt)
-      }
+      val (pointsX, pointsY) = ElkNodeUtil.allPoints(section).unzip
+      thisG.drawPolyline(pointsX.map(_.toInt).toArray, pointsY.map(_.toInt).toArray, pointsX.length)
     }
   }
 

--- a/src/main/scala/edg_ide/swing/blocks/ElkNodeUtil.scala
+++ b/src/main/scala/edg_ide/swing/blocks/ElkNodeUtil.scala
@@ -6,19 +6,10 @@ import scala.jdk.CollectionConverters.ListHasAsScala
 
 object ElkNodeUtil {
   // Utility functions
-  def edgeSectionPairs[T](section: ElkEdgeSection): Seq[((Double, Double), (Double, Double))] = {
+  def allPoints(section: ElkEdgeSection): Seq[(Double, Double)] = {
+    val bendPoints = section.getBendPoints.asScala.map { bend => (bend.getX, bend.getY) }
     val start = (section.getStartX, section.getStartY)
     val end = (section.getEndX, section.getEndY)
-    val bends = section.getBendPoints.asScala.map { elkBendPoint =>
-      (elkBendPoint.getX, elkBendPoint.getY)
-    }
-    val allPoints = Seq(start) ++ bends ++ Seq(end)
-
-    allPoints
-      .sliding(2)
-      .map { case point1 :: point2 :: Nil =>
-        (point1, point2)
-      }
-      .toSeq
+    Seq(start) ++ bendPoints ++ Seq(end)
   }
 }

--- a/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
+++ b/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
@@ -2,7 +2,7 @@ package edg_ide.swing.blocks
 
 import com.intellij.ui.JBColor
 import edg_ide.swing.{ColorUtil, Zoomable}
-import edg_ide.swing.blocks.ElkNodeUtil.edgeSectionPairs
+import edg_ide.swing.blocks.ElkNodeUtil
 import org.eclipse.elk.graph.{ElkEdge, ElkGraphElement, ElkNode, ElkPort, ElkShape}
 
 import java.awt.event.{MouseAdapter, MouseEvent, MouseMotionAdapter}
@@ -133,7 +133,13 @@ class JBlockDiagramVisualizer(var rootNode: ElkNode, var showTop: Boolean = fals
 
     def edgeClosestDistance(edge: ElkEdge, point: (Double, Double)): Double = {
       edge.getSections.asScala.map { section =>
-        edgeSectionPairs(section).map { case (line1, line2) =>
+        val segments = ElkNodeUtil.allPoints(section)
+          .sliding(2)
+          .map { case point1 :: point2 :: Nil =>
+            (point1, point2)
+          }
+
+        segments.map { case (line1, line2) =>
           lineClosestDist(line1, line2, point)
         }.min
       }.min

--- a/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
+++ b/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
@@ -184,7 +184,7 @@ class JBlockDiagramVisualizer(var rootNode: ElkNode, var showTop: Boolean = fals
   private val kDimBlend = 0.25
 
   private val errorModifier = ElementGraphicsModifier(
-    fillGraphics = ElementGraphicsModifier.withColorBlendBackground(JBColor.RED, 0.5)
+    fillGraphics = ElementGraphicsModifier.withColorBlendBackground(JBColor.RED, 0.67)
   )
   private val selectedModifier = ElementGraphicsModifier(
     strokeGraphics = ElementGraphicsModifier.withStroke(new BasicStroke(3 / zoomLevel))

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -514,7 +514,8 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
           Seq(
             new ElkEdgirGraphUtils.TitleMapper(currentCompiler),
             ElkEdgirGraphUtils.DesignPathMapper,
-            ElkEdgirGraphUtils.PortArrayMapper
+            ElkEdgirGraphUtils.PortArrayMapper,
+            new ElkEdgirGraphUtils.WireColorMapper(compiler),
           )
         )
 


### PR DESCRIPTION
Adds ATX-style color coding to the block diagram visualizer for VoltageSink, VoltageSource ports and VoltageLink edges. Supports ~3.3v (orange), ~5v (red), ~12v (yellow), GND (blue). Colors are somewhat muted (67% blend with foreground color). The specifics of the visuals probably need fine-tuning, but that's for another day and another PR.

VoltageSink ports are only colored if the voltage is restricted to the range. Wider tolerances (common on many parts) will not be color-coded.

Wire drawing also changed to a polyline, which should eliminate overlap artifacting for outlines.

Other refactoring:
- Architecturally wire colors are implemented as a stroke modifier argument
- Graphics2D makeTransformer now returns a new Graphics2D object instead of mutating in-place
- Better encapsulation of paintEdge, with outline layering handled with an isOutline arg
