### PR TITLE
Continued block diagram visualizer improvements

### DIFF
--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -184,7 +184,7 @@ object ElkEdgirGraphUtils {
     override def nodeConv(node: NodeDataWrapper): Option[Option[Color]] = None
 
     // roughly ATX power supply conventions
-    protected def outputVoltageRangeToColor(range: RangeValue): Option[Option[Color]] = range match {
+    protected def voltageRangeToColor(range: RangeValue): Option[Option[Color]] = range match {
       case RangeValue(min, max) if min >= 3.0 && max <= 3.6 => Some(Some(JBColor.ORANGE))
       case RangeValue(min, max) if min >= 4.5 && max <= 5.5 => Some(Some(JBColor.RED))
       case RangeValue(min, max) if min >= 10.5 && max <= 14.5 => Some(Some(JBColor.YELLOW))
@@ -192,28 +192,7 @@ object ElkEdgirGraphUtils {
       case _ => None
     }
 
-    protected def limitVoltageRangeToColor(range: RangeValue): Option[Option[Color]] = range match {
-      case RangeValue(min, max) if min >= 3.0 && max <= 3.6 => Some(Some(JBColor.ORANGE))
-      case RangeValue(min, max) if min >= 4.5 && max <= 5.5 => Some(Some(JBColor.RED))
-      case RangeValue(min, max) if min >= 10.5 && max <= 14.5 => Some(Some(JBColor.YELLOW))
-      case RangeValue(0, 0) => Some(Some(JBColor.BLUE))
-      case _ => None
-    }
-
-    override def portConv(port: PortWrapper): Option[Option[Color]] = {
-      val portType = BlockConnectivityAnalysis.typeOfPortLike(port.portLike)
-      portType.toSimpleString match {
-        case "VoltageSource" => compiler.getParamValue(port.path.asIndirect + "voltage_out") match {
-            case Some(range: RangeValue) => outputVoltageRangeToColor(range)
-            case _ => None
-          }
-        case "VoltageSink" => compiler.getParamValue(port.path.asIndirect + "voltage_limits") match {
-            case Some(range: RangeValue) => limitVoltageRangeToColor(range)
-            case _ => None
-          }
-        case _ => None
-      }
-    }
+    override def portConv(port: PortWrapper): Option[Option[Color]] = None
 
     override def edgeConv(edge: EdgeWrapper): Option[Option[Color]] = {
       val linkTypeOpt = edge match {
@@ -227,7 +206,7 @@ object ElkEdgirGraphUtils {
       }
       linkTypeOpt.map(_.toSimpleString) match {
         case Some("VoltageLink") => compiler.getParamValue(edge.path.asIndirect + "voltage") match {
-            case Some(range: RangeValue) => outputVoltageRangeToColor(range)
+            case Some(range: RangeValue) => voltageRangeToColor(range)
             case _ => None
           }
         case _ => None

--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -224,13 +224,13 @@ object ElkEdgirGraphUtils {
 
     protected def voltageRangeToString(range: RangeValue): Option[String] = range match {
       case RangeValue(0, 0) => Some("GND")
-      case RangeValue(min, max) if (max - min) / ((min + max) / 2) <= 0.25 => Some(f"${(min + max) / 2}%.1f")
+      case RangeValue(min, max) if (max - min) / ((min + max) / 2) <= 0.25 => Some(f"${(min + max) / 2}%.02gv")
       case _ => None
     }
   }
 
   class WireLabelMapper(compiler: Compiler)
-    extends HierarchyGraphElk.PropertyMapper[NodeDataWrapper, PortWrapper, EdgeWrapper] {
+      extends HierarchyGraphElk.PropertyMapper[NodeDataWrapper, PortWrapper, EdgeWrapper] {
     type PropertyType = String
 
     override val property: IProperty[String] = WireLabelMapper.WireLabelProperty
@@ -242,18 +242,18 @@ object ElkEdgirGraphUtils {
     override def edgeConv(edge: EdgeWrapper): Option[String] = {
       val linkTypeOpt = edge match {
         case EdgeLinkWrapper(path, linkLike) => linkLike.`type` match {
-          case elem.LinkLike.Type.Link(link) => link.selfClass
-          case elem.LinkLike.Type.LibElem(lib) => Some(lib)
-          case elem.LinkLike.Type.Array(link) => link.selfClass
-          case _ => None
-        }
+            case elem.LinkLike.Type.Link(link) => link.selfClass
+            case elem.LinkLike.Type.LibElem(lib) => Some(lib)
+            case elem.LinkLike.Type.Array(link) => link.selfClass
+            case _ => None
+          }
         case _ => None
       }
       linkTypeOpt.map(_.toSimpleString) match {
         case Some("VoltageLink") => compiler.getParamValue(edge.path.asIndirect + "voltage") match {
-          case Some(range: RangeValue) => WireLabelMapper.voltageRangeToString(range)
-          case _ => None
-        }
+            case Some(range: RangeValue) => WireLabelMapper.voltageRangeToString(range)
+            case _ => None
+          }
         case _ => None
       }
     }

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -455,6 +455,7 @@ class CompileProcessHandler(
                 ElkEdgirGraphUtils.DesignPathMapper,
                 ElkEdgirGraphUtils.PortArrayMapper,
                 new ElkEdgirGraphUtils.WireColorMapper(compiler),
+                new ElkEdgirGraphUtils.WireLabelMapper(compiler),
               ),
               options.pdfFile
             )

--- a/src/main/scala/edg_ide/swing/ColorUtil.scala
+++ b/src/main/scala/edg_ide/swing/ColorUtil.scala
@@ -8,7 +8,7 @@ object ColorUtil {
       (baseColor.getRed * (1 - factor) + topColor.getRed * factor).toInt,
       (baseColor.getGreen * (1 - factor) + topColor.getGreen * factor).toInt,
       (baseColor.getBlue * (1 - factor) + topColor.getBlue * factor).toInt,
-      baseColor.getAlpha
+      (baseColor.getAlpha * (1 - factor) + topColor.getAlpha * factor).toInt,
     )
   }
 

--- a/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
@@ -1,16 +1,13 @@
 package edg_ide.swing.blocks
 
-import com.intellij.ui.JBColor
 import edg.wir.DesignPath
 import edg_ide.edgir_graph.ElkEdgirGraphUtils
+import edg_ide.swing.DrawAnchored
 import edg_ide.swing.blocks.ElementGraphicsModifier.withColorBlendBackground
-import edg_ide.swing.{ColorUtil, DrawAnchored}
 import org.eclipse.elk.core.options.{CoreOptions, PortSide}
 import org.eclipse.elk.graph._
 
 import java.awt._
-import java.awt.geom.Rectangle2D
-import java.awt.image.BufferedImage
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 // ELK h-block graph painter with modifications for EDG graphs:
@@ -26,6 +23,39 @@ class EdgElkNodePainter(
     portInserts: Set[ElkGraphElement] = Set() // ports to draw insert indicators for
 ) extends ElkNodePainter(rootNode, showTop, zoomLevel, defaultGraphics, elementGraphics) {
   protected val kWireColorBlendFactor = 0.67
+
+  protected def drawGround(g: Graphics2D, x: Int, y: Int, anchor: DrawAnchored, size: Int): Unit = {
+    val halfsize = size / 2
+    require(halfsize > 0)
+    anchor match {
+      case DrawAnchored.Top | DrawAnchored.Bottom =>
+        val dy = anchor match {
+          case DrawAnchored.Bottom => -halfsize / 2
+          case DrawAnchored.Top | _ => halfsize / 2
+        }
+        g.drawLine(x - halfsize, y, x + halfsize, y)
+        g.drawLine(x - halfsize / 2, y + dy, x + halfsize / 2, y + dy)
+        g.drawLine(x - halfsize / 3, y + dy * 2, x + halfsize / 3, y + dy * 2)
+      case DrawAnchored.Left | DrawAnchored.Right =>
+        val dx = anchor match {
+          case DrawAnchored.Right => -halfsize / 2
+          case DrawAnchored.Left | _ => halfsize / 2
+        }
+        g.drawLine(x, y - halfsize, x, y + halfsize)
+        g.drawLine(x + dx, y - halfsize / 2, x + dx, y + halfsize / 2)
+        g.drawLine(x + dx * 2, y - halfsize / 3, x + dx * 2, y + halfsize / 3)
+      case _ => // ignored, invalid
+    }
+  }
+
+  protected def drawRail(g: Graphics2D, x: Int, y: Int, anchor: DrawAnchored, size: Int): Unit = {
+    val halfsize = size / 2
+    anchor match {
+      case DrawAnchored.Top | DrawAnchored.Bottom => g.drawLine(x - halfsize, y, x + halfsize, y)
+      case DrawAnchored.Left | DrawAnchored.Right => g.drawLine(x, y - halfsize, x, y + halfsize)
+      case _ => // ignored, invalid
+    }
+  }
 
   override protected def paintEdge(
       parentG: Graphics2D,
@@ -43,27 +73,38 @@ class EdgElkNodePainter(
     if (isOutline) return
     val baseG = getFixedEdgeBaseG(parentG, blockG, edge)
     if (edge.getSources == edge.getTargets) { // degenerate, "tunnel" (by heuristic / transform) edge
-      val label = edge.getProperty(ElkEdgirGraphUtils.DesignPathMapper.property) match {
-        case DesignPath(steps) => steps.lastOption.getOrElse("")
-        case _ => ""
-      }
-
       val targetPointOpt = edge.getSections.asScala.headOption.map { section =>
         val bend = section.getBendPoints.asScala.head
         (bend.getX, bend.getY, section.getStartX, section.getStartY)
       }
 
       val textG = textGraphics(colorStrokeModifier(baseG), edge)
-      val anchorXYOpt = targetPointOpt.collect {
-        case (x, y, x1, y1) if (x1 == x) && (y >= y1) => (DrawAnchored.Top, x, y)
-        case (x, y, x1, y1) if (x1 == x) && (y < y1) => (DrawAnchored.Bottom, x, y)
-        case (x, y, x1, y1) if (y1 == y) && (x >= x1) => (DrawAnchored.Left, x, y)
-        case (x, y, x1, y1) if (y1 == y) && (x < x1) => (DrawAnchored.Right, x, y)
-      }
-      anchorXYOpt.foreach { case (anchor, x, y) =>
-        DrawAnchored.drawLabel(textG, label, (x, y), anchor)
+      val anchorXYSizeOpt = targetPointOpt.collect {
+        case (x, y, x1, y1) if (x1 == x) && (y >= y1) => (DrawAnchored.Top, x, y, y - y1)
+        case (x, y, x1, y1) if (x1 == x) && (y < y1) => (DrawAnchored.Bottom, x, y, y1 - y)
+        case (x, y, x1, y1) if (y1 == y) && (x >= x1) => (DrawAnchored.Left, x, y, x - x1)
+        case (x, y, x1, y1) if (y1 == y) && (x < x1) => (DrawAnchored.Right, x, y, x1 - x)
       }
 
+      anchorXYSizeOpt.foreach { case (anchor, x, y, size) =>
+        val lastPath = edge.getProperty(ElkEdgirGraphUtils.DesignPathMapper.property) match {
+          case DesignPath(steps) => steps.lastOption.getOrElse("")
+          case _ => ""
+        }
+        val propLabel = edge.getProperty(ElkEdgirGraphUtils.WireLabelMapper.WireLabelProperty)
+        val label = if (lastPath.isEmpty || lastPath.startsWith("_") && propLabel.nonEmpty) {
+          if (propLabel != "GND") {
+            drawRail(textG, x.toInt, y.toInt, anchor, size.toInt)
+            propLabel // use mapper-defined labels for anon / unnamed
+          } else {
+            drawGround(textG, x.toInt, y.toInt, anchor, size.toInt)
+            "" // don't draw GND, which is handled by the symbol
+          }
+        } else {
+          lastPath
+        }
+        DrawAnchored.drawLabel(textG, label, (x, y), anchor)
+      }
     }
   }
 

--- a/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
@@ -53,7 +53,7 @@ class EdgElkNodePainter(
         (bend.getX, bend.getY, section.getStartX, section.getStartY)
       }
 
-      val textG = textGraphics(baseG, edge)
+      val textG = textGraphics(colorStrokeModifier(baseG), edge)
       targetPointOpt match {
         case Some((x, y, x1, y1)) if (x1 == x) && (y > y1) =>
           DrawAnchored.drawLabel(textG, label, (x, y), DrawAnchored.Top)

--- a/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
@@ -103,7 +103,7 @@ class EdgElkNodePainter(
         } else {
           lastPath
         }
-        DrawAnchored.drawLabel(textG, label, (x, y), anchor)
+        DrawAnchored.drawLabel(detailLabelModifier(textG), label, (x, y), anchor)
       }
     }
   }

--- a/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
@@ -108,17 +108,11 @@ class EdgElkNodePainter(
 
   override protected def paintPort(
       g: Graphics2D,
-      port: ElkPort,
-      strokeModifier: Graphics2D => Graphics2D = identity
+      port: ElkPort
   ): Unit = {
     if (portInserts.contains(port)) { // if insert is specified, draw the arrow outline
       val (xPts, yPts) = insertArrowPoints(port)
       outlineGraphics(g, port).foreach { g => g.drawPolygon(xPts, yPts, 3) }
-    }
-
-    val colorStrokeModifier = port.getProperty(ElkEdgirGraphUtils.WireColorMapper.WireColorProperty) match {
-      case Some(color) => ElementGraphicsModifier.withColor(color, kWireColorBlendFactor).andThen(strokeModifier)
-      case None => strokeModifier
     }
 
     // if an array, render the array ports under it
@@ -127,14 +121,14 @@ class EdgElkNodePainter(
       val portY = port.getY.toInt
 
       fillGraphics(g, port).fillRect(portX + 4, portY + 4, port.getWidth.toInt, port.getHeight.toInt)
-      withColorBlendBackground(0.5)(strokeGraphics(colorStrokeModifier(g), port))
+      withColorBlendBackground(0.5)(strokeGraphics(g, port))
         .drawRect(portX + 4, portY + 4, port.getWidth.toInt, port.getHeight.toInt)
 
       fillGraphics(g, port).fillRect(portX + 2, portY + 2, port.getWidth.toInt, port.getHeight.toInt)
-      withColorBlendBackground(0.75)(strokeGraphics(colorStrokeModifier(g), port))
+      withColorBlendBackground(0.75)(strokeGraphics(g, port))
         .drawRect(portX + 2, portY + 2, port.getWidth.toInt, port.getHeight.toInt)
     }
-    super.paintPort(g, port, colorStrokeModifier)
+    super.paintPort(g, port)
 
     if (portInserts.contains(port)) { // if insert is specified, draw the arrow
       val (xPts, yPts) = insertArrowPoints(port)

--- a/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/EdgElkNodePainter.scala
@@ -158,7 +158,7 @@ class EdgElkNodePainter(
       val portX = port.getX.toInt
       val portY = port.getY.toInt
       val (dx, dy) = port.getProperty(CoreOptions.PORT_SIDE) match { // have array extending inwards
-        case PortSide.NORTH => (2, -2)
+        case PortSide.NORTH => (2, 2)
         case PortSide.SOUTH => (2, -2)
         case PortSide.EAST => (-2, 2)
         case PortSide.WEST | _ => (2, 2)

--- a/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
@@ -201,10 +201,10 @@ class ElkNodePainter(
     nodeFillGraphics.fillRect(nodeX, nodeY, node.getWidth.toInt, node.getHeight.toInt)
     strokeGraphics(g, node).drawRect(nodeX, nodeY, node.getWidth.toInt, node.getHeight.toInt)
 
-    node.getLabels.asScala.zipWithIndex.foreach { case (label, i) => // first label is important, rest are detail
+    node.getLabels.asScala.zipWithIndex.foreach { case (label, i) =>
       val (labelX, labelY) =
         transformLabelCoords(g, label, label.getProperty(CoreOptions.NODE_LABELS_PLACEMENT).asScala.toSet)
-      val textG = if (i == 0) {
+      val textG = if (i == 0) { // first label is important, rest are detail
         textGraphics(g, node)
       } else {
         detailLabelModifier(textGraphics(g, node))

--- a/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
+++ b/src/main/scala/edg_ide/swing/blocks/ElkNodePainter.scala
@@ -218,13 +218,13 @@ class ElkNodePainter(
   }
 
   // Render a port, including its labels
-  protected def paintPort(g: Graphics2D, port: ElkPort, strokeModifier: Graphics2D => Graphics2D = identity): Unit = {
+  protected def paintPort(g: Graphics2D, port: ElkPort): Unit = {
     val portX = port.getX.toInt
     val portY = port.getY.toInt
 
     outlineGraphics(g, port).foreach { g => g.drawRect(portX, portY, port.getWidth.toInt, port.getHeight.toInt) }
     fillGraphics(g, port).fillRect(portX, portY, port.getWidth.toInt, port.getHeight.toInt)
-    strokeGraphics(strokeModifier(g), port).drawRect(portX, portY, port.getWidth.toInt, port.getHeight.toInt)
+    strokeGraphics(g, port).drawRect(portX, portY, port.getWidth.toInt, port.getHeight.toInt)
   }
 
   // paints the block and its contents

--- a/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
+++ b/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
@@ -2,13 +2,12 @@ package edg_ide.swing.blocks
 
 import com.intellij.ui.JBColor
 import edg_ide.swing.{ColorUtil, Zoomable}
-import edg_ide.swing.blocks.ElkNodeUtil
-import org.eclipse.elk.graph.{ElkEdge, ElkGraphElement, ElkNode, ElkPort, ElkShape}
+import org.eclipse.elk.graph.{ElkEdge, ElkGraphElement, ElkNode, ElkShape}
 
 import java.awt.event.{MouseAdapter, MouseEvent, MouseMotionAdapter}
 import java.awt.geom.Rectangle2D
 import java.awt.image.BufferedImage
-import java.awt.{BasicStroke, Color, Dimension, Graphics, Graphics2D, Rectangle, TexturePaint}
+import java.awt._
 import javax.swing.{JComponent, Scrollable}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.ListHasAsScala

--- a/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
+++ b/src/main/scala/edg_ide/swing/blocks/JBlockDiagramVisualizer.scala
@@ -183,7 +183,7 @@ class JBlockDiagramVisualizer(var rootNode: ElkNode, var showTop: Boolean = fals
   private val kDimBlend = 0.25
 
   private val errorModifier = ElementGraphicsModifier(
-    fillGraphics = ElementGraphicsModifier.withColorBlendBackground(JBColor.RED, 0.67)
+    fillGraphics = ElementGraphicsModifier.withColorBlendBackground(JBColor.RED, 0.45)
   )
   private val selectedModifier = ElementGraphicsModifier(
     strokeGraphics = ElementGraphicsModifier.withStroke(new BasicStroke(3 / zoomLevel))

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -516,6 +516,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
             ElkEdgirGraphUtils.DesignPathMapper,
             ElkEdgirGraphUtils.PortArrayMapper,
             new ElkEdgirGraphUtils.WireColorMapper(compiler),
+            new ElkEdgirGraphUtils.WireLabelMapper(compiler),
           )
         )
 


### PR DESCRIPTION
- Better colors
- Stop coloring port outlines, it doesn't work well with the port error indicator
- Add auto-generated labels for voltage lines based on voltage (if not zero) or a ground symbol (if zero), if no user-defined name is specified
- Properly blend alpha (fixes mouseover coloring)
- Draw array ports such that overlapped ports are inwards
- Dim port and block name labels when zoomed out