### PR TITLE
Don't do all-to-all connections when collapsing visualization graph nodes

### DIFF
--- a/src/main/scala/edg_ide/dse/DseFeature.scala
+++ b/src/main/scala/edg_ide/dse/DseFeature.scala
@@ -2,5 +2,5 @@ package edg_ide.dse
 
 object DseFeature {
   // feature flag to hide the feature while it's still in development
-  val kEnabled = true
+  val kEnabled = false
 }

--- a/src/main/scala/edg_ide/dse/DseFeature.scala
+++ b/src/main/scala/edg_ide/dse/DseFeature.scala
@@ -2,5 +2,5 @@ package edg_ide.dse
 
 object DseFeature {
   // feature flag to hide the feature while it's still in development
-  val kEnabled = false
+  val kEnabled = true
 }

--- a/src/main/scala/edg_ide/edgir_graph/CollapseNodeTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/CollapseNodeTransform.scala
@@ -34,18 +34,15 @@ trait CollapseNodeTransform {
     val collapsedEdgesData = (collapsedBlockSources ++ collapsedBlockTargets)
       .map { case (_, data) => data }
 
-    // If there are no sources or sinks, give up and do an all-to-all connect
-    // TODO maybe be smarter about this?
-
-    val fixedSources = if (collapsedBlockSources.isEmpty) {
-      collapsedBlockTargets
+    // If there are no sources or sinks, arbitrarily designate the first as the source
+    val (fixedSources, fixedTargets) = if (collapsedBlockSources.isEmpty && collapsedBlockSources.isEmpty) {
+      (Seq(), Seq())
+    } else if (collapsedBlockSources.isEmpty) {
+      (Seq(collapsedBlockTargets.head), collapsedBlockTargets.tail)
+    } else if (collapsedBlockTargets.isEmpty) {
+      (Seq(collapsedBlockSources.head), collapsedBlockSources.tail)
     } else {
-      collapsedBlockSources
-    }
-    val fixedTargets = if (collapsedBlockTargets.isEmpty) {
-      collapsedBlockSources
-    } else {
-      collapsedBlockTargets
+      (collapsedBlockSources, collapsedBlockTargets)
     }
 
     val crossSourceTarget =


### PR DESCRIPTION
this can create a lot of nodes, which effectively freezes the collapse transform