### PR TITLE
Clean up and enable DSE feature

### DIFF
--- a/src/main/scala/edg_ide/dse/DseFeature.scala
+++ b/src/main/scala/edg_ide/dse/DseFeature.scala
@@ -1,6 +1,5 @@
 package edg_ide.dse
 
 object DseFeature {
-  // feature flag to hide the feature while it's still in development
   val kEnabled = true
 }

--- a/src/main/scala/edg_ide/dse/DseFeature.scala
+++ b/src/main/scala/edg_ide/dse/DseFeature.scala
@@ -2,5 +2,5 @@ package edg_ide.dse
 
 object DseFeature {
   // feature flag to hide the feature while it's still in development
-  val kEnabled = false
+  val kEnabled = true
 }

--- a/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
@@ -1,6 +1,7 @@
 package edg_ide.swing.dse
 
 import com.intellij.ui.JBColor
+import edg_ide.util.SiPrefixUtil
 
 import java.awt.Color
 import scala.collection.mutable
@@ -86,7 +87,7 @@ object JDsePlot {
     var tickPos = (math.floor(range._1 / tickSpacing) * tickSpacing).toFloat
     val ticksBuilder = mutable.ArrayBuffer[(Float, String)]()
     while (tickPos <= range._2) {
-      ticksBuilder.append((tickPos, f"$tickPos%.02g"))
+      ticksBuilder.append((tickPos, SiPrefixUtil.unitsToString(tickPos, "")))
       tickPos = (tickPos + tickSpacing).toFloat
     }
     ticksBuilder.toSeq

--- a/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
@@ -14,12 +14,12 @@ object JDsePlot {
   val kBackgroundBlend: Float = 0.25f
   val kBackgroundAlpha: Int = 127
 
-  val kPointSizePx: Int = 6 // diameter in px
-  val kSnapDistancePx: Int = 9 // distance (radius) to snap for a click
-  val kPointSelectedSizePx: Int = 9 // diameter in px
-  val kPointHoverOutlinePx: Int = 14 // diameter in px
-  val kLineHoverBackgroundPx: Int = 24 // width in px
-  val kLineHoverOutlinePx: Int = 14 // width in px
+  val kPointSizePx: Int = 4 // diameter in px
+  val kSnapDistancePx: Int = 6 // distance (radius) to snap for a click
+  val kPointSelectedSizePx: Int = 6 // diameter in px
+  val kPointHoverOutlinePx: Int = 12 // diameter in px
+  val kLineHoverBackgroundPx: Int = 19 // width in px
+  val kLineHoverOutlinePx: Int = 9 // width in px
   val kHoverOutlineColor: Color = JBColor.BLUE
   val kHoverOutlineBlend: Float = 0.5f
 

--- a/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
@@ -13,12 +13,12 @@ object JDsePlot {
   val kBackgroundBlend: Float = 0.25f
   val kBackgroundAlpha: Int = 127
 
-  val kPointSizePx: Int = 4 // diameter in px
-  val kSnapDistancePx: Int = 6 // distance (radius) to snap for a click
-  val kPointSelectedSizePx: Int = 6 // diameter in px
-  val kPointHoverOutlinePx: Int = 12 // diameter in px
-  val kLineHoverBackgroundPx: Int = 19 // width in px
-  val kLineHoverOutlinePx: Int = 9 // width in px
+  val kPointSizePx: Int = 8 // diameter in px
+  val kSnapDistancePx: Int = 12 // distance (radius) to snap for a click
+  val kPointSelectedSizePx: Int = 12 // diameter in px
+  val kPointHoverOutlinePx: Int = 18 // diameter in px
+  val kLineHoverBackgroundPx: Int = 30 // width in px
+  val kLineHoverOutlinePx: Int = 16 // width in px
   val kHoverOutlineColor: Color = JBColor.BLUE
   val kHoverOutlineBlend: Float = 0.5f
 

--- a/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
+++ b/src/main/scala/edg_ide/swing/dse/JDsePlot.scala
@@ -14,12 +14,12 @@ object JDsePlot {
   val kBackgroundBlend: Float = 0.25f
   val kBackgroundAlpha: Int = 127
 
-  val kPointSizePx: Int = 8 // diameter in px
-  val kSnapDistancePx: Int = 12 // distance (radius) to snap for a click
-  val kPointSelectedSizePx: Int = 12 // diameter in px
-  val kPointHoverOutlinePx: Int = 18 // diameter in px
-  val kLineHoverBackgroundPx: Int = 30 // width in px
-  val kLineHoverOutlinePx: Int = 16 // width in px
+  val kPointSizePx: Int = 6 // diameter in px
+  val kSnapDistancePx: Int = 9 // distance (radius) to snap for a click
+  val kPointSelectedSizePx: Int = 9 // diameter in px
+  val kPointHoverOutlinePx: Int = 14 // diameter in px
+  val kLineHoverBackgroundPx: Int = 24 // width in px
+  val kLineHoverOutlinePx: Int = 14 // width in px
   val kHoverOutlineColor: Color = JBColor.BLUE
   val kHoverOutlineBlend: Float = 0.5f
 

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -285,16 +285,13 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
         dsePanelShown = dseConfigSelected // set it now, so we don't get multiple invocations of the update
         ApplicationManager.getApplication.invokeLater(() => {
           if (dseConfigSelected) {
-            mainSplitter.setSecondComponent(dsePanel)
-//            remove(mainSplitter)
-//            dseSplitter.setFirstComponent(mainSplitter)
-//            add(dseSplitter)
+            remove(mainSplitter)
+            dseSplitter.setFirstComponent(mainSplitter)
+            add(dseSplitter)
           } else {
-            mainSplitter.setSecondComponent(bottomSplitter)
-
-//            remove(dseSplitter)
-//            dseSplitter.setFirstComponent(null)
-//            add(mainSplitter)
+            remove(dseSplitter)
+            dseSplitter.setFirstComponent(null)
+            add(mainSplitter)
           }
         })
         revalidate()

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -285,13 +285,16 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
         dsePanelShown = dseConfigSelected // set it now, so we don't get multiple invocations of the update
         ApplicationManager.getApplication.invokeLater(() => {
           if (dseConfigSelected) {
-            remove(mainSplitter)
-            dseSplitter.setFirstComponent(mainSplitter)
-            add(dseSplitter)
+            mainSplitter.setSecondComponent(dsePanel)
+//            remove(mainSplitter)
+//            dseSplitter.setFirstComponent(mainSplitter)
+//            add(dseSplitter)
           } else {
-            remove(dseSplitter)
-            dseSplitter.setFirstComponent(null)
-            add(mainSplitter)
+            mainSplitter.setSecondComponent(bottomSplitter)
+
+//            remove(dseSplitter)
+//            dseSplitter.setFirstComponent(null)
+//            add(mainSplitter)
           }
         })
         revalidate()

--- a/src/main/scala/edg_ide/ui/DetailPanel.scala
+++ b/src/main/scala/edg_ide/ui/DetailPanel.scala
@@ -20,7 +20,7 @@ import edgrpc.hdl.{hdl => edgrpc}
 import java.awt.datatransfer.StringSelection
 import java.awt.event.{KeyAdapter, KeyEvent, MouseAdapter, MouseEvent}
 import java.awt.{BorderLayout, Toolkit}
-import javax.swing.{JPanel, JPopupMenu, KeyStroke, SwingUtilities}
+import javax.swing.{JMenu, JPanel, JPopupMenu, KeyStroke, SwingUtilities}
 
 class DetailParamPopupMenu(
     path: IndirectDesignPath,
@@ -92,9 +92,16 @@ class DetailParamPopupMenu(
     )
   )
 
+  addSeparator()
+  val hotkeyModifier = Toolkit.getDefaultToolkit.getMenuShortcutKeyMaskEx
+  val copyValueItem = add(ContextMenuUtils.MenuItemFromErrorable(copyAction, s"Copy value"))
+  copyValueItem.setMnemonic(KeyEvent.VK_C)
+  copyValueItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, hotkeyModifier))
+
   if (DseFeature.kEnabled) {
-    addSeparator()
-    add(
+    val dseMenu = new JMenu("Design Space Exploration")
+
+    dseMenu.add(
       ContextMenuUtils.MenuItemFromErrorable(
         exceptable {
           val directPath = DesignPath.fromIndirectOption(path).exceptNone("not a direct param")
@@ -114,7 +121,7 @@ class DetailParamPopupMenu(
       )
     )
 
-    add(
+    dseMenu.add(
       ContextMenuUtils.MenuItemNamedFromErrorable(
         exceptable {
           val (paramDefiningClass, postfix) = paramDefiningClassPostfix.exceptError
@@ -137,8 +144,8 @@ class DetailParamPopupMenu(
       )
     )
 
-    addSeparator()
-    add(
+    dseMenu.addSeparator()
+    dseMenu.add(
       ContextMenuUtils.MenuItemFromErrorable(
         exceptable {
           val objective = compiler.getParamType(path) match {
@@ -155,13 +162,10 @@ class DetailParamPopupMenu(
         "Add objective"
       )
     )
-  }
 
-  addSeparator()
-  val hotkeyModifier = Toolkit.getDefaultToolkit.getMenuShortcutKeyMaskEx
-  val copyValueItem = add(ContextMenuUtils.MenuItemFromErrorable(copyAction, s"Copy value"))
-  copyValueItem.setMnemonic(KeyEvent.VK_C)
-  copyValueItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, hotkeyModifier))
+    addSeparator()
+    add(dseMenu)
+  }
 }
 
 // TODO: remove initCompiler, it's counterintuitive

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -387,8 +387,10 @@ class DsePanel(project: Project) extends JPanel {
       val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.searchConfigNode)
       configTree.getTree.expandPath(nodePath)
       if (scrollToLast) {
-        val lastNodePath = nodePath.pathByAddingChild(treeRoot.searchConfigNode.children.last)
-        configTree.scrollRectToVisible(configTree.getTree.getPathBounds(lastNodePath))
+        treeRoot.searchConfigNode.children.lastOption.foreach { last =>
+          val lastNodePath = nodePath.pathByAddingChild(last)
+          configTree.scrollRectToVisible(configTree.getTree.getPathBounds(lastNodePath))
+        }
       }
       tabbedPane.setSelectedIndex(kTabConfig)
     })

--- a/src/main/scala/edg_ide/ui/DsePanel.scala
+++ b/src/main/scala/edg_ide/ui/DsePanel.scala
@@ -403,8 +403,10 @@ class DsePanel(project: Project) extends JPanel {
       val nodePath = new TreePath(treeRoot).pathByAddingChild(treeRoot.objectivesNode)
       configTree.getTree.expandPath(nodePath)
       if (scrollToLast) {
-        val lastNodePath = nodePath.pathByAddingChild(treeRoot.objectivesNode.children.last)
-        configTree.scrollRectToVisible(configTree.getTree.getPathBounds(lastNodePath))
+        treeRoot.objectivesNode.children.lastOption.foreach { last =>
+          val lastNodePath = nodePath.pathByAddingChild(last)
+          configTree.scrollRectToVisible(configTree.getTree.getPathBounds(lastNodePath))
+        }
       }
       tabbedPane.setSelectedIndex(kTabConfig)
     })

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -306,7 +306,7 @@ class DesignPortPopupMenu(path: DesignPath, interface: ToolInterface)
             case edgir.init.init.ValInit.Val.Integer(_) => classOf[edg.compiler.IntValue]
             case edgir.init.init.ValInit.Val.Boolean(_) => classOf[edg.compiler.BooleanValue]
             case edgir.init.init.ValInit.Val.Text(_) => classOf[edg.compiler.TextValue]
-            case edgir.init.init.ValInit.Val.Range(_) => classOf[edg.compiler.RangeValue]
+            case edgir.init.init.ValInit.Val.Range(_) => classOf[edg.compiler.RangeType]
             case _ => exceptable.fail(f"unknown parameter type")
           }
           val objective = DseObjectiveParameter(path.asIndirect + paramName, paramType)


### PR DESCRIPTION
Enable the DSE feature globally. Clean it up so the entry points are non-obtrusive, they're behind a DSE submenu in the context menus

Also cleaning up of the DSE feature interface:
- Axis ticks use SI prefix instead of the 1e9 mess
- Adding a first objective / search space no longer brings up a (nonfatal) IDE error - using .lastOption instead of .last
- Gate unproven objective behind the feature enable config
- Add DSE objective insert on port parameters - it should be possible to do the example purely graphically