### PR TITLE
Allow stopping run process

### DIFF
--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -276,9 +276,18 @@ class CompileProcessHandler(
 ) extends ProcessHandler
     with HasConsoleStages {
   var runThread: Option[Thread] = None
+  var pythonInterfaceOpt: Option[LoggingPythonInterface] = None
 
   override def destroyProcessImpl(): Unit = {
+    pythonInterfaceOpt.foreach { pythonInterface =>
+      pythonInterface.destroy()
+      pythonInterface.forwardProcessOutput()
+      console.print(f"Python subprocess terminated.\n", ConsoleViewContentType.ERROR_OUTPUT)
+      pythonInterfaceOpt = None
+    }
     runThread.foreach(_.interrupt())
+    console.print(f"Compilation terminated.\n", ConsoleViewContentType.ERROR_OUTPUT)
+    terminatedNotify(-1)
   }
   override def detachProcessImpl(): Unit = {
     throw new NotImplementedError()
@@ -303,7 +312,7 @@ class CompileProcessHandler(
     BlockVisualizerService(project).setDesignStale()
 
     // A maybe Python interface is needed at this level so on an error it can be shut down if it exists
-    var pythonInterfaceOpt: Option[LoggingPythonInterface] = None
+    require(pythonInterfaceOpt.isEmpty)
     var exitCode: Int = -1
 
     try {

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -311,7 +311,6 @@ class CompileProcessHandler(
     console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
     BlockVisualizerService(project).setDesignStale()
 
-    // A maybe Python interface is needed at this level so on an error it can be shut down if it exists
     require(pythonInterfaceOpt.isEmpty)
     var exitCode: Int = -1
 


### PR DESCRIPTION
Now kills the subprocess and interrupts the thread, previously this didn't really do anything.

Ideally it would send SIGINT so Python could provide a stack trace (like KeyboardInterrupt; if the failing item was infinite-looping), but it seems that's not part of the cross-platform Java API.