### PR TITLE
Automatically detect submodule prefix

### DIFF
--- a/src/main/scala/edg_ide/runner/BlockLineMarkerContributor.scala
+++ b/src/main/scala/edg_ide/runner/BlockLineMarkerContributor.scala
@@ -96,8 +96,8 @@ class BlockLineMarkerContributor extends LineMarkerProvider {
       case parent: PyClass =>
         val project = element.getProject
         // shouldn't fail, and if it does it should fail noisily
-        val designTopClass = DesignAnalysisUtils.pyClassOf("edg.core.DesignTop.DesignTop", project).get
-        val blockClass = DesignAnalysisUtils.pyClassOf("edg.core.HierarchyBlock.Block", project).get
+        val designTopClass = DesignAnalysisUtils.corePyClassOf(DesignAnalysisUtils.kDesignTopClassName, project).get
+        val blockClass = DesignAnalysisUtils.corePyClassOf(DesignAnalysisUtils.kBlockClassName, project).get
         if (
           parent.isSubclass(blockClass, TypeEvalContext.codeAnalysis(project, null)) &&
           !parent.isSubclass(designTopClass, TypeEvalContext.codeAnalysis(project, null))

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -310,11 +310,6 @@ class CompileProcessHandler(
     console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
     BlockVisualizerService(project).setDesignStale()
 
-    val corePrefix = ReadAction.compute(() => { DesignAnalysisUtils.resolveCorePrefix(project) }).get
-    if (corePrefix.nonEmpty) {
-      console.print(s"Using core prefix ${corePrefix.mkString(".")}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
-    }
-
     require(pythonInterfaceOpt.isEmpty)
     var exitCode: Int = -1
 
@@ -330,6 +325,11 @@ class CompileProcessHandler(
       )
       val pythonInterface = new LoggingPythonInterface(console, pythonCommand, pythonPaths)
       pythonInterfaceOpt = Some(pythonInterface)
+
+      val packagePrefix = pythonInterface.packagePrefix
+      if (packagePrefix.nonEmpty) {
+        console.print(s"Using core prefix ${packagePrefix}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
+      }
 
       (pythonInterface.getProtoVersion() match {
         case Errorable.Success(pyVersion) if pyVersion == Compiler.kExpectedProtoVersion => None
@@ -393,7 +393,7 @@ class CompileProcessHandler(
 
         runFailableStageUnit("refdes", indicator) {
           val refdes = pythonInterface.runRefinementPass(
-            ElemBuilder.LibraryPath((corePrefix :+ "edg.electronics_model.RefdesRefinementPass").mkString(".")),
+            ElemBuilder.LibraryPath(packagePrefix + "edg.electronics_model.RefdesRefinementPass"),
             compiled,
             compiler.getAllSolved
           ).mapErr(msg => s"while refdesing: $msg")
@@ -411,7 +411,7 @@ class CompileProcessHandler(
         if (options.netlistFile.nonEmpty) {
           runFailableStageUnit("generate netlist", indicator) {
             val netlist = pythonInterface.runBackend(
-              ElemBuilder.LibraryPath((corePrefix :+ "edg.electronics_model.NetlistBackend").mkString(".")),
+              ElemBuilder.LibraryPath(packagePrefix + "edg.electronics_model.NetlistBackend"),
               compiled,
               compiler.getAllSolved,
               Map("RefdesMode" -> options.toggle.toString)
@@ -435,7 +435,7 @@ class CompileProcessHandler(
         if (options.bomFile.nonEmpty) {
           runFailableStageUnit("generate BOM", indicator) {
             val bom = pythonInterface.runBackend(
-              ElemBuilder.LibraryPath((corePrefix :+ "edg.electronics_model.BomBackend.GenerateBom").mkString(".")),
+              ElemBuilder.LibraryPath(packagePrefix + "edg.electronics_model.BomBackend.GenerateBom"),
               compiled,
               compiler.getAllSolved,
               Map()

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -16,10 +16,10 @@ import edg.ElemBuilder
 import edg.compiler._
 import edg.util.{Errorable, StreamUtils, timeExec}
 import edg.wir.DesignPath
-import edg_ide.edgir_graph.{ElkEdgirGraphUtils, HierarchyGraphElk}
+import edg_ide.edgir_graph.ElkEdgirGraphUtils
 import edg_ide.ui.{BlockVisualizerService, EdgCompilerService, EdgSettingsState}
 import edg_ide.util.ExceptionNotifyImplicits.ExceptNotify
-import edg_ide.util.exceptable
+import edg_ide.util.{DesignAnalysisUtils, exceptable}
 import edgir.elem.elem
 import edgir.ref.ref
 import edgir.schema.schema
@@ -310,6 +310,11 @@ class CompileProcessHandler(
     console.print(s"Starting compilation of ${options.designName}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
     BlockVisualizerService(project).setDesignStale()
 
+    val corePrefix = ReadAction.compute(() => { DesignAnalysisUtils.resolveCorePrefix(project) }).get
+    if (corePrefix.nonEmpty) {
+      console.print(s"Using core prefix ${corePrefix.mkString(".")}\n", ConsoleViewContentType.LOG_INFO_OUTPUT)
+    }
+
     require(pythonInterfaceOpt.isEmpty)
     var exitCode: Int = -1
 
@@ -388,7 +393,7 @@ class CompileProcessHandler(
 
         runFailableStageUnit("refdes", indicator) {
           val refdes = pythonInterface.runRefinementPass(
-            ElemBuilder.LibraryPath("edg.electronics_model.RefdesRefinementPass"),
+            ElemBuilder.LibraryPath((corePrefix :+ "edg.electronics_model.RefdesRefinementPass").mkString(".")),
             compiled,
             compiler.getAllSolved
           ).mapErr(msg => s"while refdesing: $msg")
@@ -406,7 +411,7 @@ class CompileProcessHandler(
         if (options.netlistFile.nonEmpty) {
           runFailableStageUnit("generate netlist", indicator) {
             val netlist = pythonInterface.runBackend(
-              ElemBuilder.LibraryPath("edg.electronics_model.NetlistBackend"),
+              ElemBuilder.LibraryPath((corePrefix :+ "edg.electronics_model.NetlistBackend").mkString(".")),
               compiled,
               compiler.getAllSolved,
               Map("RefdesMode" -> options.toggle.toString)
@@ -430,7 +435,7 @@ class CompileProcessHandler(
         if (options.bomFile.nonEmpty) {
           runFailableStageUnit("generate BOM", indicator) {
             val bom = pythonInterface.runBackend(
-              ElemBuilder.LibraryPath("edg.electronics_model.BomBackend.GenerateBom"),
+              ElemBuilder.LibraryPath((corePrefix :+ "edg.electronics_model.BomBackend.GenerateBom").mkString(".")),
               compiled,
               compiler.getAllSolved,
               Map()

--- a/src/main/scala/edg_ide/runner/DesignTopRunConfigurationProducer.scala
+++ b/src/main/scala/edg_ide/runner/DesignTopRunConfigurationProducer.scala
@@ -25,7 +25,7 @@ class DesignTopRunConfigurationProducer extends LazyRunConfigurationProducer[Des
       case Some(psiPyClass) =>
         val project = psiPyClass.getProject
         // shouldn't fail, and if it does it should fail noisily
-        val designTopClass = DesignAnalysisUtils.pyClassOf("edg.core.DesignTop.DesignTop", project).get
+        val designTopClass = DesignAnalysisUtils.corePyClassOf(DesignAnalysisUtils.kDesignTopClassName, project).get
         if (psiPyClass.isSubclass(designTopClass, TypeEvalContext.codeAnalysis(project, null))) {
           configuration.setName(psiPyClass.getQualifiedName)
           configuration.options.designName = psiPyClass.getQualifiedName

--- a/src/main/scala/edg_ide/runner/DesignTopRunMarkerContributor.scala
+++ b/src/main/scala/edg_ide/runner/DesignTopRunMarkerContributor.scala
@@ -20,7 +20,7 @@ class DesignTopRunMarkerContributor extends RunLineMarkerContributor {
       case parent: PyClass =>
         val project = element.getProject
         // shouldn't fail, and if it does it should fail noisily
-        val designTopClass = DesignAnalysisUtils.pyClassOf("edg.core.DesignTop.DesignTop", project).get
+        val designTopClass = DesignAnalysisUtils.corePyClassOf(DesignAnalysisUtils.kDesignTopClassName, project).get
         if (parent.isSubclass(designTopClass, TypeEvalContext.codeAnalysis(project, null))) {
           new Info(AllIcons.RunConfigurations.TestState.Run, ExecutorAction.getActions(), null)
         } else {

--- a/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
+++ b/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
@@ -36,13 +36,13 @@ object DesignAnalysisUtils {
   }
 
   // List of prefixes to try for corePyClassOf, in order (submodule is preferred over top-level)
-  val kCorePrefixes = Seq(Seq("PolymorphicBlocks"), Seq())
+  val kCorePrefixes = Seq("PolymorphicBlocks.", "")
   val kDesignTopClassName = "edg.core.DesignTop.DesignTop"
   val kBlockClassName = "edg.core.HierarchyBlock.Block"
 
-  def resolveCorePrefix(project: Project): Errorable[Seq[String]] = {
+  def resolveCorePrefix(project: Project): Errorable[String] = {
     kCorePrefixes
-      .map(prefix => (prefix, pyClassOf((prefix :+ kDesignTopClassName).mkString("."), project)))
+      .map(prefix => (prefix, pyClassOf(prefix + kDesignTopClassName, project)))
       .collectFirst { case (prefix, Errorable.Success(_)) => Errorable.Success(prefix) }
       .getOrElse(Errorable.Error(s"unable to resolve edg core prefix, tried ${kCorePrefixes}"))
   }
@@ -52,7 +52,7 @@ object DesignAnalysisUtils {
     */
   def corePyClassOf(className: String, project: Project): Errorable[PyClass] = exceptable {
     val prefix = resolveCorePrefix(project).exceptError
-    return pyClassOf((prefix :+ className).mkString("."), project)
+    return pyClassOf(prefix + className, project)
   }
 
   def typeOf(pyClass: PyClass): ref.LibraryPath = {

--- a/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
+++ b/src/main/scala/edg_ide/util/DesignAnalysisUtils.scala
@@ -19,16 +19,6 @@ import scala.jdk.CollectionConverters.{CollectionHasAsScala, ListHasAsScala}
 import scala.collection.mutable
 
 object DesignAnalysisUtils {
-  // Returns whether subclass is a subclass of superclass, using the PSI.
-  // If anything can't be found, returns false.
-  def isSubclassOfPsi(subclass: ref.LibraryPath, superclass: ref.LibraryPath, project: Project): Boolean = {
-    (pyClassOf(subclass, project).toOption, pyClassOf(superclass, project).toOption) match {
-      case (Some(subclass), Some(superclass)) =>
-        subclass.isSubclass(superclass, TypeEvalContext.codeAnalysis(project, null))
-      case _ => false
-    }
-  }
-
   /** Returns the PyClass of a LibraryPath
     */
   def pyClassOf(path: ref.LibraryPath, project: Project): Errorable[PyClass] = {


### PR DESCRIPTION
If in a project that submodules PolymorphicBlocks (instead of pip-installed `edg`), this detects the submodule and adds prefixes so the Run button appears and the Python-based compiler passes are detected and runs.

A bit of ugliness in that the submodule name is hardcoded, and that the detection for the pyClassOf and the CompileProcessHandler is separate, the former based on directory existence and the latter based on the PSI.