### PR TITLE
Set CWD of Python subprocess to top-level-design-file's containing folder

### DIFF
--- a/src/main/scala/edg_ide/runner/DseProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/DseProcessHandler.scala
@@ -154,7 +154,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
     var exitCode: Int = -1
 
     try {
-      val (pythonCommand, pythonPaths, sdkName) =
+      val (pythonCommand, workingDir, pythonPaths, sdkName) =
         CompileProcessHandler
           .getPythonInterpreter(project, options.designName)
           .mapErr(msg => s"while getting Python interpreter path: $msg")
@@ -164,7 +164,7 @@ class DseProcessHandler(project: Project, options: DseRunConfigurationOptions, v
         ConsoleViewContentType.LOG_INFO_OUTPUT
       )
 
-      val pythonProcess = new LoggingPythonInterface(pythonCommand, pythonPaths, console)
+      val pythonProcess = new LoggingPythonInterface(pythonCommand, Some(new File(workingDir)), pythonPaths, console)
       val pythonInterface = new LoggingCompilerInterface(pythonProcess, console)
       pythonProcessOpt = Some(pythonProcess)
 


### PR DESCRIPTION
... otherwise, the IDE gets set as the CWD, and the IDE's PolymorphicBlocks directory can get referenced instead of the project-specific submodule. This should not affect anything else since PYTHONPATH was setting the correct paths.