### PR TITLE
Block grouping transform + fixes

### DIFF
--- a/.github/workflows/pr-scala.yml
+++ b/.github/workflows/pr-scala.yml
@@ -20,6 +20,8 @@ jobs:
       with:
         distribution: temurin
         java-version: 17
+    - name: Setup sbt launcher
+      uses: sbt/setup-sbt@v1
 
     - name: sbt test
       run: sbt -v +test

--- a/src/main/scala/edg_ide/edgir_graph/CollapseNodeTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/CollapseNodeTransform.scala
@@ -35,7 +35,7 @@ trait CollapseNodeTransform {
       .map { case (_, data) => data }
 
     // If there are no sources or sinks, arbitrarily designate the first as the source
-    val (fixedSources, fixedTargets) = if (collapsedBlockSources.isEmpty && collapsedBlockSources.isEmpty) {
+    val (fixedSources, fixedTargets) = if (collapsedBlockSources.isEmpty && collapsedBlockTargets.isEmpty) {
       (Seq(), Seq())
     } else if (collapsedBlockSources.isEmpty) {
       (Seq(collapsedBlockTargets.head), collapsedBlockTargets.tail)

--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -211,6 +211,10 @@ object ElkEdgirGraphUtils {
             case Some(range: RangeValue) => WireColorMapper.voltageRangeToColor(range)
             case _ => None
           }
+        case Some("GroundLink") => compiler.getParamValue(edge.path.asIndirect + "voltage") match {
+            case Some(range: RangeValue) => WireColorMapper.voltageRangeToColor(range)
+            case _ => None
+          }
         case _ => None
       }
     }
@@ -253,6 +257,10 @@ object ElkEdgirGraphUtils {
       }
       linkTypeOpt.map(_.toSimpleString) match {
         case Some("VoltageLink") => compiler.getParamValue(edge.path.asIndirect + "voltage") match {
+            case Some(range: RangeValue) => WireLabelMapper.voltageRangeToString(range)
+            case _ => None
+          }
+        case Some("GroundLink") => compiler.getParamValue(edge.path.asIndirect + "voltage") match {
             case Some(range: RangeValue) => WireLabelMapper.voltageRangeToString(range)
             case _ => None
           }

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -1,0 +1,31 @@
+package edg_ide.edgir_graph
+
+import scala.collection.SeqMap
+
+/**
+  * Given a map of (group names -> node names in that group), creates a node for each group,
+  * then moves prior nodes in a group into that node.
+  * Edges between nodes of the same group are moved into the group node, while edges between nodes
+  * are transformed into tunnels (implemented as degenerate edges)
+  */
+class GroupingTransform {
+  def apply(container: EdgirGraph.EdgirNode, groups: SeqMap[String, Seq[String]]) = {
+    val nodeToGroup = groups.flatMap { case (groupName, members) =>
+      members.map(Seq(_) -> groupName)  // convert to pathname
+    }
+    val groupedNodes = container.members.map { case (pathName, node) =>
+      nodeToGroup.getOrElse(pathName, None) -> node
+    }.groupBy(_._1)
+    val groupedEdges = container.edges.flatMap { edge =>
+      val srcGroup = nodeToGroup.getOrElse(edge.source, None)
+      val dstGroup = nodeToGroup.getOrElse(edge.target, None)
+      if (srcGroup == dstGroup) { // if in same group, move to group
+        Seq(srcGroup -> edge)
+      } else { // else create degenerate edge / tunnel
+        Seq(None -> edge)
+      }
+    }.groupBy(_._1)
+
+//    val newContainerMembers =
+  }
+}

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -2,36 +2,44 @@ package edg_ide.edgir_graph
 
 import scala.collection.SeqMap
 
-/**
-  * Given a map of (group names -> node names in that group), creates a node for each group,
-  * then moves prior nodes in a group into that node.
-  * Edges between nodes of the same group are moved into the group node, while edges between nodes
+/** Given a map of (group names -> node names in that group), creates a node for each group, then moves prior nodes in a
+  * group into that node. Edges between nodes of the same group are moved into the group node, while edges between nodes
   * are transformed into tunnels (implemented as degenerate edges)
   */
 class GroupingTransform {
-  def apply(container: EdgirGraph.EdgirNode, groups: SeqMap[String, Seq[String]]) = {
+  def apply(container: EdgirGraph.EdgirNode, groups: SeqMap[String, Seq[String]]): EdgirGraph.EdgirNode = {
     val nodeToGroup = groups.flatMap { case (groupName, members) =>
-      members.map(Seq(_) -> groupName)  // convert to pathname
+      members.map(Seq(_) -> groupName) // convert to pathname
     }
-    val groupedNodes = container.members.map { case (pathName, node) =>
-      nodeToGroup.getOrElse(pathName, None) -> node
-    }.groupBy(_._1)
+    val groupedNodes = container.members.toSeq.map { case (pathName, node) => // toSeq conversion preserves order
+      nodeToGroup.getOrElse(pathName, None) -> (pathName -> node)
+    }.groupBy(_._1).view.mapValues(_.map(_._2).to(SeqMap))
+
     val groupedEdges = container.edges.flatMap { edge =>
       val srcGroup = nodeToGroup.getOrElse(edge.source, None)
       val dstGroup = nodeToGroup.getOrElse(edge.target, None)
       if (srcGroup == dstGroup) { // if in same group, move to group
         Seq(srcGroup -> edge)
       } else { // else create degenerate edge / tunnel
-        Seq(None -> edge)
+        Seq(
+          srcGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = edge.source, target = edge.source),
+          dstGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = edge.target, target = edge.target),
+        )
       }
-    }.groupBy(_._1)
+    }.groupBy(_._1).view.mapValues(_.map(_._2))
 
-//    val newContainerMembers =
+    val groupsMembers = groups.keys.map { groupName =>
+      Seq(groupName) -> EdgirGraph.EdgirNode(
+        data = container.data,
+        members = groupedNodes.getOrElse(groupName, SeqMap()),
+        edges = groupedEdges.getOrElse(groupName, Seq())
+      )
+    }
 
     EdgirGraph.EdgirNode(
       data = container.data,
-      members = ???,
-      edges = ???
+      members = groupedNodes.getOrElse(None, SeqMap()) ++ groupsMembers,
+      edges = groupedEdges.getOrElse(None, Seq())
     )
   }
 }

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -27,5 +27,11 @@ class GroupingTransform {
     }.groupBy(_._1)
 
 //    val newContainerMembers =
+
+    EdgirGraph.EdgirNode(
+      data = container.data,
+      members = ???,
+      edges = ???
+    )
   }
 }

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -16,8 +16,8 @@ class GroupingTransform {
     }.groupBy(_._1).view.mapValues(_.map(_._2).to(SeqMap))
 
     val groupedEdges = container.edges.flatMap { edge =>
-      val srcGroup = nodeToGroup.getOrElse(edge.source, None)
-      val dstGroup = nodeToGroup.getOrElse(edge.target, None)
+      val srcGroup = nodeToGroup.getOrElse(Seq(edge.source.head), None)
+      val dstGroup = nodeToGroup.getOrElse(Seq(edge.target.head), None)
       if (srcGroup == dstGroup) { // if in same group, move to group
         Seq(srcGroup -> edge)
       } else { // else create degenerate edge / tunnel

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -6,7 +6,7 @@ import scala.collection.SeqMap
   * group into that node. Edges between nodes of the same group are moved into the group node, while edges between nodes
   * are transformed into tunnels (implemented as degenerate edges)
   */
-class GroupingTransform {
+object GroupingTransform {
   def apply(container: EdgirGraph.EdgirNode, groups: SeqMap[String, Seq[String]]): EdgirGraph.EdgirNode = {
     val nodeToGroup = groups.flatMap { case (groupName, members) =>
       members.map(Seq(_) -> groupName) // convert to pathname

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -212,15 +212,27 @@ object HierarchyGraphElk {
       4,
       Set(LibraryPath("edg.electronics_model.VoltagePorts.VoltageLink"))
     )
+    val blockGroupings = block.meta match {
+      case Some(meta) => meta.meta.members.get.node.get("block_group") match {
+          case Some(meta) => meta.meta.members.get.node.map { case (name, group) =>
+              name -> group.meta.textLeaf.get.split(',').map(_.strip()).toSeq
+            }
+          case None => Seq()
+        }
+      case None => Seq()
+    }
     val transformedGraph = highFanoutTransform(
-      CollapseLinkTransform(
-        CollapseBridgeTransform(
-          InferEdgeDirectionTransform(
-            SimplifyPortTransform(
-              PruneDepthTransform(edgirGraph, depth)
+      GroupingTransform(
+        CollapseLinkTransform(
+          CollapseBridgeTransform(
+            InferEdgeDirectionTransform(
+              SimplifyPortTransform(
+                PruneDepthTransform(edgirGraph, depth)
+              )
             )
           )
-        )
+        ),
+        blockGroupings.to(SeqMap)
       )
     )
 

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -210,7 +210,10 @@ object HierarchyGraphElk {
     val edgirGraph = EdgirGraph.blockToNode(blockPath, block)
     val highFanoutTransform = new RemoveHighFanoutEdgeTransform(
       4,
-      Set(LibraryPath("edg.electronics_model.VoltagePorts.VoltageLink"))
+      Set(
+        LibraryPath("edg.electronics_model.VoltagePorts.VoltageLink"),
+        LibraryPath("edg.electronics_model.GroundPort.GroundLink")
+      )
     )
     val blockGroupings = block.meta match {
       case Some(meta) => meta.meta.members.get.node.get("block_group") match {

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -216,7 +216,7 @@ object HierarchyGraphElk {
       )
     )
     val blockGroupings = block.meta match {
-      case Some(meta) => meta.meta.members.get.node.get("block_group") match {
+      case Some(meta) => meta.meta.members.get.node.get("_block_diagram_grouping") match {
           case Some(meta) => meta.meta.members.get.node.map { case (name, group) =>
               name -> group.meta.textLeaf.get.split(',').map(_.strip()).toSeq
             }

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -209,7 +209,7 @@ object HierarchyGraphElk {
     // In the future, maybe this will also update or filter the design tree.
     val edgirGraph = EdgirGraph.blockToNode(blockPath, block)
     val highFanoutTransform = new RemoveHighFanoutEdgeTransform(
-      4,
+      6,
       Set(
         LibraryPath("edg.electronics_model.VoltagePorts.VoltageLink"),
         LibraryPath("edg.electronics_model.GroundPort.GroundLink")

--- a/src/main/scala/edg_ide/edgir_graph/InferEdgeDirectionTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/InferEdgeDirectionTransform.scala
@@ -22,8 +22,9 @@ object InferEdgeDirectionTransform {
   def sourcePorts(link: LinkWrapper, ports: Map[String, Set[Seq[String]]]): Set[Seq[String]] = {
     // TODO these should be in the IR, perhaps as metadata, instead of hardcoded in the viz code
     val sources = Set(
+      "ref", // gnd
       "source",
-      "single_sources",
+      "sources",
       "driver",
       "host",
       "master",
@@ -31,6 +32,7 @@ object InferEdgeDirectionTransform {
       "controller" // CAN logic
     )
     val sinks = Set(
+      "gnds",
       "sink",
       "sinks",
       "crystal",
@@ -38,7 +40,8 @@ object InferEdgeDirectionTransform {
       "devices", // SWD, USB
       "targets", // I2C
       "peripherals", // SPI
-      "transceiver" // CAN logic
+      "transceiver", // CAN logic
+      "target_receiver", // I2S
     )
     val bidirs = Set(
       "bidirs",
@@ -46,7 +49,8 @@ object InferEdgeDirectionTransform {
       "passives",
       "a",
       "b", // UART
-      "nodes" // CAN diff
+      "nodes", // CAN diff
+      "pad", // touch
     )
     val allKnownPorts = sources ++ sinks ++ bidirs
 

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -10,8 +10,7 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
   behavior.of("GroupingTransform")
 
   it should "no-op" in {
-    val grouper = new GroupingTransform {}
-    val transformed = grouper(
+    val transformed = GroupingTransform(
       InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
       SeqMap()
     )
@@ -20,8 +19,7 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
   }
 
   it should "group nodes including internal edges" in {
-    val grouper = new GroupingTransform {}
-    val transformed = grouper(
+    val transformed = GroupingTransform(
       InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
       SeqMap("group" -> Seq("source", "sink", "link"))
     )
@@ -33,8 +31,7 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
   }
 
   it should "group nodes and convert inter-group edges to degenerate edges" in {
-    val grouper = new GroupingTransform {}
-    val transformed = grouper(
+    val transformed = GroupingTransform(
       InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
       SeqMap("src_group" -> Seq("source", "link"), "snk_group" -> Seq("sink"))
     )

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -1,0 +1,26 @@
+package edg_ide.edgir_graph.tests
+
+import edg_ide.edgir_graph.InferEdgeDirectionTransform
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.SeqMap
+
+class GroupingTransformTest extends AnyFlatSpec with Matchers {
+  behavior.of("GroupingTransform")
+
+  it should "group nodes including internal edges" in {
+    val grouper = new GrouperTransform {}
+    val transformed = grouper.group(
+      InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
+      SeqMap("group" -> Seq("source", "sink"))
+    )
+
+    transformed.members should equal(
+      SeqMap("group" -> InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph))
+    )
+    transformed.edges should equal(Seq())
+  }
+
+  it should "group nodes and convert inter-group edges to degenerate edges" in {}
+}

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -11,7 +11,7 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
 
   it should "group nodes including internal edges" in {
     val grouper = new GrouperTransform {}
-    val transformed = grouper.group(
+    val transformed = grouper(
       InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
       SeqMap("group" -> Seq("source", "sink"))
     )
@@ -24,7 +24,7 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
 
   it should "group nodes and convert inter-group edges to degenerate edges" in {
     val grouper = new GrouperTransform {}
-    val transformed = grouper.group(
+    val transformed = grouper(
       InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
       SeqMap("src_group" -> Seq("source"), "snk_group" -> Seq("sink"))
     )

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -1,6 +1,6 @@
 package edg_ide.edgir_graph.tests
 
-import edg_ide.edgir_graph.{GroupingTransform, InferEdgeDirectionTransform}
+import edg_ide.edgir_graph.{EdgirGraph, GroupingTransform, InferEdgeDirectionTransform}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -8,6 +8,16 @@ import scala.collection.SeqMap
 
 class GroupingTransformTest extends AnyFlatSpec with Matchers {
   behavior.of("GroupingTransform")
+
+  it should "no-op" in {
+    val grouper = new GroupingTransform {}
+    val transformed = grouper(
+      InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
+      SeqMap()
+    )
+
+    transformed should equal(InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph))
+  }
 
   it should "group nodes including internal edges" in {
     val grouper = new GroupingTransform {}
@@ -17,7 +27,7 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
     )
 
     transformed.members should equal(
-      SeqMap("group" -> InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph))
+      SeqMap(Seq("group") -> InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph))
     )
     transformed.edges should equal(Seq())
   }
@@ -29,9 +39,15 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
       SeqMap("src_group" -> Seq("source"), "snk_group" -> Seq("sink"))
     )
 
-    transformed.members(Seq("src_group")).members.keys.toSeq should equal(Seq("source"))
-    transformed.members(Seq("snk_group")).members.keys.toSeq should equal(Seq("sink"))
-    print(transformed.members(Seq("snk_group")).edges) // TODO add reference degenerate edges
+    transformed.members(Seq("src_group")).asInstanceOf[EdgirGraph.EdgirNode].members.keys.toSeq should equal(
+      Seq("source")
+    )
+    transformed.members(Seq("snk_group")).asInstanceOf[EdgirGraph.EdgirNode].members.keys.toSeq should equal(
+      Seq("sink")
+    )
+    print(
+      transformed.members(Seq("snk_group")).asInstanceOf[EdgirGraph.EdgirNode].edges
+    ) // TODO add reference degenerate edges
     transformed.edges should equal(Seq()) // should be no top edges
   }
 }

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -1,6 +1,6 @@
 package edg_ide.edgir_graph.tests
 
-import edg_ide.edgir_graph.InferEdgeDirectionTransform
+import edg_ide.edgir_graph.{GroupingTransform, InferEdgeDirectionTransform}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,7 +10,7 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
   behavior.of("GroupingTransform")
 
   it should "group nodes including internal edges" in {
-    val grouper = new GrouperTransform {}
+    val grouper = new GroupingTransform {}
     val transformed = grouper(
       InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
       SeqMap("group" -> Seq("source", "sink"))
@@ -23,15 +23,15 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
   }
 
   it should "group nodes and convert inter-group edges to degenerate edges" in {
-    val grouper = new GrouperTransform {}
+    val grouper = new GroupingTransform {}
     val transformed = grouper(
       InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
       SeqMap("src_group" -> Seq("source"), "snk_group" -> Seq("sink"))
     )
 
-    transformed.members("src_group").members.keys.toSeq should equal(Seq("source"))
-    transformed.members("snk_group").members.keys.toSeq should equal(Seq("sink"))
-    print(transformed.members("snk_group").edges) // TODO add reference degenerate edges
+    transformed.members(Seq("src_group")).members.keys.toSeq should equal(Seq("source"))
+    transformed.members(Seq("snk_group")).members.keys.toSeq should equal(Seq("sink"))
+    print(transformed.members(Seq("snk_group")).edges) // TODO add reference degenerate edges
     transformed.edges should equal(Seq()) // should be no top edges
   }
 }

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -22,5 +22,16 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
     transformed.edges should equal(Seq())
   }
 
-  it should "group nodes and convert inter-group edges to degenerate edges" in {}
+  it should "group nodes and convert inter-group edges to degenerate edges" in {
+    val grouper = new GrouperTransform {}
+    val transformed = grouper.group(
+      InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph),
+      SeqMap("src_group" -> Seq("source"), "snk_group" -> Seq("sink"))
+    )
+
+    transformed.members("src_group").members.keys.toSeq should equal(Seq("source"))
+    transformed.members("snk_group").members.keys.toSeq should equal(Seq("sink"))
+    print(transformed.members("snk_group").edges) // TODO add reference degenerate edges
+    transformed.edges should equal(Seq()) // should be no top edges
+  }
 }


### PR DESCRIPTION
Experimental block diagram transform that groups blocks according to user-defined metadata. Helps with block diagram readability with user-defined groupings instead of 100 blocks of spaghetti.

Also fixes a bug where non-directioned edges were pruned out, and adds support for new link port names and the new Ground link.