### PR TITLE
Improved port side inference by incoming edges for block diagram layout

### DIFF
--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -14,6 +14,10 @@ sealed trait NodeDataWrapper {
   def path: DesignPath
 }
 
+case class GroupWrapper(path: DesignPath, name: String) extends NodeDataWrapper {
+  override def toString: String = "" // no type name for groups
+}
+
 case class BlockWrapper(path: DesignPath, blockLike: elem.BlockLike) extends NodeDataWrapper {
   override def toString: String = blockLike.`type` match {
     case elem.BlockLike.Type.Hierarchy(block) =>

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -224,7 +224,6 @@ object EdgirGraph {
     case elem.PortLike.Is.Bundle(port) => Seq(name -> portLikeToPort(path, portLike))
     case elem.PortLike.Is.LibElem(port) => Seq(name -> portLikeToPort(path, portLike))
     case elem.PortLike.Is.Array(array) =>
-      Seq(name -> portLikeToPort(path, portLike))
       array.getPorts.ports.toSeqMap.toSeq.flatMap { case (subname, subport) =>
         expandPortsWithNames(path + subname, name :+ subname, subport)
       }

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -1,13 +1,13 @@
 package edg_ide.edgir_graph
 
-import scala.collection.SeqMap
+import edg.EdgirUtils.SimpleLibraryPath
+import edg.util.MapUtils
+import edg.wir.DesignPath
+import edg.wir.ProtoUtil._
 import edgir.elem.elem
 import edgir.expr.expr
-import edg.wir.DesignPath
-import edg.EdgirUtils.SimpleLibraryPath
-import edg.ExprBuilder.Ref
-import edg.util.MapUtils
-import edg.wir.ProtoUtil._
+
+import scala.collection.SeqMap
 
 // Should be an union type, but not supported in Scala, so here's wrappers =(
 sealed trait NodeDataWrapper {

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -137,7 +137,7 @@ object EdgirGraph {
         val allMembers = MapUtils
           .mergeSeqMapSafe( // arrays not collapse
             block.ports.toSeqMap.flatMap { case (name, port) =>
-              expandPortsWithNames(path + name, Seq(name), port, true)
+              expandPortsWithNames(path + name, Seq(name), port)
             },
             block.blocks.toSeqMap.map { case (name, subblock) =>
               Seq(name) -> blockLikeToNode(path + name, subblock)
@@ -168,7 +168,7 @@ object EdgirGraph {
         val allMembers = MapUtils
           .mergeSeqMapSafe(
             link.ports.toSeqMap.flatMap { case (name, port) =>
-              expandPortsWithNames(path + name, Seq(name), port, false)
+              expandPortsWithNames(path + name, Seq(name), port)
             }, // arrays collapsed
             link.links.toSeqMap.map { case (name, sublink) =>
               Seq(name) -> linkLikeToNode(path + name, sublink)
@@ -185,7 +185,7 @@ object EdgirGraph {
         val allMembers = MapUtils
           .mergeSeqMapSafe(
             link.ports.toSeqMap.flatMap { case (name, port) =>
-              expandPortsWithNames(path + name, Seq(name), port, false)
+              expandPortsWithNames(path + name, Seq(name), port)
             }, // arrays collapsed
             link.links.toSeqMap.map { case (name, sublink) =>
               Seq(name) -> linkLikeToNode(path + name, sublink)
@@ -214,18 +214,16 @@ object EdgirGraph {
   def expandPortsWithNames(
       path: DesignPath,
       name: Seq[String],
-      portLike: elem.PortLike,
-      expandArrays: Boolean
+      portLike: elem.PortLike
   ): Seq[(Seq[String], EdgirPort)] = portLike.is match {
     case elem.PortLike.Is.Port(port) => Seq(name -> portLikeToPort(path, portLike))
     case elem.PortLike.Is.Bundle(port) => Seq(name -> portLikeToPort(path, portLike))
     case elem.PortLike.Is.LibElem(port) => Seq(name -> portLikeToPort(path, portLike))
-    case elem.PortLike.Is.Array(array) if expandArrays =>
+    case elem.PortLike.Is.Array(array) =>
       Seq(name -> portLikeToPort(path, portLike))
       array.getPorts.ports.toSeqMap.toSeq.flatMap { case (subname, subport) =>
-        expandPortsWithNames(path + subname, name :+ subname, subport, expandArrays)
+        expandPortsWithNames(path + subname, name :+ subname, subport)
       }
-    case elem.PortLike.Is.Array(array) => Seq(name -> portLikeToPort(path, portLike)) // for links
     case port => throw new NotImplementedError()
   }
 }

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -70,8 +70,8 @@ object EdgirGraph {
 
   case class EdgirEdge(
       override val data: EdgeWrapper,
-      override val source: Seq[String],
-      override val target: Seq[String]
+      override val source: Option[Seq[String]],
+      override val target: Option[Seq[String]]
   ) extends HGraphEdge[EdgeWrapper]
 
   /** Simple wrapper around blockLikeToNode that provides the blockLike wrapper around the block
@@ -110,8 +110,8 @@ object EdgirGraph {
     case Seq() => Seq( // in the loading pass, the source is the block side and the target is the link side
         EdgirEdge(
           ConnectWrapper(path + constrName, constr),
-          source = connected.getBlockPort.getRef.steps.map(_.getName), // only block and port, ignore arrays
-          target = connected.getLinkPort.getRef.steps.map(_.getName)
+          source = Some(connected.getBlockPort.getRef.steps.map(_.getName)), // only block and port, ignore arrays
+          target = Some(connected.getLinkPort.getRef.steps.map(_.getName))
         ))
     case Seq(expanded) => connectedToEdge(path, constrName, constr, expanded)
     case _ => throw new IllegalArgumentException("unexpected multiple expanded")
@@ -127,8 +127,8 @@ object EdgirGraph {
       Seq( // in the loading pass, the source is the block side and the target is the external port
         EdgirEdge(
           ConnectWrapper(path + constrName, constr),
-          source = exported.getInternalBlockPort.getRef.steps.map(_.getName),
-          target = exported.getExteriorPort.getRef.steps.map(_.getName)
+          source = Some(exported.getInternalBlockPort.getRef.steps.map(_.getName)),
+          target = Some(exported.getExteriorPort.getRef.steps.map(_.getName))
         ))
     case Seq(expanded) => exportedToEdge(path, constrName, constr, expanded)
     case _ => throw new IllegalArgumentException("unexpected multiple expanded")

--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -60,6 +60,7 @@ object ElkEdgirGraphUtils {
           case _ => None
         }
         Some(refdesStringMaybe.getOrElse(node.path.lastString))
+      case GroupWrapper(path, name) => Some(name)
       case _ => None // use default for non-blocks
     }
 

--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -183,7 +183,6 @@ object ElkEdgirGraphUtils {
         case None if targetPorts.contains(path) => Some(PortSide.WEST)
         case None =>
           Some(PortSide.EAST)
-
       }
     }
     override def edgeConv(nodePath: Seq[String], edge: HGraphEdge[EdgeWrapper]): Option[PortSide] = None

--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -1,5 +1,6 @@
 package edg_ide.edgir_graph
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.ui.JBColor
 import edg.EdgirUtils.SimpleLibraryPath
 import edg.compiler.{Compiler, RangeValue, TextValue}
@@ -74,6 +75,8 @@ object ElkEdgirGraphUtils {
 
   import org.eclipse.elk.core.options.PortSide
   object PortSideMapper extends HierarchyGraphElk.PropertyMapper[NodeDataWrapper, PortWrapper, EdgeWrapper] {
+    private val logger = Logger.getInstance(this.getClass)
+
     import org.eclipse.elk.core.options.CoreOptions.PORT_SIDE
     type PropertyType = PortSide
 
@@ -135,7 +138,7 @@ object ElkEdgirGraphUtils {
         case "Passive" => Some(PortSide.EAST) // un-directioned
 
         case port =>
-          println(s"Unknown port type $port")
+          logger.warn(s"Unknown port type $port")
           Some(PortSide.EAST)
       }
     }

--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -85,48 +85,58 @@ object ElkEdgirGraphUtils {
       val portName = port.path.steps.last
 
       portType.toSimpleString match {
+        case "Ground" => Some(PortSide.SOUTH)
+        case "GroundReference" => Some(PortSide.SOUTH)
+
         case "VoltageSource" => Some(PortSide.EAST)
-        case "VoltageSink" =>
-          portName match {
-            case "gnd" | "vss" => Some(PortSide.SOUTH)
-            case _ => Some(PortSide.NORTH)
-          }
+        case "VoltageSink" => Some(PortSide.NORTH)
 
         case "DigitalSource" => Some(PortSide.EAST)
-        case "DigitalSingleSource" => Some(PortSide.EAST)
         case "DigitalSink" => Some(PortSide.WEST)
-        case "DigitalBidir" => None
+        case "DigitalBidir" => Some(PortSide.EAST) // bidirectional
 
         case "AnalogSource" => Some(PortSide.EAST)
         case "AnalogSink" => Some(PortSide.WEST)
 
         case "CanControllerPort" => Some(PortSide.EAST)
         case "CanTransceiverPort" => Some(PortSide.WEST)
-        case "CanDiffPort" => None
+        case "CanDiffPort" => Some(PortSide.EAST) // un-directioned
 
         case "CrystalDriver" => Some(PortSide.EAST)
         case "CrystalPort" => Some(PortSide.WEST)
 
-        case "I2cMaster" => Some(PortSide.EAST)
+        case "I2cController" => Some(PortSide.EAST)
         case "I2cPullupPort" => Some(PortSide.EAST)
-        case "I2cSlave" => Some(PortSide.WEST)
+        case "I2cTarget" => Some(PortSide.WEST)
 
         case "SpeakerDriverPort" => Some(PortSide.EAST)
         case "SpeakerPort" => Some(PortSide.WEST)
 
-        case "SpiMaster" => Some(PortSide.EAST)
-        case "SpiSlave" => Some(PortSide.WEST)
+        case "SpiController" => Some(PortSide.EAST)
+        case "SpiPeripheral" => Some(PortSide.WEST)
 
         case "SwdHostPort" => Some(PortSide.EAST)
         case "SwdTargetPort" => Some(PortSide.WEST)
 
-        case "UartPrt" => None
+        case "UartPort" => Some(PortSide.EAST) // un-directioned
 
         case "UsbHostPort" => Some(PortSide.EAST)
         case "UsbDevicePort" => Some(PortSide.WEST)
-        case "UsbPassivePort" => None
+        case "UsbPassivePort" => Some(PortSide.WEST)
 
-        case _ => None
+        case "I2sController" => Some(PortSide.EAST)
+        case "I2sTargetReceiver" => Some(PortSide.WEST)
+
+        case "TouchDriver" => Some(PortSide.EAST)
+        case "TouchPadPort" => Some(PortSide.WEST)
+
+        case "UsbCcPort" => Some(PortSide.EAST) // un-directioned
+
+        case "Passive" => Some(PortSide.EAST) // un-directioned
+
+        case port =>
+          println(s"Unknown port type $port")
+          Some(PortSide.EAST)
       }
     }
     override def edgeConv(edge: EdgeWrapper): Option[PortSide] = None

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -30,7 +30,7 @@ object GroupingTransform {
 
     val groupsMembers = groups.keys.map { groupName =>
       Seq(groupName) -> EdgirGraph.EdgirNode(
-        data = container.data,
+        data = GroupWrapper(container.data.path, groupName),
         members = groupedNodes.getOrElse(groupName, SeqMap()),
         edges = groupedEdges.getOrElse(groupName, Seq())
       )

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -16,14 +16,14 @@ object GroupingTransform {
     }.groupBy(_._1).view.mapValues(_.map(_._2).to(SeqMap))
 
     val groupedEdges = container.edges.flatMap { edge =>
-      val srcGroup = nodeToGroup.getOrElse(Seq(edge.source.head), None)
-      val dstGroup = nodeToGroup.getOrElse(Seq(edge.target.head), None)
-      if (srcGroup == dstGroup) { // if in same group, move to group
-        Seq(srcGroup -> edge)
-      } else { // else create degenerate edge / tunnel
+      val srcGroup = edge.source.map(source => nodeToGroup.getOrElse(Seq(source.head), None))
+      val dstGroup = edge.target.map(target => nodeToGroup.getOrElse(Seq(target.head), None))
+      if (srcGroup == dstGroup || srcGroup.isEmpty || dstGroup.isEmpty) { // if in same group, move to group
+        Seq(srcGroup.getOrElse(dstGroup) -> edge)
+      } else { // else create tunnel
         Seq(
-          srcGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = edge.source, target = edge.source),
-          dstGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = edge.target, target = edge.target),
+          srcGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = edge.source, target = None),
+          dstGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = None, target = edge.target),
         )
       }
     }.groupBy(_._1).view.mapValues(_.map(_._2))

--- a/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/GroupingTransform.scala
@@ -18,13 +18,26 @@ object GroupingTransform {
     val groupedEdges = container.edges.flatMap { edge =>
       val srcGroup = edge.source.map(source => nodeToGroup.getOrElse(Seq(source.head), None))
       val dstGroup = edge.target.map(target => nodeToGroup.getOrElse(Seq(target.head), None))
-      if (srcGroup == dstGroup || srcGroup.isEmpty || dstGroup.isEmpty) { // if in same group, move to group
+      if (srcGroup == dstGroup) { // if in same group, move to group
         Seq(srcGroup.getOrElse(dstGroup) -> edge)
       } else { // else create tunnel
-        Seq(
-          srcGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = edge.source, target = None),
-          dstGroup -> EdgirGraph.EdgirEdge(data = edge.data, source = None, target = edge.target),
-        )
+        val sourceOpt = edge.source match {
+          case Some(source) => Seq(srcGroup.getOrElse(None) -> EdgirGraph.EdgirEdge(
+              data = edge.data,
+              source = Some(source),
+              target = None
+            ))
+          case _ => Seq()
+        }
+        val targetOpt = edge.target match {
+          case Some(target) => Seq(dstGroup.getOrElse(None) -> EdgirGraph.EdgirEdge(
+              data = edge.data,
+              source = None,
+              target = Some(target)
+            ))
+          case _ => Seq()
+        }
+        sourceOpt ++ targetOpt
       }
     }.groupBy(_._1).view.mapValues(_.map(_._2))
 

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraph.scala
@@ -8,13 +8,11 @@ import scala.collection.SeqMap
 // this is where we are
 trait HGraphNodeMember[+NodeType, +PortType, +EdgeType] {}
 
-// TODO support undirected edges?
+// directed edge, if only one of source or target is present, it is a tunnel
 trait HGraphEdge[EdgeType] {
   val data: EdgeType
-  val source: Seq[String]
-  val target: Seq[String]
-
-  def ports: Seq[String] = source ++ target
+  val source: Option[Seq[String]]
+  val target: Option[Seq[String]]
 }
 
 trait HGraphPort[PortType] extends HGraphNodeMember[Nothing, PortType, Nothing] {

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -162,6 +162,14 @@ object HierarchyGraphElk {
     val myElkElements =
       myElkPorts ++ myElkChildren // unify namespace, data structure should prevent conflicts
     node.edges.foreach { edge =>
+      (edge.source, edge.target) match {
+        case (None, None) => logger.warn(s"empty edge")
+        case (None, Some(target)) =>
+        case (Some(source), None) =>
+        case (Some(source), Some(target))
+
+      }
+
       (myElkElements.get(edge.source), myElkElements.get(edge.target)) match {
         case (None, None) => logger.warn(s"edge with invalid source ${edge.source} and target ${edge.target}")
         case (None, _) => logger.warn(s"edge with invalid source ${edge.source}")

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -8,7 +8,7 @@ import edgir.elem.elem.HierarchyBlock
 import org.eclipse.elk.alg.layered.options.{LayeredMetaDataProvider, LayeredOptions}
 import org.eclipse.elk.core.RecursiveGraphLayoutEngine
 import org.eclipse.elk.core.data.LayoutMetaDataService
-import org.eclipse.elk.core.math.KVector
+import org.eclipse.elk.core.math.{ElkPadding, KVector}
 import org.eclipse.elk.core.options._
 import org.eclipse.elk.core.util.BasicProgressMonitor
 import org.eclipse.elk.graph._
@@ -64,7 +64,7 @@ object HierarchyGraphElk {
       )
     )
     node.setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.minimumSizeWithPorts)
-    node.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(200, 20))
+    node.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(200, 30))
 
     node
   }
@@ -118,6 +118,7 @@ object HierarchyGraphElk {
         elkNode.setProperty(mapper.property, mapperResult)
       }
     }
+    elkNode.setProperty(CoreOptions.NODE_LABELS_PADDING, new ElkPadding(15))
 
     val title = Option(elkNode.getProperty(TitleProperty)).getOrElse(name)
     ElkGraphUtil

--- a/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutLinkTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutLinkTransform.scala
@@ -34,12 +34,12 @@ class RemoveHighFanoutLinkTransform(minConnects: Int, allowedLinkTypes: Set[Libr
     val allNodeEdges: Map[Seq[String], Seq[(Seq[String], DesignPath, EdgirEdge)]] = node.edges
       .collect { edge =>
         val sourceEdge = edge.source match {
-          case sourceNode :: sourceTail =>
+          case Some(sourceNode :: sourceTail) =>
             Seq((Seq(sourceNode), (sourceTail, node.data.path ++ edge.target, edge)))
           case _ => Seq()
         }
         val targetEdge = edge.target match {
-          case targetNode :: targetTail =>
+          case Some(targetNode :: targetTail) =>
             Seq((Seq(targetNode), (targetTail, node.data.path ++ edge.source, edge)))
           case _ => Seq()
         }
@@ -60,15 +60,15 @@ class RemoveHighFanoutLinkTransform(minConnects: Int, allowedLinkTypes: Set[Libr
       .toMap
 
     val filteredEdges = node.edges.map {
-      // Transform to degenerate edges
+      // Transform to tunnels
       case EdgirEdge(data, Seq(sourceNode, _*), target)
         if highFanoutLinkNameWraps.contains(Seq(sourceNode)) =>
         val linkWrap = highFanoutLinkNameWraps(Seq(sourceNode))
-        EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), target, target)
+        EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), None, target)
       case EdgirEdge(data, source, Seq(targetNode, _*))
         if highFanoutLinkNameWraps.contains(Seq(targetNode)) =>
         val linkWrap = highFanoutLinkNameWraps(Seq(targetNode))
-        EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), source, source)
+        EdgirEdge(EdgeLinkWrapper(linkWrap.path, linkWrap.linkLike), source, None)
       case edge => edge
     }
 

--- a/src/main/scala/edg_ide/edgir_graph/SimplifyPortTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/SimplifyPortTransform.scala
@@ -31,12 +31,12 @@ object SimplifyPortTransform {
 
   def apply(node: EdgirGraph.EdgirNode): EdgirGraph.EdgirNode = {
     val newEdges = node.edges.flatMap { edge =>
-      val sourceSimplified = simplify(edge.source, Seq(), node)
-      val targetSimplified = simplify(edge.target, Seq(), node)
+      val sourceSimplified = edge.source.flatMap(simplify(_, Seq(), node))
+      val targetSimplified = edge.target.flatMap(simplify(_, Seq(), node))
       (sourceSimplified, targetSimplified) match {
         case (Some(sourceSimplified), Some(targetSimplified)) =>
           Some(
-            EdgirGraph.EdgirEdge(edge.data, sourceSimplified, targetSimplified)
+            EdgirGraph.EdgirEdge(edge.data, Some(sourceSimplified), Some(targetSimplified))
           )
         case (None, None) =>
           logger.warn(s"unknown source ${edge.source} and target ${edge.target}, discarding edge")

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -475,11 +475,14 @@ class CompileProcessHandler(
                 ElkEdgirGraphUtils.PortArrayMapper,
                 new ElkEdgirGraphUtils.WireColorMapper(compiler),
                 new ElkEdgirGraphUtils.WireLabelMapper(compiler),
+                new ElkEdgirGraphUtils.PortSideMapper(),
+                ElkEdgirGraphUtils.PortConstraintMapper,
               ),
               childMappers = Seq( // because inner blocks are deduplicated, don't run instance-specific mappers
                 new ElkEdgirGraphUtils.TitleMapper(compiler),
                 ElkEdgirGraphUtils.DesignPathMapper,
                 ElkEdgirGraphUtils.PortArrayMapper,
+                // TODO add the port side mapper - it crashes the PDF generation
               ),
               options.pdfFile
             )

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -517,6 +517,8 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
             ElkEdgirGraphUtils.PortArrayMapper,
             new ElkEdgirGraphUtils.WireColorMapper(compiler),
             new ElkEdgirGraphUtils.WireLabelMapper(compiler),
+            ElkEdgirGraphUtils.PortSideMapper,
+            ElkEdgirGraphUtils.PortConstraintMapper,
           )
         )
 

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -517,7 +517,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
             ElkEdgirGraphUtils.PortArrayMapper,
             new ElkEdgirGraphUtils.WireColorMapper(compiler),
             new ElkEdgirGraphUtils.WireLabelMapper(compiler),
-            ElkEdgirGraphUtils.PortSideMapper,
+            new ElkEdgirGraphUtils.PortSideMapper(),
             ElkEdgirGraphUtils.PortConstraintMapper,
           )
         )

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -279,7 +279,7 @@ class LibraryPreview(project: Project) extends JPanel {
           val blockGraph = HierarchyGraphElk.HGraphNodeToElk(
             transformedGraph,
             "", // no name, the class is already shown as the class name
-            Seq(ElkEdgirGraphUtils.PortSideMapper, ElkEdgirGraphUtils.PortConstraintMapper),
+            Seq(ElkEdgirGraphUtils.SimplePortSideMapper, ElkEdgirGraphUtils.PortConstraintMapper),
             true
           ) // need to make a root so root doesn't have ports
 

--- a/src/test/scala/edg_ide/edgir_graph/tests/CollapseLinkTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/CollapseLinkTransformTest.scala
@@ -14,8 +14,8 @@ class CollapseLinkTransformTest extends AnyFlatSpec with Matchers {
     transformed.edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgeLinkWrapper(DesignPath() + "link", EdgirTestUtils.Dummy.LinkLike),
-        source = Seq("source", "port"),
-        target = Seq("sink", "port")
+        source = Some(Seq("source", "port")),
+        target = Some(Seq("sink", "port"))
       ),
     ))
     transformed.members.keys.toSeq should equal(Seq(Seq("source"), Seq("sink")))

--- a/src/test/scala/edg_ide/edgir_graph/tests/CollapseNodeTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/CollapseNodeTransformTest.scala
@@ -22,8 +22,8 @@ class CollapseNodeTransformTest extends AnyFlatSpec with Matchers {
     transformed.edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "merged"),
-        source = Seq("source", "port"),
-        target = Seq("sink", "port")
+        source = Some(Seq("source", "port")),
+        target = Some(Seq("sink", "port"))
       ),
     ))
     transformed.members.keys.toSeq should equal(Seq(Seq("source"), Seq("sink")))

--- a/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
@@ -285,10 +285,16 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
           data = BlockWrapper(DesignPath() + "block", designIr.blocks("block")),
           members = SeqMap(
             Seq("ports", "0") -> EdgirGraph.EdgirPort(
-              data = PortWrapper(DesignPath() + "block" + "ports" + "0", blockIr.ports("ports").getArray.getPorts.ports.head.getValue)
+              data = PortWrapper(
+                DesignPath() + "block" + "ports" + "0",
+                blockIr.ports("ports").getArray.getPorts.ports.head.getValue
+              )
             ),
             Seq("ports", "test") -> EdgirGraph.EdgirPort(
-              data = PortWrapper(DesignPath() + "block" + "ports" + "test", blockIr.ports("ports").getArray.getPorts.ports.last.getValue)
+              data = PortWrapper(
+                DesignPath() + "block" + "ports" + "test",
+                blockIr.ports("ports").getArray.getPorts.ports.last.getValue
+              )
             ),
           ),
           edges = Seq()

--- a/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
@@ -284,8 +284,11 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
         Seq("block") -> EdgirGraph.EdgirNode(
           data = BlockWrapper(DesignPath() + "block", designIr.blocks("block")),
           members = SeqMap(
-            Seq("ports") -> EdgirGraph.EdgirPort(
-              data = PortWrapper(DesignPath() + "block" + "ports", blockIr.ports("ports"))
+            Seq("ports", "0") -> EdgirGraph.EdgirPort(
+              data = PortWrapper(DesignPath() + "block" + "ports" + "0", blockIr.ports("ports").getArray.getPorts.ports.head.getValue)
+            ),
+            Seq("ports", "test") -> EdgirGraph.EdgirPort(
+              data = PortWrapper(DesignPath() + "block" + "ports" + "test", blockIr.ports("ports").getArray.getPorts.ports.last.getValue)
             ),
           ),
           edges = Seq()
@@ -295,8 +298,8 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
     )
 
     // These checks allow better error localization
-    edgirGraph.members(Seq("block")).asInstanceOf[EdgirNode].members(Seq("ports")) should equal(
-      refGraph.members(Seq("block")).asInstanceOf[EdgirNode].members(Seq("ports"))
+    edgirGraph.members(Seq("block")).asInstanceOf[EdgirNode].members(Seq("ports", "0")) should equal(
+      refGraph.members(Seq("block")).asInstanceOf[EdgirNode].members(Seq("ports", "0"))
     )
 
     // The final catch-all check

--- a/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/EdgirGraphTest.scala
@@ -123,13 +123,13 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
       edges = Seq(
         EdgirGraph.EdgirEdge(
           data = ConnectWrapper(DesignPath() + "connect_source", blockIr.constraints("connect_source")),
-          source = Seq("source", "port"),
-          target = Seq("link", "source")
+          source = Some(Seq("source", "port")),
+          target = Some(Seq("link", "source"))
         ),
         EdgirGraph.EdgirEdge(
           data = ConnectWrapper(DesignPath() + "connect_sink", blockIr.constraints("connect_sink")),
-          source = Seq("sink", "port"),
-          target = Seq("link", "sink")
+          source = Some(Seq("sink", "port")),
+          target = Some(Seq("link", "sink"))
         ),
       )
     )
@@ -217,8 +217,8 @@ class EdgirGraphTest extends AnyFlatSpec with Matchers {
           edges = Seq(
             EdgirGraph.EdgirEdge(
               data = ConnectWrapper(DesignPath() + "outer" + "export", outerBlockIr.constraints("export")),
-              source = Seq("inner", "port"),
-              target = Seq("port")
+              source = Some(Seq("inner", "port")),
+              target = Some(Seq("port"))
             ),
           )
         ),

--- a/src/test/scala/edg_ide/edgir_graph/tests/EdgirTestUtils.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/EdgirTestUtils.scala
@@ -83,13 +83,13 @@ object EdgirTestUtils {
       edges = Seq(
         EdgirGraph.EdgirEdge(
           data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_source"),
-          source = Seq("source", "port"),
-          target = Seq("link", "source")
+          source = Some(Seq("source", "port")),
+          target = Some(Seq("link", "source"))
         ),
         EdgirGraph.EdgirEdge(
           data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_sink"),
-          source = Seq("sink", "port"),
-          target = Seq("link", "sinks", "0")
+          source = Some(Seq("sink", "port")),
+          target = Some(Seq("link", "sinks", "0"))
         ),
       )
     )
@@ -119,8 +119,8 @@ object EdgirTestUtils {
           edges = Seq(
             EdgirGraph.EdgirEdge(
               data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "source" + "export_inner"),
-              source = Seq("inner", "port"),
-              target = Seq("port")
+              source = Some(Seq("inner", "port")),
+              target = Some(Seq("port"))
             )
           )
         ),
@@ -143,8 +143,8 @@ object EdgirTestUtils {
           edges = Seq(
             EdgirGraph.EdgirEdge(
               data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "sink" + "export_inner"),
-              source = Seq("inner", "port"),
-              target = Seq("port")
+              source = Some(Seq("inner", "port")),
+              target = Some(Seq("port"))
             )
           )
         ),
@@ -167,13 +167,13 @@ object EdgirTestUtils {
       edges = Seq(
         EdgirGraph.EdgirEdge(
           data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_source"),
-          source = Seq("source", "port"),
-          target = Seq("link", "source")
+          source = Some(Seq("source", "port")),
+          target = Some(Seq("link", "source"))
         ),
         EdgirGraph.EdgirEdge(
           data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_sink"),
-          source = Seq("sink", "port"),
-          target = Seq("link", "sinks", "0")
+          source = Some(Seq("sink", "port")),
+          target = Some(Seq("link", "sinks", "0"))
         ),
       )
     )

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -51,20 +51,20 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
     transformed.members(Seq("src_group")).asInstanceOf[EdgirGraph.EdgirNode].edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.TestGraphs.flatGraph.edges(0).data, // internal link for two blocks within group
-        source = Seq("source", "port"),
-        target = Seq("link", "source")
+        source = Some(Seq("source", "port")),
+        target = Some(Seq("link", "source"))
       ),
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.TestGraphs.flatGraph.edges(1).data, // degenerate edge for connection to other group
-        source = Seq("link", "sinks", "0"),
-        target = Seq("link", "sinks", "0")
+        source = Some(Seq("link", "sinks", "0")),
+        target = None
       )
     ))
     transformed.members(Seq("snk_group")).asInstanceOf[EdgirGraph.EdgirNode].edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.TestGraphs.flatGraph.edges(1).data,
-        source = Seq("sink", "port"),
-        target = Seq("sink", "port")
+        source = None,
+        target = Some(Seq("sink", "port"))
       )
     ))
     transformed.edges should equal(Seq()) // no edges left at top level

--- a/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/GroupingTransformTest.scala
@@ -1,6 +1,7 @@
 package edg_ide.edgir_graph.tests
 
-import edg_ide.edgir_graph.{EdgirGraph, GroupingTransform, InferEdgeDirectionTransform}
+import edg.wir.DesignPath
+import edg_ide.edgir_graph.{EdgirGraph, GroupWrapper, GroupingTransform, InferEdgeDirectionTransform}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -24,8 +25,13 @@ class GroupingTransformTest extends AnyFlatSpec with Matchers {
       SeqMap("group" -> Seq("source", "sink", "link"))
     )
 
+    val ref = InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph)
     transformed.members should equal(
-      SeqMap(Seq("group") -> InferEdgeDirectionTransform(EdgirTestUtils.TestGraphs.flatGraph))
+      SeqMap(Seq("group") -> EdgirGraph.EdgirNode(
+        data = GroupWrapper(DesignPath(), "group"),
+        members = ref.members,
+        edges = ref.edges
+      ))
     )
     transformed.edges should equal(Seq())
   }

--- a/src/test/scala/edg_ide/edgir_graph/tests/HierarchyGraphElkTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/HierarchyGraphElkTest.scala
@@ -55,7 +55,7 @@ class HierarchyGraphElkTest extends AnyFlatSpec with Matchers {
         SimpleEdge("edge2", source = Some(Seq("n1", "n1p1")), target = Some(Seq("n2", "n2p1"))),
       )
     )
-    val (root, elkElementsMap) = HierarchyGraphElk.HGraphNodeToElkNode(simpleGraph, "", None)
+    val (root, elkElementsMap) = HierarchyGraphElk.HGraphNodeToElkNode(simpleGraph, Seq(""), None)
 
     (root, elkElementsMap)
   }

--- a/src/test/scala/edg_ide/edgir_graph/tests/HierarchyGraphElkTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/HierarchyGraphElkTest.scala
@@ -23,8 +23,8 @@ class HierarchyGraphElkTest extends AnyFlatSpec with Matchers {
 
   case class SimpleEdge(
       override val data: String,
-      override val source: Seq[String],
-      override val target: Seq[String]
+      override val source: Option[Seq[String]],
+      override val target: Option[Seq[String]]
   ) extends HGraphEdge[String] {}
 
   behavior.of("HGraphNodeToElkNode")
@@ -51,8 +51,8 @@ class HierarchyGraphElkTest extends AnyFlatSpec with Matchers {
         )
       ),
       edges = Seq(
-        SimpleEdge("edge1", source = Seq("p1"), target = Seq("n1", "n1p1")),
-        SimpleEdge("edge2", source = Seq("n1", "n1p1"), target = Seq("n2", "n2p1")),
+        SimpleEdge("edge1", source = Some(Seq("p1")), target = Some(Seq("n1", "n1p1"))),
+        SimpleEdge("edge2", source = Some(Seq("n1", "n1p1")), target = Some(Seq("n2", "n2p1"))),
       )
     )
     val (root, elkElementsMap) = HierarchyGraphElk.HGraphNodeToElkNode(simpleGraph, "", None)

--- a/src/test/scala/edg_ide/edgir_graph/tests/InferEdgeDirectionTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/InferEdgeDirectionTransformTest.scala
@@ -15,13 +15,13 @@ class InferEdgeDirectionTransformTest extends AnyFlatSpec with Matchers {
     transformed.edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_source"),
-        source = Seq("source", "port"),
-        target = Seq("link", "source")
+        source = Some(Seq("source", "port")),
+        target = Some(Seq("link", "source"))
       ),
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_sink"),
-        source = Seq("link", "sinks", "0"),
-        target = Seq("sink", "port")
+        source = Some(Seq("link", "sinks", "0")),
+        target = Some(Seq("sink", "port"))
       ),
     ))
   }
@@ -32,28 +32,28 @@ class InferEdgeDirectionTransformTest extends AnyFlatSpec with Matchers {
     transformed.edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_source"),
-        source = Seq("source", "port"),
-        target = Seq("link", "source")
+        source = Some(Seq("source", "port")),
+        target = Some(Seq("link", "source"))
       ),
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "connect_sink"),
-        source = Seq("link", "sinks", "0"),
-        target = Seq("sink", "port")
+        source = Some(Seq("link", "sinks", "0")),
+        target = Some(Seq("sink", "port"))
       ),
     ))
 
     transformed.members(Seq("source")).asInstanceOf[EdgirNode].edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "source" + "export_inner"),
-        source = Seq("inner", "port"),
-        target = Seq("port")
+        source = Some(Seq("inner", "port")),
+        target = Some(Seq("port"))
       )
     ))
     transformed.members(Seq("sink")).asInstanceOf[EdgirNode].edges should equal(Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "sink" + "export_inner"),
-        source = Seq("port"),
-        target = Seq("inner", "port")
+        source = Some(Seq("port")),
+        target = Some(Seq("inner", "port"))
       )
     ))
   }

--- a/src/test/scala/edg_ide/edgir_graph/tests/RemoveHighFanoutLinkTransformTest.scala
+++ b/src/test/scala/edg_ide/edgir_graph/tests/RemoveHighFanoutLinkTransformTest.scala
@@ -36,18 +36,18 @@ class RemoveHighFanoutLinkTransformTest extends AnyFlatSpec with Matchers {
     edges = Seq(
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "link" + "source"),
-        source = Seq("sourceBlock", "port"),
-        target = Seq("link", "source")
+        source = Some(Seq("sourceBlock", "port")),
+        target = Some(Seq("link", "source"))
       ),
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "link" + "source"),
-        source = Seq("sinkBlock1", "port"),
-        target = Seq("link", "sink", "0")
+        source = Some(Seq("sinkBlock1", "port")),
+        target = Some(Seq("link", "sink", "0"))
       ),
       EdgirGraph.EdgirEdge(
         data = EdgirTestUtils.Dummy.ConnectWrapper(DesignPath() + "link" + "source"),
-        source = Seq("sinkBlock2", "port"),
-        target = Seq("link", "sink", "1")
+        source = Some(Seq("sinkBlock2", "port")),
+        target = Some(Seq("link", "sink", "1"))
       ),
     )
   )


### PR DESCRIPTION
- Change edge data structure to have optional target and source - this represents directioned tunnels, update transforms to deal with this
- Fix port directions for ground and a few ports that have changed names
- Refactor mappers to take in the node, port, and edge instead of their contained data structures
- Pass current path through to mappers and in building the elk node structure
- Write group name to group blocks
- Expand array ports instead of using aggregate ports
  - This probably breaks interactive connects - needs work to think about how the new-port UI would coexist with expanded array ports
- Update PDFer to use improved port side inference on top-level only. Some bug is preventing this from working on inner blocks.