### PR TITLE
Fix block diagram viewer on non-hdl repos

### DIFF
--- a/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
+++ b/src/main/scala/edg_ide/edgir_graph/ElkEdgirGraphUtils.scala
@@ -110,6 +110,7 @@ object ElkEdgirGraphUtils {
         case "CanControllerPort" => Some(PortSide.EAST)
         case "CanTransceiverPort" => Some(PortSide.WEST)
         case "CanDiffPort" => None
+        case "CanPassivePort" => Some(PortSide.EAST)
 
         case "CrystalDriver" => Some(PortSide.EAST)
         case "CrystalPort" => Some(PortSide.WEST)

--- a/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
+++ b/src/main/scala/edg_ide/edgir_graph/HierarchyGraphElk.scala
@@ -224,13 +224,7 @@ object HierarchyGraphElk {
     // For now, this only updates the graph visualization, which can change with focus.
     // In the future, maybe this will also update or filter the design tree.
     val edgirGraph = EdgirGraph.blockToNode(blockPath, block)
-    val highFanoutTransform = new RemoveHighFanoutEdgeTransform(
-      6,
-      Set(
-        LibraryPath("edg.electronics_model.VoltagePorts.VoltageLink"),
-        LibraryPath("edg.electronics_model.GroundPort.GroundLink")
-      )
-    )
+    val highFanoutTransform = new RemoveHighFanoutEdgeTransform(5, Set("VoltageLink", "GroundLink"))
     val blockGroupings = block.meta match {
       case Some(meta) => meta.meta.members.get.node.get("_block_diagram_grouping") match {
           case Some(meta) => meta.meta.members.get.node.map { case (name, group) =>

--- a/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutEdgeTransform.scala
+++ b/src/main/scala/edg_ide/edgir_graph/RemoveHighFanoutEdgeTransform.scala
@@ -1,5 +1,6 @@
 package edg_ide.edgir_graph
 
+import edg.EdgirUtils.SimpleLibraryPath
 import edgir.elem.elem
 import edgir.ref.ref.LibraryPath
 import edg.wir.DesignPath
@@ -8,7 +9,7 @@ import edg_ide.edgir_graph.EdgirGraph.EdgirEdge
 /** Removes links (as edges - must run AFTER collapse - prevents weird interactions with bridge removal) that are
   * "high-fanout", based on the link type allowlist and parameterized number of sink connections.
   */
-class RemoveHighFanoutEdgeTransform(minConnects: Int, allowedLinkTypes: Set[LibraryPath]) {
+class RemoveHighFanoutEdgeTransform(minConnects: Int, allowedLinkTypeSimple: Set[String]) {
   def apply(node: EdgirGraph.EdgirNode): EdgirGraph.EdgirNode = {
     val highFanoutLinks = node.edges
       .collect { case EdgirEdge(EdgeLinkWrapper(linkPath, linkLike), source, target) =>
@@ -24,7 +25,8 @@ class RemoveHighFanoutEdgeTransform(minConnects: Int, allowedLinkTypes: Set[Libr
         (linkPath, link, linkLike, source, target) // extract elaborated link
       }
       .collect {
-        case (linkPath, link, linkLike, source, target) if allowedLinkTypes.contains(link.getSelfClass) =>
+        case (linkPath, link, linkLike, source, target)
+          if allowedLinkTypeSimple.contains(link.getSelfClass.toSimpleString) =>
           (linkPath, linkLike, source, target) // filter by type
       }
       .groupBy(_._1)


### PR DESCRIPTION
Use .toSimpleString when comparing the high fanout edge allow-list, so it's not sensitive to paths.

Also re-rune the fanout limit to 5, down from 6.