### PR TITLE
Update to IntelliJ 2025.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / intellijPluginName := "edg-ide"
 // release build versions here: https://youtrack.jetbrains.com/articles/IDEA-A-21/IDEA-Latest-Builds-And-Release-Notes
 // note, 2025.3 seemed to change the Python APIs which breaks a lot of stuff here
 ThisBuild / intellijBuild := "252.28539.13"  // 2025.2
-ThisBuild / intellijPlatform := IntelliJPlatform.IdeaCommunity
+ThisBuild / intellijPlatform := IntelliJPlatform.PyCharmCommunity
 
 lazy val edgCompiler = (project in file("PolymorphicBlocks/compiler"))  // proto imported transitively
   .enablePlugins(SbtIdeaPlugin)  // sbt-idea-plugin doesn't import properly if this isn't enabled

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbtbuildinfo.BuildInfoPlugin.autoImport.buildInfoOptions
 ThisBuild / intellijPluginName := "edg-ide"
 // release build versions here: https://youtrack.jetbrains.com/articles/IDEA-A-21/IDEA-Latest-Builds-And-Release-Notes
 // note, 2025.3 seemed to change the Python APIs which breaks a lot of stuff here
-ThisBuild / intellijBuild := "252.28539.33"  // 2025.2
+ThisBuild / intellijBuild := "252.28539.13"  // 2025.2
 ThisBuild / intellijPlatform := IntelliJPlatform.IdeaCommunity
 
 lazy val edgCompiler = (project in file("PolymorphicBlocks/compiler"))  // proto imported transitively

--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,9 @@ lazy val root = (project in file("."))
       xml.untilBuild        = "252.*"
     },
 
-    intellijVMOptions := intellijVMOptions.value.copy(
-      xmx = 4096,
-      xms = 1024
+    customIntellijVMOptions := customIntellijVMOptions.value.copy(
+      xmx = Some(4096),
+      xms = Some(1024)
     ),
   ).enablePlugins(BuildInfoPlugin)
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "4.1.17")
+addSbtPlugin("org.jetbrains.scala" % "sbt-idea-plugin" % "5.1.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.11"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,9 @@
             instance="edg_ide.ui.EdgSettingsConfigurable"
             id="edg_ide.ui.EdgSettingsConfigurable"
             displayName="EDG IDE"/>
+    <notificationGroup id="EDG IDE Notifications"
+             displayType="BALLOON"
+             key="edg_ide.ui"/>
 
     <projectService serviceImplementation="edg_ide.ui.BlockVisualizerServiceWrapper"/>
     <projectService serviceImplementation="edg_ide.ui.DseServiceWrapper"/>

--- a/src/main/scala/edg_ide/actions/EmptyBlockCacheAction.scala
+++ b/src/main/scala/edg_ide/actions/EmptyBlockCacheAction.scala
@@ -1,17 +1,14 @@
 package edg_ide.actions
 
-import com.intellij.notification.{NotificationGroup, NotificationType}
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.{AnAction, AnActionEvent}
 import edg_ide.ui.EdgCompilerService
 
 class EmptyBlockCacheAction() extends AnAction() {
-  val notificationGroup: NotificationGroup =
-    NotificationGroup.balloonGroup("edg_ide.actions.EmptyCacheAction")
-
   override def actionPerformed(event: AnActionEvent): Unit = {
     EdgCompilerService(event.getProject).pyLib.clearThisCache()
 
-    notificationGroup
+    EdgCompilerService.notificationGroup()
       .createNotification(
         s"Block Cache Emptied",
         NotificationType.INFORMATION

--- a/src/main/scala/edg_ide/actions/FocusToElementAction.scala
+++ b/src/main/scala/edg_ide/actions/FocusToElementAction.scala
@@ -11,7 +11,7 @@ import edg.ElemBuilder
 import edg.wir.DesignPath
 import edg.wir.ProtoUtil._
 import edg_ide.{EdgirUtils, PsiUtils}
-import edg_ide.ui.{BlockVisualizerService, PopupUtils}
+import edg_ide.ui.{BlockVisualizerService, EdgCompilerService, PopupUtils}
 import edg_ide.util.ExceptionNotifyImplicits.{ExceptErrorable, ExceptNotify, ExceptOption, ExceptSeq}
 import edg_ide.util.{DesignFindBlockOfTypes, exceptionPopup}
 
@@ -34,9 +34,6 @@ object FocusToElementAction {
 }
 
 class FocusToElementAction() extends AnAction() {
-  val notificationGroup: NotificationGroup =
-    NotificationGroup.balloonGroup("edg_ide.actions.NavigateToBlockAction")
-
   case class NavigateNode(desc: String, action: () => Unit) {
     override def toString: String = desc
   }
@@ -44,7 +41,7 @@ class FocusToElementAction() extends AnAction() {
   override def actionPerformed(event: AnActionEvent): Unit = {
     val editor = event.getData(CommonDataKeys.EDITOR)
     if (editor == null) {
-      notificationGroup
+      EdgCompilerService.notificationGroup()
         .createNotification("No editor", NotificationType.WARNING)
         .notify(event.getProject)
     }

--- a/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
+++ b/src/main/scala/edg_ide/runner/CompileProcessHandler.scala
@@ -26,6 +26,7 @@ import edgir.schema.schema
 import edgrpc.hdl.{hdl => edgrpc}
 
 import java.io._
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters._
 
@@ -432,7 +433,7 @@ class CompileProcessHandler(
             require(netlist.size == 1)
 
             Files.createDirectories(Paths.get(options.netlistFile).getParent)
-            val writer = new FileWriter(options.netlistFile)
+            val writer = new FileWriter(options.netlistFile, StandardCharsets.UTF_8)
             writer.write(netlist.head._2)
             writer.close()
             f"wrote ${options.netlistFile}"
@@ -456,7 +457,7 @@ class CompileProcessHandler(
             require(bom.size == 1)
 
             Files.createDirectories(Paths.get(options.bomFile).getParent)
-            val writer = new FileWriter(options.bomFile)
+            val writer = new FileWriter(options.bomFile, StandardCharsets.UTF_8)
             writer.write(bom.head._2)
             writer.close()
             f"wrote ${options.bomFile}"

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -475,13 +475,12 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
       designTree.getTree.addTreeSelectionListener(designTreeListener) // overridden when the model is updated
       designTree.setTreeCellRenderer(designTreeTreeRenderer)
       designTree.setDefaultRenderer(classOf[Object], designTreeTableRenderer)
+
+      selectPath(selectionPath)
     })
 
-    // Also update the active detail panel
-    selectPath(selectionPath)
-    detailPanel.setStale(false)
-
     updateDisplay()
+    detailPanel.setStale(false)
   }
 
   /** Sets the entire design as stale, eg if a recompile is running. Cleared with any variation of setDesign.

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -304,7 +304,7 @@ class BlockVisualizerPanel(val project: Project, toolWindow: ToolWindow) extends
 
   private var designTreeModel = new BlockTreeTableModel(project, edgir.elem.elem.HierarchyBlock())
   private val designTree = new TreeTable(designTreeModel) with ProvenTreeTableMixin
-  new TreeTableSpeedSearch(designTree)
+  TreeTableSpeedSearch.installOn(designTree)
   designTree.addMouseMotionListener(new MouseMotionListener {
     override def mouseDragged(e: MouseEvent): Unit = {} // ignored
     override def mouseMoved(e: MouseEvent): Unit = {

--- a/src/main/scala/edg_ide/ui/EdgCompilerService.scala
+++ b/src/main/scala/edg_ide/ui/EdgCompilerService.scala
@@ -1,6 +1,6 @@
 package edg_ide.ui
 
-import com.intellij.notification.NotificationGroup
+import com.intellij.notification.{NotificationGroup, NotificationGroupManager}
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.{ModalityState, ReadAction}
 import com.intellij.openapi.components.PersistentStateComponent
@@ -10,7 +10,7 @@ import com.intellij.psi.{PsiManager, PsiTreeChangeEvent, PsiTreeChangeListener}
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.jetbrains.python.psi.PyClass
 import com.jetbrains.python.psi.search.PyClassInheritorsSearch
-import edg.compiler.{Compiler, ElaborateRecord, PythonInterfaceLibrary}
+import edg.compiler.{Compiler, PythonInterfaceLibrary}
 import edg.util.{Errorable, timeExec}
 import edg.wir.Refinements
 import edg_ide.util.ExceptionNotifyImplicits.ExceptErrorable
@@ -30,6 +30,9 @@ object EdgCompilerService {
   def apply(project: Project): EdgCompilerService = {
     project.getService(classOf[EdgCompilerServiceWrapper]).asInstanceOf[EdgCompilerService]
   }
+
+  def notificationGroup(): NotificationGroup =
+    NotificationGroupManager.getInstance().getNotificationGroup("EDG IDE Notifications")
 }
 
 /** A single shared interface to Python and for running EDG compilation jobs.
@@ -39,8 +42,6 @@ object EdgCompilerService {
 class EdgCompilerService(project: Project)
     extends PersistentStateComponent[EdgCompilerServiceState]
     with Disposable {
-  val notificationGroup: NotificationGroup = NotificationGroup.balloonGroup("edg_ide.ui.EdgCompilerService")
-
   val pyLib = new PythonInterfaceLibrary()
 
   // Tracks modified classes, so the appropriate library elements can be discarded on the next refresh.

--- a/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
+++ b/src/main/scala/edg_ide/ui/EdgSettingsComponent.scala
@@ -12,10 +12,9 @@ import javax.swing.{JCheckBox, JPanel}
 class EdgSettingsComponent {
   val kicadDirectoryText = new TextFieldWithBrowseButton()
   kicadDirectoryText.addBrowseFolderListener(
-    "Choose KiCad Footprint Directory",
-    "",
     null,
     FileChooserDescriptorFactory.createSingleFolderDescriptor()
+      .withTitle("Choose KiCad Footprint Directory")
   )
   val kicadDirectoryHelp = new JBLabel(
     "Multiple footprint directories can be separated by semicolons (;). " +

--- a/src/main/scala/edg_ide/ui/KicadVizPanel.scala
+++ b/src/main/scala/edg_ide/ui/KicadVizPanel.scala
@@ -1,6 +1,5 @@
 package edg_ide.ui
 
-import com.intellij.notification.NotificationGroup
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.ui.JBSplitter
@@ -30,8 +29,6 @@ import javax.swing.event.{DocumentEvent, DocumentListener}
 import javax.swing.tree.TreePath
 
 class KicadVizPanel(project: Project) extends JPanel with MouseWheelListener {
-  val notificationGroup: NotificationGroup = NotificationGroup.balloonGroup("edg_ide.ui.KicadVizPanel")
-
   // State
   //
   var currentBlockPathTypePin: Option[(DesignPath, ref.LibraryPath, elem.HierarchyBlock, Map[String, ref.LocalPath])] =

--- a/src/main/scala/edg_ide/ui/LibraryPanel.scala
+++ b/src/main/scala/edg_ide/ui/LibraryPanel.scala
@@ -378,7 +378,7 @@ class LibraryPanel(project: Project) extends JPanel {
 
   private var libraryTreeModel = new FilteredTreeTableModel(new EdgirLibraryTreeTableModel(project, library))
   private val libraryTree = new TreeTable(libraryTreeModel) with ProvenTreeTableMixin
-  new TreeTableSpeedSearch(libraryTree)
+  TreeTableSpeedSearch.installOn(libraryTree)
   private val libraryTreeListener =
     new TreeSelectionListener { // an object so it can be re-used since a model change wipes everything out
       override def valueChanged(e: TreeSelectionEvent): Unit = {

--- a/src/main/scala/edg_ide/util/ExceptionNotify.scala
+++ b/src/main/scala/edg_ide/util/ExceptionNotify.scala
@@ -4,7 +4,7 @@ import com.intellij.notification.{NotificationGroup, NotificationType}
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import edg.util.Errorable
-import edg_ide.ui.PopupUtils
+import edg_ide.ui.{EdgCompilerService, PopupUtils}
 
 import java.awt.event.MouseEvent
 import scala.reflect.ClassTag
@@ -35,7 +35,7 @@ object exceptionNotify {
     * those fail, terminates execution and displays the failure message.
     */
   def apply(notificationId: String, project: Project)(fn: => Unit): Unit = {
-    apply(NotificationGroup.balloonGroup(notificationId), project)(fn)
+    apply(EdgCompilerService.notificationGroup(), project)(fn)
   }
 
   def apply(notificationGroup: NotificationGroup, project: Project)(fn: => Unit): Unit = {


### PR DESCRIPTION
Last available version before upstream APIs change and breaks a bunch of PyCharm namespaces, if not worse.

Also fixes some deprecations and forces UTF-8 output in netlister to match Python encoding.