### PR TITLE
Update for port-bundle unification in HDL

### DIFF
--- a/src/main/scala/edg_ide/EdgirUtils.scala
+++ b/src/main/scala/edg_ide/EdgirUtils.scala
@@ -29,7 +29,6 @@ object EdgirUtils {
 
   def typeOfPortLike(portLike: elem.PortLike): Option[ref.LibraryPath] = portLike.is match {
     case elem.PortLike.Is.Port(port) => Some(port.getSelfClass)
-    case elem.PortLike.Is.Bundle(port) => Some(port.getSelfClass)
     case elem.PortLike.Is.Array(port) => Some(port.getSelfClass)
     case elem.PortLike.Is.LibElem(lib) => Some(lib)
     case _ => None
@@ -180,8 +179,18 @@ object EdgirUtils {
       portLike.is match {
         case elem.PortLike.Is.Port(port) =>
           (postfix, target) match {
-            case (_, ResolveTarget.Any | ResolveTarget.Port) =>
-              Some((prefix, port.asInstanceOf[T])) // deepest along path
+            case (Seq(), ResolveTarget.Any | ResolveTarget.Port) => Some((prefix, port.asInstanceOf[T]))
+            case (Seq(), _) => None // target isn't the right type, but nowhere to continue
+            case (Seq(head, tail @ _*), target) =>
+              if (port.ports.toSeqMap.contains(head) && target == ResolveTarget.Port) {
+                fromPortLike(prefix :+ head, tail, port.ports(head), target)
+              } else if (target == ResolveTarget.Port) { // deepest possible target along path
+                ??? // TODO return non-Port PortType
+              } else if (target == ResolveTarget.Any) { // deepest possible target along path
+                Some((prefix, port.asInstanceOf[T]))
+              } else {
+                None
+              }
             case _ => None
           }
         case elem.PortLike.Is.Array(port) =>
@@ -200,23 +209,6 @@ object EdgirUtils {
                   ) && target == ResolveTarget.Port
               ) {
                 fromPortLike(prefix :+ head, tail, port.getPorts.ports(head), target)
-              } else if (target == ResolveTarget.Port) { // deepest possible target along path
-                ??? // TODO return non-Port PortType
-              } else if (target == ResolveTarget.Any) { // deepest possible target along path
-                Some((prefix, port.asInstanceOf[T]))
-              } else {
-                None
-              }
-            case _ => None
-          }
-        case elem.PortLike.Is.Bundle(port) =>
-          (postfix, target) match {
-            case (Seq(), ResolveTarget.Any) => Some((prefix, port.asInstanceOf[T]))
-            case (Seq(), ResolveTarget.Port) => ??? // TODO return non-Port PortType
-            case (Seq(), _) => None // target isn't the right type, but nowhere to continue
-            case (Seq(head, tail @ _*), target) =>
-              if (port.ports.toSeqMap.contains(head) && target == ResolveTarget.Port) {
-                fromPortLike(prefix :+ head, tail, port.ports(head), target)
               } else if (target == ResolveTarget.Port) { // deepest possible target along path
                 ??? // TODO return non-Port PortType
               } else if (target == ResolveTarget.Any) { // deepest possible target along path

--- a/src/main/scala/edg_ide/EdgirUtils.scala
+++ b/src/main/scala/edg_ide/EdgirUtils.scala
@@ -185,7 +185,7 @@ object EdgirUtils {
               if (port.ports.toSeqMap.contains(head) && target == ResolveTarget.Port) {
                 fromPortLike(prefix :+ head, tail, port.ports(head), target)
               } else if (target == ResolveTarget.Port) { // deepest possible target along path
-                ??? // TODO return non-Port PortType
+                Some((prefix, port.asInstanceOf[T]))
               } else if (target == ResolveTarget.Any) { // deepest possible target along path
                 Some((prefix, port.asInstanceOf[T]))
               } else {

--- a/src/main/scala/edg_ide/dse/DesignBlockMap.scala
+++ b/src/main/scala/edg_ide/dse/DesignBlockMap.scala
@@ -10,9 +10,8 @@ import scala.collection.SeqMap
 /** A simplified version of DesignMap that needs an implementation for blocks
   */
 trait DesignBlockMap[BlockType] extends DesignMap[Unit, BlockType, Unit] {
-  override def mapPort(path: DesignPath, port: elem.Port): Unit = {}
+  override def mapPort(path: DesignPath, port: elem.Port, ports: SeqMap[String, Unit]): Unit = {}
   override def mapPortArray(path: DesignPath, port: elem.PortArray, ports: SeqMap[String, Unit]): Unit = {}
-  override def mapBundle(path: DesignPath, port: elem.Bundle, ports: SeqMap[String, Unit]): Unit = {}
   override def mapPortLibrary(path: DesignPath, port: ref.LibraryPath): Unit = {}
 
   override def mapBlock(

--- a/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
+++ b/src/main/scala/edg_ide/edgir_graph/EdgirGraph.scala
@@ -221,7 +221,6 @@ object EdgirGraph {
       portLike: elem.PortLike
   ): Seq[(Seq[String], EdgirPort)] = portLike.is match {
     case elem.PortLike.Is.Port(port) => Seq(name -> portLikeToPort(path, portLike))
-    case elem.PortLike.Is.Bundle(port) => Seq(name -> portLikeToPort(path, portLike))
     case elem.PortLike.Is.LibElem(port) => Seq(name -> portLikeToPort(path, portLike))
     case elem.PortLike.Is.Array(array) =>
       array.getPorts.ports.toSeqMap.toSeq.flatMap { case (subname, subport) =>

--- a/src/main/scala/edg_ide/psi_edits/InsertPinningAction.scala
+++ b/src/main/scala/edg_ide/psi_edits/InsertPinningAction.scala
@@ -29,8 +29,7 @@ object InsertPinningAction {
       path: ref.LocalPath,
       port: elem.PortLike
   ): Seq[(ref.LocalPath, ref.LibraryPath)] = port.is match {
-    case elem.PortLike.Is.Port(port) => Seq((path, port.getSelfClass))
-    case elem.PortLike.Is.Bundle(port) =>
+    case elem.PortLike.Is.Port(port) =>
       Seq((path, port.getSelfClass)) ++
         port.ports.asPairs.flatMap { case (name, subport) =>
           val subpath = path.update(

--- a/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
+++ b/src/main/scala/edg_ide/swing/ElementDetailTreeModel.scala
@@ -79,21 +79,6 @@ class ElementDetailNodes(
         linkNode,
         Some(new SuperclassesNode(port.superclasses)),
         Some(new ParamNode(path.asIndirect + IndirectStep.IsConnected, ExprBuilder.ValInit.Boolean)),
-        port.params.asPairs.map { case (name, param) =>
-          new ParamNode(path.asIndirect + name, param)
-        }
-      ).flatten
-    }
-
-    override def getColumns(index: Int): String = port.getSelfClass.toSimpleString
-  }
-
-  class BundleNode(val path: DesignPath, port: elem.Bundle, val fromLink: Boolean = false)
-      extends BasePortNode {
-    override lazy val children = {
-      Seq(
-        Some(new SuperclassesNode(port.superclasses)),
-        Some(new ParamNode(path.asIndirect + IndirectStep.IsConnected, ExprBuilder.ValInit.Boolean)),
         port.ports.asPairs.map { case (name, subport) =>
           PortLikeNode(path + name, subport, fromLink)
         },
@@ -131,7 +116,6 @@ class ElementDetailNodes(
   def PortLikeNode(path: DesignPath, port: elem.PortLike, fromLink: Boolean = false): ElementDetailNode = {
     port.is match {
       case elem.PortLike.Is.Port(port) => new PortNode(path, port, fromLink)
-      case elem.PortLike.Is.Bundle(port) => new BundleNode(path, port, fromLink)
       case elem.PortLike.Is.Array(port) => new PortArrayNode(path, port, fromLink)
       case elem.PortLike.Is.LibElem(port) =>
         new UnelaboratedNode(path, s"unelaborated ${port.toSimpleString}")

--- a/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
+++ b/src/main/scala/edg_ide/ui/BlockVisualizerPanel.scala
@@ -638,16 +638,12 @@ class DesignToolTipTextMap(compiler: Compiler) extends DesignMap[Unit, Unit, Uni
 
   def getTextMap: Map[DesignPath, String] = textMap.toMap
 
-  override def mapPort(path: DesignPath, port: elem.Port): Unit = {
+  override def mapPort(path: DesignPath, port: elem.Port, ports: SeqMap[String, Unit]): Unit = {
     val classString = port.getSelfClass.toSimpleString
     textMap.put(path, s"<b>$classString</b> at $path")
   }
   override def mapPortArray(path: DesignPath, port: elem.PortArray, ports: SeqMap[String, Unit]): Unit = {
     val classString = s"Array[${port.getSelfClass.toSimpleString}]"
-    textMap.put(path, s"<b>$classString</b> at $path")
-  }
-  override def mapBundle(path: DesignPath, port: elem.Bundle, ports: SeqMap[String, Unit]): Unit = {
-    val classString = port.getSelfClass.toSimpleString
     textMap.put(path, s"<b>$classString</b> at $path")
   }
   override def mapPortLibrary(path: DesignPath, port: ref.LibraryPath): Unit = {

--- a/src/main/scala/edg_ide/ui/DesignFastPathUtil.scala
+++ b/src/main/scala/edg_ide/ui/DesignFastPathUtil.scala
@@ -3,7 +3,7 @@ import edg.ExprBuilder.Ref
 import edg.util.Errorable
 import edg.wir.LibraryConnectivityAnalysis
 import edg.wir.ProtoUtil._
-import edg.{IrPort, wir}
+import edg.wir
 import edg_ide.util.ExceptionNotifyImplicits.ExceptErrorable
 import edg_ide.util.exceptable
 import edgir.elem.elem
@@ -15,20 +15,11 @@ class DesignFastPathUtil(library: wir.Library) {
   lazy val libraryAnalysis = new LibraryConnectivityAnalysis(library)
 
   def instantiatePortLike(portType: ref.LibraryPath): Errorable[elem.PortLike] = exceptable {
-    library.getPort(portType).exceptError match {
-      case IrPort.Port(port) =>
-        elem
-          .PortLike()
-          .update(
-            _.port := port
-          )
-      case IrPort.Bundle(bundle) =>
-        elem
-          .PortLike()
-          .update(
-            _.bundle := bundle
-          )
-    }
+    elem
+      .PortLike()
+      .update(
+        _.port := library.getPort(portType).exceptError
+      )
   }
 
   private def recursiveExpandPort(portLike: elem.PortLike): Errorable[elem.PortLike] = exceptable {

--- a/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/ConnectTool.scala
@@ -28,7 +28,6 @@ object ConnectTool {
       val port = EdgirUtils.resolveExact(portPath, interface.getDesign).exceptNone("no port")
       val portType = port match {
         case port: elem.Port => port.getSelfClass
-        case port: elem.Bundle => port.getSelfClass
         case array: elem.PortArray => array.getSelfClass
         case _ => exceptable.fail("invalid port type")
       }
@@ -231,7 +230,7 @@ class ConnectTool(
     if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount == 1) { // toggle selected port
       val currentSelectedPorts = currentConnectBuilder.connected.map(containingBlockPath ++ _._1.connect.topPortRef)
       resolved match {
-        case Some(_: elem.Port | _: elem.Bundle | _: elem.PortArray) => // toggle port
+        case Some(_: elem.Port | _: elem.PortArray) => // toggle port
           if (selectedConnects.exists(containingBlockPath ++ _.connect.topPortRef == path)) { // toggle de-select
             removeConnect(path)
           } else if (!currentSelectedPorts.contains(path) && path != startingPortPath) { // toggle select

--- a/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
+++ b/src/main/scala/edg_ide/ui/tools/DefaultTool.scala
@@ -274,7 +274,6 @@ class DesignPortPopupMenu(path: DesignPath, interface: ToolInterface)
   }
   private val portClass = port match {
     case port: elem.Port => port.getSelfClass
-    case bundle: elem.Bundle => bundle.getSelfClass
     case array: elem.PortArray => array.getSelfClass
     case other =>
       PopupUtils.createErrorPopupAtMouse(f"internal error: unknown ${other.getClass} at $path", this)
@@ -300,7 +299,6 @@ class DesignPortPopupMenu(path: DesignPath, interface: ToolInterface)
 
     val params = port match {
       case port: elem.Port => port.params
-      case bundle: elem.Bundle => bundle.params
       case _ => Seq() // including arrays, not supported
     }
     params.toSeqMap.foreach { case (paramName, paramValue) =>
@@ -342,7 +340,7 @@ class DefaultTool(val interface: ToolInterface) extends BaseTool {
           exceptionPopup(e) {
             new DesignBlockPopupMenu(path, interface).setFocusAction.exceptError()
           }
-        case Some(_: elem.Port | _: elem.Bundle | _: elem.PortArray) => // ports: start connect
+        case Some(_: elem.Port | _: elem.PortArray) => // ports: start connect
           exceptionPopup(e) {
             new DesignPortPopupMenu(path, interface).startConnectAction.exceptError()
           }
@@ -353,7 +351,7 @@ class DefaultTool(val interface: ToolInterface) extends BaseTool {
       resolved match {
         case Some(_: elem.HierarchyBlock) =>
           new DesignBlockPopupMenu(path, interface).show(e.getComponent, e.getX, e.getY)
-        case Some(_: elem.Port | _: elem.Bundle | _: elem.PortArray) =>
+        case Some(_: elem.Port | _: elem.PortArray) =>
           new DesignPortPopupMenu(path, interface).show(e.getComponent, e.getX, e.getY)
         case _ => // TODO support other element types
       }

--- a/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
+++ b/src/main/scala/edg_ide/util/BlockConnectedAnalysis.scala
@@ -66,8 +66,6 @@ class BlockConnectedAnalysis(val block: elem.HierarchyBlock) {
 //      val connectTypedOpt = port.is match {
 //        case elem.PortLike.Is.Port(port) =>
 //          Some(PortConnectTyped(PortConnects.BoundaryPort(portName, Seq()), port.getSelfClass))
-//        case elem.PortLike.Is.Bundle(port) =>
-//          Some(PortConnectTyped(PortConnects.BoundaryPort(portName, Seq()), port.getSelfClass))
 //        case elem.PortLike.Is.Array(array) =>
 //          Some(PortConnectTyped(PortConnects.BoundaryPortVectorUnit(portName), array.getSelfClass))
 //        case _ => None
@@ -84,8 +82,6 @@ class BlockConnectedAnalysis(val block: elem.HierarchyBlock) {
       subBlock.ports.toSeqMap.foreach { case (subBlockPortName, port) =>
         val disconnectedConnectOpt = port.is match {
           case elem.PortLike.Is.Port(port) if !connectedsByPortRef.contains(Seq(subBlockName, subBlockPortName)) =>
-            Some(PortConnectTyped(PortConnects.BlockPort(subBlockName, subBlockPortName), port.getSelfClass))
-          case elem.PortLike.Is.Bundle(port) if !connectedsByPortRef.contains(Seq(subBlockName, subBlockPortName)) =>
             Some(PortConnectTyped(PortConnects.BlockPort(subBlockName, subBlockPortName), port.getSelfClass))
           case elem.PortLike.Is.Array(array) => // arrays can have multiple connections
             val connectOpt = connectedsByPortRef.get(Seq(subBlockName, subBlockPortName)) match {

--- a/src/main/scala/edg_ide/util/ConnectBuilder.scala
+++ b/src/main/scala/edg_ide/util/ConnectBuilder.scala
@@ -29,7 +29,6 @@ object PortConnects { // types of connections a port attached to a connection ca
   protected def typeOfSinglePort(portLike: elem.PortLike): Option[ref.LibraryPath] = portLike.is match {
     case elem.PortLike.Is.LibElem(lib) => Some(lib)
     case elem.PortLike.Is.Port(port) => port.selfClass
-    case elem.PortLike.Is.Bundle(port) => port.selfClass
     case _ => None
   }
 

--- a/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
+++ b/src/test/scala/edg_ide/util/tests/ConnectBuilderTest.scala
@@ -16,7 +16,7 @@ class ConnectBuilderTest extends AnyFlatSpec {
     "topDesign",
     ports = SeqMap(
       "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),
-      "bundle" -> Port.Bundle(
+      "bundle" -> Port.Port(
         "sourceBundle",
         ports = SeqMap(
           "port" -> Port.Port("sourcePort", params = SeqMap("param" -> ValInit.Integer)),


### PR DESCRIPTION
Updates code here to reflect that Ports can now have sub-Ports and the removal of the now-redundant Bundle.

Updates HDL sub-module to latest.